### PR TITLE
Adding Utah statewide data

### DIFF
--- a/sources/us/Utah.yaml
+++ b/sources/us/Utah.yaml
@@ -1,15 +1,10 @@
-- city: Salt Lake City
-  county: ""
+- county: Laramie
+  data: "http://arcims.laramiecounty.com/arcgis/rest/services/Floodplains/MapServer/0"
+- county: Albany
+  data: "http://arcmobile.co.albany.wy.us/arcgis/rest/services/PublicWebMap/Ownership/MapServer/0"
+- county: Carbon
+  data: "http://arcmobile.co.albany.wy.us/arcgis/rest/services/CarbonCounty/CarbonCntyWebMap/MapServer/4"
+- state: Utah
   data: "ftp://ftp.agrc.utah.gov/UtahSGID_Vector/UTM12_NAD83/LOCATION/UnpackagedData/AddressPoints/_Statewide/AddressPoints_shp.zip"
-  license: ""
-  year: ""
-- city: ""
-  county: ""
-  website: "download, arccgis web service"
-  license: PD (to verify)
-  year: ""
-- city: ""
-  county: ""
-  website: Parcels
-  license: PD
-  year: 2012 and older
+  comment: "there is a GDB version available as well."
+  date: 2014-02-12


### PR DESCRIPTION
This renames Utah.yml to Utah.yaml to conform to the apparent naming convention, and adds the state wide address point dataset from AGRC.
