### PR TITLE
Add Compression Field

### DIFF
--- a/sources/ca-al-strathcona.json
+++ b/sources/ca-al-strathcona.json
@@ -4,5 +4,6 @@
     "data": "https://data.strathcona.ca/api/geospatial/ahu6-iwum?method=export&format=Shapefile",
     "license": null,
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": "zip"
 }

--- a/sources/ca-bc.json
+++ b/sources/ca-bc.json
@@ -4,5 +4,6 @@
     "data": "ftp://webftp.vancouver.ca/OpenData/shape/ICIS_GIS_shp.zip",
     "license": "",
     "year": "",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/ca-nb.json
+++ b/sources/ca-nb.json
@@ -5,5 +5,6 @@
     "website": "http://www.snb.ca/geonb1/e/DC/catalogue-E.asp",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": "zip"
 }

--- a/sources/ca-ns.json
+++ b/sources/ca-ns.json
@@ -3,5 +3,6 @@
     "city": "all",
     "website": "http://www.novascotia.ca/snsmr/access/land/land-services-information/ask-data.asp",
     "license": "",
-    "year": ""
+    "year": "",
+    "compression": ""
 }

--- a/sources/ca-on-burlington.json
+++ b/sources/ca-on-burlington.json
@@ -3,5 +3,6 @@
     "city": "Burlington",
     "website": "http://cms.burlington.ca/Page12956.aspx",
     "license": "",
-    "year": ""
+    "year": "",
+    "compression": ""
 }

--- a/sources/ca-on-hamilton.json
+++ b/sources/ca-on-hamilton.json
@@ -3,5 +3,6 @@
     "city": "Hamilton",
     "website": "http://www.hamilton.ca/ProjectsInitiatives/OpenData/",
     "license": "",
-    "year": ""
+    "year": "",
+    "compression": ""
 }

--- a/sources/ca-on-ottawa.json
+++ b/sources/ca-on-ottawa.json
@@ -3,5 +3,6 @@
     "city": "Ottawa",
     "website": "http://data.ottawa.ca/dataset/address-points-main-and-subordinates",
     "license": "",
-    "year": ""
+    "year": "",
+    "compression": ""
 }

--- a/sources/ca-on-toronto.json
+++ b/sources/ca-on-toronto.json
@@ -3,5 +3,6 @@
     "city": "Toronto",
     "website": "http://www1.toronto.ca/wps/portal/contentonly?vgnextoid=91415f9cd70bb210VgnVCM1000003dd60f89RCRD&vgnextchannel=1a66e03bb8d1e310VgnVCM10000071d60f89RCRD",
     "license": "",
-    "year": ""
+    "year": "",
+    "compression": ""
 }

--- a/sources/ca-on-waterloo.json
+++ b/sources/ca-on-waterloo.json
@@ -4,5 +4,6 @@
     "data": "http://cityofwaterlooopendata.cloudapp.net/DataBrowser/DownloadShape?container=CityOfWaterlooOpenData&entitySet=AddressPoints&filter=NOFILTER",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": "zip"
 }

--- a/sources/ca-on-york.json
+++ b/sources/ca-on-york.json
@@ -5,5 +5,6 @@
     "data": "http://findit.yorkmaps.ca/opendata/downloads/cache/cf/cf5/cfcf5ea2af555e64_9C2DAB28/4B5F6CDE7B794C91/Address_Points.shp.zip",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": "zip"
 }

--- a/sources/ca-pei-prince.json
+++ b/sources/ca-pei-prince.json
@@ -3,5 +3,6 @@
     "city": "all",
     "website": "http://www.gov.pe.ca/civicaddress/download/download.php3?county=PRN",
     "license": "",
-    "year": ""
+    "year": "",
+    "compression": ""
 }

--- a/sources/us-ak-anchorage.json
+++ b/sources/us-ak-anchorage.json
@@ -4,5 +4,6 @@
     "data": "http://munimaps.muni.org/ftp_gis/address_shp.zip",
     "license": "Public Domain",
     "year": "1997?",
-    "type": "http"
+    "type": "http",
+    "compression": "zip"
 }

--- a/sources/us-al-calhoun.json
+++ b/sources/us-al-calhoun.json
@@ -4,5 +4,6 @@
     "data": "http://gis.calhouncounty.org/arcgis2/rest/services/ParcelViewer/MapServer/68",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-al-huntsville.json
+++ b/sources/us-al-huntsville.json
@@ -4,5 +4,6 @@
     "data": "http://maps.huntsvilleal.gov/ArcGIS/rest/services/Layers/Addresses/MapServer/3",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-al-montgomery.json
+++ b/sources/us-al-montgomery.json
@@ -4,5 +4,6 @@
     "data": "http://gis.montgomeryal.gov/ArcGIS/rest/services/Parcel/MapServer/11",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-al-shelby.json
+++ b/sources/us-al-shelby.json
@@ -4,5 +4,6 @@
     "data": "http://gis.shelbyal.com/ArcGIS/rest/services/Address-Numbers-Capture/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-al-tuscaloosa.json
+++ b/sources/us-al-tuscaloosa.json
@@ -1,5 +1,6 @@
 {
     "city": "Tuscaloosa",
     "data": "http://tuscgis.tuscaloosa-al.gov/ArcGIS/rest/services/ADDRESSES/MapServer/0",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-az-mesa.json
+++ b/sources/us-az-mesa.json
@@ -4,5 +4,6 @@
     "data": "http://gis.mesaaz.gov/mesaaz/rest/services/Address/AddressIndexAcella/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-az-scottsdale.json
+++ b/sources/us-az-scottsdale.json
@@ -4,5 +4,6 @@
     "data": "http://maps.scottsdaleaz.gov/arcgis/rest/services/ParcelInformation/MapServer/15",
     "license": "Crappy License",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-az-tucson.json
+++ b/sources/us-az-tucson.json
@@ -3,5 +3,6 @@
     "county": "Pima",
     "website": "http://webcms.pima.gov/cms/one.aspx?portalId=169&pageId=33931",
     "license": "Crappy License",
-    "year": ""
+    "year": "",
+    "compression": ""
 }

--- a/sources/us-ca-bakersfield.json
+++ b/sources/us-ca-bakersfield.json
@@ -4,5 +4,6 @@
     "data": "http://www.bakersfieldcity.us/gis/downloads/vectors/AddressPoints.zip",
     "license": "http://www.bakersfieldcity.us/gis/gis_spatial_data.htm",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": "zip"
 }

--- a/sources/us-ca-fresno.json
+++ b/sources/us-ca-fresno.json
@@ -3,5 +3,6 @@
     "county": "",
     "website": "http://www.co.fresno.ca.us/ViewDocument.aspx?id=52117",
     "license": "http://www.co.fresno.ca.us/DepartmentPage.aspx?id=52121",
-    "year": "9/10/2013"
+    "year": "9/10/2013",
+    "compression": ""
 }

--- a/sources/us-ca-los_angeles.json
+++ b/sources/us-ca-los_angeles.json
@@ -4,5 +4,6 @@
     "data": "http://egis3.lacounty.gov/dataportal/wp-content/uploads/2012/06/lacounty_address_points.zip",
     "license": "http://egis3.lacounty.gov/dataportal/disclaimer/",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": "zip"
 }

--- a/sources/us-ca-marin.json
+++ b/sources/us-ca-marin.json
@@ -1,5 +1,6 @@
 {
     "county": "Marin",
     "data": "http://gis.marinpublic.com/arcgis/rest/services/BaseMap/BaseMap/MapServer/25",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-ca-oakland.json
+++ b/sources/us-ca-oakland.json
@@ -4,5 +4,6 @@
     "data": "https://data.acgov.org/api/geospatial/8e4s-7f4v?method=export&format=Original",
     "license": "http://www.acgov.org/acdata/terms.htm",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": "zip"
 }

--- a/sources/us-ca-sacramento.json
+++ b/sources/us-ca-sacramento.json
@@ -3,5 +3,6 @@
     "county": "",
     "website": "http://www.cityofsacramento.org/gis/data.html",
     "license": "",
-    "year": ""
+    "year": "",
+    "compression": ""
 }

--- a/sources/us-ca-san_diago.json
+++ b/sources/us-ca-san_diago.json
@@ -4,5 +4,6 @@
     "data": "http://rdw.sandag.org/file_store/Address/Address_APN.zip",
     "license": "http://rdw.sandag.org/",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": "zip"
 }

--- a/sources/us-ca-san_francisco.json
+++ b/sources/us-ca-san_francisco.json
@@ -4,5 +4,6 @@
     "data": "https://data.sfgov.org/download/kvej-w5kb/ZIPPED%20SHAPEFILE",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": "zip"
 }

--- a/sources/us-ca-solano.json
+++ b/sources/us-ca-solano.json
@@ -1,5 +1,6 @@
 {
     "county": "Solano",
     "data": "http://regis.solanocounty.com/ArcGIS/rest/services/Addresses/MapServer/1",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-co-adams.json
+++ b/sources/us-co-adams.json
@@ -3,5 +3,6 @@
     "county": "Adams",
     "website": "http://www.co.adams.co.us/index.aspx?NID=417",
     "license": "Indemnification",
-    "year": ""
+    "year": "",
+    "compression": ""
 }

--- a/sources/us-co-arapahoe.json
+++ b/sources/us-co-arapahoe.json
@@ -4,5 +4,6 @@
     "data": "http://gis.arapahoegov.com/DL_Data/Address_Points/WGS/Address_Points_SHAPE_WGS.zip",
     "license": "Crappy License",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": "zip"
 }

--- a/sources/us-co-arvada.json
+++ b/sources/us-co-arvada.json
@@ -4,5 +4,6 @@
     "data": "http://maps.arvada.org/ArcGIS/rest/services/Address/Master_Address_Join/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-co-aurora.json
+++ b/sources/us-co-aurora.json
@@ -4,5 +4,6 @@
     "data": "https://apps.auroragov.org/GISOpenData/DataDownload/LL_AddressPoints_SHP.zip",
     "license": "Crappy License",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": "zip"
 }

--- a/sources/us-co-denver.json
+++ b/sources/us-co-denver.json
@@ -4,5 +4,6 @@
     "data": "http://data.denvergov.org/download/gis/addresses/shape/addresses.zip",
     "license": "CCBY3.0",
     "year": "11/12/2013",
-    "type": "http"
+    "type": "http",
+    "compression": "zip"
 }

--- a/sources/us-co-douglas_county.json
+++ b/sources/us-co-douglas_county.json
@@ -3,5 +3,6 @@
     "county": "Douglas County",
     "website": "http://www.douglas.co.us/gis/",
     "license": "steve@asklater.com has emailed to ask",
-    "year": ""
+    "year": "",
+    "compression": ""
 }

--- a/sources/us-co-gilpin.json
+++ b/sources/us-co-gilpin.json
@@ -4,5 +4,6 @@
     "data": "https://maps.digitaldataservices.com/Clients/GILP/Data/SiteAddressPoint.zip",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": "zip"
 }

--- a/sources/us-co-jefferson.json
+++ b/sources/us-co-jefferson.json
@@ -4,5 +4,6 @@
     "data": "http://jeffco.us/ArcGIS/rest/services/address/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-co-larimer.json
+++ b/sources/us-co-larimer.json
@@ -4,5 +4,6 @@
     "data": "http://maps.larimer.org/arcgis/rest/services/maps/selectableLayers/MapServer/3",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-co-pitkin.json
+++ b/sources/us-co-pitkin.json
@@ -1,5 +1,6 @@
 {
     "county": "Pitkin",
     "data": "http://205.170.51.182:6080/arcgis/rest/services/PitkinBase/Address/MapServer/0",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-co-westminster.json
+++ b/sources/us-co-westminster.json
@@ -1,5 +1,6 @@
 {
     "city": "Westminster",
     "data": "http://maps.cityofwestminster.us/arcgis/rest/services/Addresses/MapServer/0",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-dc.json
+++ b/sources/us-dc.json
@@ -4,5 +4,6 @@
     "data": "http://dcatlas.dcgis.dc.gov/catalog/download.asp?downloadID=2182&downloadTYPE=ESRI",
     "license": "http://data.dc.gov/TermsOfUse.aspx",
     "year": "3/28/2013",
-    "type": "http"
+    "type": "http",
+    "compression": "zip"
 }

--- a/sources/us-fl-alachua.json
+++ b/sources/us-fl-alachua.json
@@ -4,5 +4,6 @@
     "data": "http://kate.acpafl.org/ArcGIS/rest/services/basemap/ARM360/MapServer/4",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-fl-broward.json
+++ b/sources/us-fl-broward.json
@@ -3,5 +3,6 @@
     "county": "Broward",
     "website": "https://bcpasecure.net/InfoBroward/InfoBroward.asp",
     "license": "Public Domain",
-    "year": ""
+    "year": "",
+    "compression": ""
 }

--- a/sources/us-fl-collier.json
+++ b/sources/us-fl-collier.json
@@ -3,5 +3,6 @@
     "county": "Collier",
     "website": "http://www.colliergov.net/Index.aspx?page=2713",
     "license": "Public Domain",
-    "year": ""
+    "year": "",
+    "compression": ""
 }

--- a/sources/us-fl-hernando.json
+++ b/sources/us-fl-hernando.json
@@ -4,5 +4,6 @@
     "data": "https://www.hernandocountygis-fl.us/arcgis/rest/services/Parcels_Addresses/MapServer/2",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-fl-lake.json
+++ b/sources/us-fl-lake.json
@@ -3,5 +3,6 @@
     "county": "Lake",
     "website": "http://www.lakecountyfl.gov/departments/information_technology/geographic_information_services/datadownloads.aspx",
     "license": "Public Domain",
-    "year": ""
+    "year": "",
+    "compression": ""
 }

--- a/sources/us-fl-lee.json
+++ b/sources/us-fl-lee.json
@@ -3,5 +3,6 @@
     "county": "Lee",
     "website": "http://leegis.leegov.com/GISData.htm",
     "license": "Public Domain",
-    "year": ""
+    "year": "",
+    "compression": ""
 }

--- a/sources/us-fl-manatee.json
+++ b/sources/us-fl-manatee.json
@@ -3,5 +3,6 @@
     "county": "Manatee",
     "website": "http://www.mymanatee.org/home/government/departments/information-technology/gis-home/gis-datadownload.html",
     "license": "Public Domain",
-    "year": ""
+    "year": "",
+    "compression": ""
 }

--- a/sources/us-fl-miami.json
+++ b/sources/us-fl-miami.json
@@ -3,5 +3,6 @@
     "county": "Miami-Dade",
     "website": "http://gisweb.miamidade.gov/GISSelfServices/GeographicData/MDGeographicData.html",
     "license": "Public Domain",
-    "year": ""
+    "year": "",
+    "compression": ""
 }

--- a/sources/us-fl-orlando.json
+++ b/sources/us-fl-orlando.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.onetgov.net/divisions/Infomap/pub/GIS_Downloads/FTP%20Shapefiles/",
     "license": "Public Domain",
     "year": "",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": ""
 }

--- a/sources/us-fl-sarasota.json
+++ b/sources/us-fl-sarasota.json
@@ -3,5 +3,6 @@
     "county": "Sarasota",
     "website": "http://gis.scgov.net/data_download_page.asp",
     "license": "Public Domain",
-    "year": ""
+    "year": "",
+    "compression": ""
 }

--- a/sources/us-fl-st_petersburg.json
+++ b/sources/us-fl-st_petersburg.json
@@ -3,5 +3,6 @@
     "county": "Pinellas",
     "website": "http://www.pcpao.org/datadownload.php",
     "license": "Public Domain",
-    "year": ""
+    "year": "",
+    "compression": ""
 }

--- a/sources/us-fl-tampa.json
+++ b/sources/us-fl-tampa.json
@@ -3,5 +3,6 @@
     "county": "Hillsborough",
     "website": "ftp://public:access@209.26.172.71/shapefiles/",
     "license": "Public Domain",
-    "year": ""
+    "year": "",
+    "compression": ""
 }

--- a/sources/us-fl-volusia.json
+++ b/sources/us-fl-volusia.json
@@ -3,5 +3,6 @@
     "county": "Volusia",
     "website": "http://www.volusia.org/services/financial-and-administrative-services/information-technology/geographic-information-services/data-available-in-shapefile-format.stml",
     "license": "Public Domain",
-    "year": ""
+    "year": "",
+    "compression": ""
 }

--- a/sources/us-fl-west_palm_beach.json
+++ b/sources/us-fl-west_palm_beach.json
@@ -3,5 +3,6 @@
     "county": "Palm Beach",
     "website": "http://www.pbcgov.com/iss/itoperations/cwgis/GISdatasearch/",
     "license": "Public Domain",
-    "year": ""
+    "year": "",
+    "compression": ""
 }

--- a/sources/us-fl.json
+++ b/sources/us-fl.json
@@ -3,5 +3,6 @@
     "county": "ALL",
     "website": "ftp://sdrftp03.dor.state.fl.us",
     "license": "Public Domain",
-    "year": ""
+    "year": "",
+    "compression": ""
 }

--- a/sources/us-ga-atlanta.json
+++ b/sources/us-ga-atlanta.json
@@ -4,5 +4,6 @@
     "data": "http://share.myfultoncountyga.us/GPDownload/FultonCounty/Tax_Parcels2013",
     "license": "Public Domain",
     "year": "1/17/2013",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-ga-gordon.json
+++ b/sources/us-ga-gordon.json
@@ -4,5 +4,6 @@
     "data": "http://maps.binarybus.com/arcgis/rest/services/gordon/gordon/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-ga-muscogee.json
+++ b/sources/us-ga-muscogee.json
@@ -4,5 +4,6 @@
     "data": "http://maps.binarybus.com/arcgis/rest/services/Columbus/publicsafety/MapServer/22",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-ga-sumter.json
+++ b/sources/us-ga-sumter.json
@@ -4,5 +4,6 @@
     "data": "http://maps.binarybus.com/arcgis/rest/services/Americus/Public/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-ia-adams.json
+++ b/sources/us-ia-adams.json
@@ -4,5 +4,6 @@
     "data": "https://sites.integritygis.com/Geocortex/Essentials/REST/sites/Adams_County_IA_Public/map/mapservices/0/layers/5",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-ia-boone.json
+++ b/sources/us-ia-boone.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Boone/address_08.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-bremer.json
+++ b/sources/us-ia-bremer.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Bremer/address_09.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-buchanan.json
+++ b/sources/us-ia-buchanan.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Buchanan/Address_10.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-buena_vista.json
+++ b/sources/us-ia-buena_vista.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Buena_Vista/Address_11.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-calhoun.json
+++ b/sources/us-ia-calhoun.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Calhoun/Address_13.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-carroll.json
+++ b/sources/us-ia-carroll.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Carroll/Address_14.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-cass.json
+++ b/sources/us-ia-cass.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Cass/Address_15.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-cherokee.json
+++ b/sources/us-ia-cherokee.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Cherokee/Address_18.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-clarke.json
+++ b/sources/us-ia-clarke.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Clarke/Address_20.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-clay.json
+++ b/sources/us-ia-clay.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Clay/Address_21.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-crawford.json
+++ b/sources/us-ia-crawford.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Crawford/Address_24.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-dallas.json
+++ b/sources/us-ia-dallas.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Dallas/Address_25.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-decatur.json
+++ b/sources/us-ia-decatur.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Decatur/Address_27.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-delaware.json
+++ b/sources/us-ia-delaware.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Delaware/Address_28.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-dickinson.json
+++ b/sources/us-ia-dickinson.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Dickinson/Address_30.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-emmet.json
+++ b/sources/us-ia-emmet.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Emmet/address_32.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-franklin.json
+++ b/sources/us-ia-franklin.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Franklin/Address_35.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-fremont.json
+++ b/sources/us-ia-fremont.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Fremont/Address_36.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-greene.json
+++ b/sources/us-ia-greene.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Greene/Address_37.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-guthrie.json
+++ b/sources/us-ia-guthrie.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Guthrie/Address_39.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-hamilton.json
+++ b/sources/us-ia-hamilton.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Hamilton/Address_40.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-hardin.json
+++ b/sources/us-ia-hardin.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Hardin/Address_42.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-harrison.json
+++ b/sources/us-ia-harrison.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Harrison/Address_43.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-howard.json
+++ b/sources/us-ia-howard.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Howard/Address_45.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-humboldt.json
+++ b/sources/us-ia-humboldt.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Humboldt/Address_46.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-ida.json
+++ b/sources/us-ia-ida.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Ida/Address_47.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-jasper.json
+++ b/sources/us-ia-jasper.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Jasper/Address_50.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-kossuth.json
+++ b/sources/us-ia-kossuth.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Kossuth/Address_55.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-linn.json
+++ b/sources/us-ia-linn.json
@@ -4,5 +4,6 @@
     "data": "http://gis.linncounty.org/arcgis/rest/services/POL/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-ia-lucas.json
+++ b/sources/us-ia-lucas.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Lucas/Address_59.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-lyon.json
+++ b/sources/us-ia-lyon.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Lyon/Address_60.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-madison.json
+++ b/sources/us-ia-madison.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Madison/Address_61.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-marion.json
+++ b/sources/us-ia-marion.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Marion/Address_63.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-marshall.json
+++ b/sources/us-ia-marshall.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Marshall/Address_64.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-mills.json
+++ b/sources/us-ia-mills.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Mills/Address_65.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-monona.json
+++ b/sources/us-ia-monona.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Monona/Address_67.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-monroe.json
+++ b/sources/us-ia-monroe.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Monroe/Address_68.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-montgomery.json
+++ b/sources/us-ia-montgomery.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Montgomery/Address_69.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-palo_alto.json
+++ b/sources/us-ia-palo_alto.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Palo_Alto/Address_74.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-pocahontas.json
+++ b/sources/us-ia-pocahontas.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Pocahontas/Address_76.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-polk.json
+++ b/sources/us-ia-polk.json
@@ -1,5 +1,6 @@
 {
     "county": "Polk",
     "data": "http://www.gis.co.polk.ia.us/ArcGIS/rest/services/PolkIA/MapServer/1",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-ia-pottawattamie.json
+++ b/sources/us-ia-pottawattamie.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Pottawattamie/Address_78.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-sac.json
+++ b/sources/us-ia-sac.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Sac/Address_81.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-shelby.json
+++ b/sources/us-ia-shelby.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Shelby/Address_83.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-sioux.json
+++ b/sources/us-ia-sioux.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Sioux/Address_84.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-story.json
+++ b/sources/us-ia-story.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Story/Address_85.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-warren.json
+++ b/sources/us-ia-warren.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Warren/Address_91.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-webster.json
+++ b/sources/us-ia-webster.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Webster/Address_94.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-winnebago.json
+++ b/sources/us-ia-winnebago.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Winnebago/Address_95.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-winneshiek.json
+++ b/sources/us-ia-winneshiek.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Winneshiek/Address_96.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ia-wright.json
+++ b/sources/us-ia-wright.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Wright/Address_99.zip",
     "license": "Public Domain",
     "year": "2012?",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-id-canyon.json
+++ b/sources/us-id-canyon.json
@@ -4,5 +4,6 @@
     "data": "http://gis.canyonco.org:6080/arcgis/rest/services/cc/Taxparcels/FeatureServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-id-post_falls.json
+++ b/sources/us-id-post_falls.json
@@ -1,5 +1,6 @@
 {
     "city": "Post Falls",
     "data": "http://gis.postfallsidaho.org/arcgis/rest/services/MAPGALLERY/Addresses/MapServer/0",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-id-teton.json
+++ b/sources/us-id-teton.json
@@ -4,5 +4,6 @@
     "data": "http://www.co.teton.id.us/arcgis/rest/services/ADDRESS/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-il-adams.json
+++ b/sources/us-il-adams.json
@@ -4,5 +4,6 @@
     "data": "ftp://website:adamsgis@ftp.adamscountygis.com/0100_ADDRESSES/0100_010_ADDRESSES/",
     "license": "",
     "year": "",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": ""
 }

--- a/sources/us-il-champaign.json
+++ b/sources/us-il-champaign.json
@@ -4,5 +4,6 @@
     "data": "http://www.maps.ccgisc.org/arcgis101/rest/services/County/CCAddresses/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-il-chicago.json
+++ b/sources/us-il-chicago.json
@@ -3,5 +3,6 @@
     "county": "",
     "website": "https://github.com/Chicago/osd-building-footprints",
     "license": "MIT",
-    "year": ""
+    "year": "",
+    "compression": ""
 }

--- a/sources/us-il-christian.json
+++ b/sources/us-il-christian.json
@@ -4,5 +4,6 @@
     "data": "http://services2.bhamaps.com/arcgis/rest/services/AGS_christian_co_il_taxmap/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-il-clark.json
+++ b/sources/us-il-clark.json
@@ -4,5 +4,6 @@
     "data": "http://services2.bhamaps.com/arcgis/rest/services/AGS_clark_co_il_taxmap/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-il-cook.json
+++ b/sources/us-il-cook.json
@@ -4,5 +4,6 @@
     "data": "http://cookviewer1.cookcountyil.gov/ArcGIS/rest/services/cookElectnSrvc/MapServer/1",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-il-jackson.json
+++ b/sources/us-il-jackson.json
@@ -4,5 +4,6 @@
     "data": "http://services2.bhamaps.com/arcgis/rest/services/AGS_jackson_co_il_taxmap/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-il-jersey.json
+++ b/sources/us-il-jersey.json
@@ -4,5 +4,6 @@
     "data": "http://services2.bhamaps.com/arcgis/rest/services/AGS_jersey_co_il_taxmap/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-il-lake.json
+++ b/sources/us-il-lake.json
@@ -4,5 +4,6 @@
     "data": "http://rest.lakecountyil.gov/ArcGIS/rest/services/TaxPortalBaseMap/MapServer/41",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-il-lawrence.json
+++ b/sources/us-il-lawrence.json
@@ -4,5 +4,6 @@
     "data": "http://services2.bhamaps.com/arcgis/rest/services/AGS_lawrence_co_il_taxmap/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-il-macon.json
+++ b/sources/us-il-macon.json
@@ -4,5 +4,6 @@
     "data": "http://services2.bhamaps.com/arcgis/rest/services/AGS_macon_co_il_taxmap/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-il-macoupin.json
+++ b/sources/us-il-macoupin.json
@@ -4,5 +4,6 @@
     "data": "http://services2.bhamaps.com/arcgis/rest/services/AGS_macoupin_co_il_taxmap/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-il-massac.json
+++ b/sources/us-il-massac.json
@@ -4,5 +4,6 @@
     "data": "http://services2.bhamaps.com/arcgis/rest/services/AGS_massac_co_il_taxmap/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-il-mcdonough.json
+++ b/sources/us-il-mcdonough.json
@@ -1,5 +1,6 @@
 {
     "county": "McDonough",
     "data": "http://gis.wiu.edu/arcgis/rest/services/mcdonough_highway/MapServer/0",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-il-menard.json
+++ b/sources/us-il-menard.json
@@ -4,5 +4,6 @@
     "data": "http://services2.bhamaps.com/arcgis/rest/services/AGS_menard_co_il_taxmap/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-il-morgan.json
+++ b/sources/us-il-morgan.json
@@ -4,5 +4,6 @@
     "data": "http://services2.bhamaps.com/arcgis/rest/services/AGS_morgan_co_il_taxmap/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-il-moultrie.json
+++ b/sources/us-il-moultrie.json
@@ -4,5 +4,6 @@
     "data": "http://services2.bhamaps.com/arcgis/rest/services/AGS_moultrie_co_il_taxmap_web_mercator/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-il-putnam.json
+++ b/sources/us-il-putnam.json
@@ -4,5 +4,6 @@
     "data": "http://services2.bhamaps.com/arcgis/rest/services/AGS_putnam_co_il_taxmap/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-il-schuyler.json
+++ b/sources/us-il-schuyler.json
@@ -4,5 +4,6 @@
     "data": "http://services2.bhamaps.com/arcgis/rest/services/AGS_schuyler_co_il_taxmap/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-il-shelby.json
+++ b/sources/us-il-shelby.json
@@ -4,5 +4,6 @@
     "data": "http://services2.bhamaps.com/arcgis/rest/services/AGS_shelby_co_il_taxmap/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-il-tazewell.json
+++ b/sources/us-il-tazewell.json
@@ -4,5 +4,6 @@
     "data": "http://services.arcgis.com/pPTAs43AFhhk0pXQ/ArcGIS/rest/services/TazewellCounty_Parcels_Owner/FeatureServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-il-vermillion.json
+++ b/sources/us-il-vermillion.json
@@ -4,5 +4,6 @@
     "data": "http://services2.bhamaps.com/arcgis/rest/services/AGS_vermilion_co_il_taxmap/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-il-wayne.json
+++ b/sources/us-il-wayne.json
@@ -4,5 +4,6 @@
     "data": "http://services2.bhamaps.com/arcgis/rest/services/AGS_wayne_co_oh_taxmap/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-il-williamson.json
+++ b/sources/us-il-williamson.json
@@ -4,5 +4,6 @@
     "data": "http://services2.bhamaps.com/arcgis/rest/services/AGS_williamson_co_il_taxmap/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-in-fort_wayne.json
+++ b/sources/us-in-fort_wayne.json
@@ -3,5 +3,6 @@
     "county": "",
     "website": "http://ags.acimap.us/arcgis/rest/services/",
     "license": "",
-    "year": ""
+    "year": "",
+    "compression": ""
 }

--- a/sources/us-in-hamilton.json
+++ b/sources/us-in-hamilton.json
@@ -4,5 +4,6 @@
     "data": "http://gis.hamiltoncounty.in.gov/ArcGIS/rest/services/E911/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-in-indianapolis.json
+++ b/sources/us-in-indianapolis.json
@@ -4,5 +4,6 @@
     "data": "http://maps.indy.gov/ArcGIS10a/rest/services/MapIndyProperty/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-in-madison.json
+++ b/sources/us-in-madison.json
@@ -4,5 +4,6 @@
     "data": "http://arcgis01.madisoncty.com/arcgis/rest/services/web_edits/CountyAddressPoints/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-ks-doniphan.json
+++ b/sources/us-ks-doniphan.json
@@ -4,5 +4,6 @@
     "data": "https://sites.integritygis.com/Geocortex/Essentials/REST/sites/Doniphan_County_KS_Public/map/mapservices/2/layers/13",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-ks-harper.json
+++ b/sources/us-ks-harper.json
@@ -4,5 +4,6 @@
     "data": "https://sites.integritygis.com/Geocortex/Essentials/REST/sites/Harper_County_KS_Public/map/mapservices/1/layers/16",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-ks-riley.json
+++ b/sources/us-ks-riley.json
@@ -3,5 +3,6 @@
     "county": "Riley",
     "website": "ftp://ftpgis.rileycountyks.gov/ (credentials available from GIS department)",
     "license": "",
-    "year": "2012"
+    "year": "2012",
+    "compression": ""
 }

--- a/sources/us-ks-wichita.json
+++ b/sources/us-ks-wichita.json
@@ -3,5 +3,6 @@
     "county": "Sedgwick",
     "website": "http://gis.sedgwick.gov/gisdata/default1.asp",
     "license": "",
-    "year": ""
+    "year": "",
+    "compression": ""
 }

--- a/sources/us-ky-lexington-fayette.json
+++ b/sources/us-ky-lexington-fayette.json
@@ -3,5 +3,6 @@
     "county": "Fayette",
     "website": "http://data.lexingtonky.gov/dataset/parcel",
     "license": "Public Domain",
-    "year": "2013"
+    "year": "2013",
+    "compression": ""
 }

--- a/sources/us-ky-oldham.json
+++ b/sources/us-ky-oldham.json
@@ -1,5 +1,6 @@
 {
     "county": "Oldham",
     "data": "http://oldhamgis.org/ArcGIS/rest/services/Addresses/MapServer/0",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-la-st_james.json
+++ b/sources/us-la-st_james.json
@@ -5,5 +5,6 @@
     "website": "http://stjamesassessor.com/gis-data",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-ma-boston.json
+++ b/sources/us-ma-boston.json
@@ -3,5 +3,6 @@
     "county": "",
     "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
     "license": "",
-    "year": ""
+    "year": "",
+    "compression": ""
 }

--- a/sources/us-ma-brookline.json
+++ b/sources/us-ma-brookline.json
@@ -4,5 +4,6 @@
     "data": "http://gisweb.brooklinema.gov/arcgis/rest/services/abutters/MapServer/8",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-md-baltimore.json
+++ b/sources/us-md-baltimore.json
@@ -3,5 +3,6 @@
     "county": "",
     "website": "https://data.baltimorecity.gov/Geographic/Parcels-Shape/jk3c-vrfy",
     "license": "Public Domain",
-    "year": ""
+    "year": "",
+    "compression": ""
 }

--- a/sources/us-me.json
+++ b/sources/us-me.json
@@ -2,5 +2,6 @@
     "state": "Maine",
     "data": "http://www.maine.gov/megis/catalog/shps/state/ng911pts.zip",
     "date": "2014-01-17T00:00:00.000Z",
-    "type": "http"
+    "type": "http",
+    "compression": "zip"
 }

--- a/sources/us-mn-aitkin.json
+++ b/sources/us-mn-aitkin.json
@@ -4,5 +4,6 @@
     "data": "http://gisweb.co.aitkin.mn.us/arcgis/rest/services/MapLayers/MapServer/3",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-mn-anoka.json
+++ b/sources/us-mn-anoka.json
@@ -4,5 +4,6 @@
     "data": "http://gisservices.co.anoka.mn.us/anoka_gis/rest/services/Address_Pts/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-mn-becker.json
+++ b/sources/us-mn-becker.json
@@ -4,5 +4,6 @@
     "data": "http://gis-server.co.becker.mn.us/data/gis/shapefiles/drive_pnts.zip",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": "zip"
 }

--- a/sources/us-mn-carver.json
+++ b/sources/us-mn-carver.json
@@ -4,5 +4,6 @@
     "data": "ftp://gisftp.metc.state.mn.us/Parcels2009.zip",
     "license": "PD + Indemnification",
     "year": "2009",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mn-cass.json
+++ b/sources/us-mn-cass.json
@@ -4,5 +4,6 @@
     "data": "http://www.co.cass.mn.us/arcgis/rest/services/Basic_Layers/MapServer/1",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-mn-chisago.json
+++ b/sources/us-mn-chisago.json
@@ -4,5 +4,6 @@
     "data": "http://24.56.144.170/wf2_chisagopublic/download/addresses.zip",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": "zip"
 }

--- a/sources/us-mn-clay.json
+++ b/sources/us-mn-clay.json
@@ -4,5 +4,6 @@
     "data": "ftp://gis.co.clay.mn.us/Download/Clay/ClayAddresses.zip",
     "license": "",
     "year": "",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mn-crow_wing.json
+++ b/sources/us-mn-crow_wing.json
@@ -4,5 +4,6 @@
     "data": "http://gis.co.crow-wing.mn.us/arcgis/rest/services/CROWWINGGENERAL/MapServer/12",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-mn-dakota.json
+++ b/sources/us-mn-dakota.json
@@ -4,5 +4,6 @@
     "data": "ftp://gisftp.metc.state.mn.us/Parcels2009.zip",
     "license": "PD + Indemnification",
     "year": "2009",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mn-hennepin.json
+++ b/sources/us-mn-hennepin.json
@@ -4,5 +4,6 @@
     "data": "http://gis.co.hennepin.mn.us/ArcGIS/rest/services/Maps/PROPERTY/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-mn-lake_of_the_woods.json
+++ b/sources/us-mn-lake_of_the_woods.json
@@ -4,5 +4,6 @@
     "data": "http://oak.co.lake-of-the-woods.mn.us/arcgis/rest/services/LOW_Internal/MapServer/54",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-mn-mille_lacs.json
+++ b/sources/us-mn-mille_lacs.json
@@ -4,5 +4,6 @@
     "data": "http://136.234.73.7/arcgis/rest/services/MilleLacs_E911/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-mn-otter_tail.json
+++ b/sources/us-mn-otter_tail.json
@@ -4,5 +4,6 @@
     "data": "http://www.ottertailcounty.net/arcgiswa/rest/services/Address_Roads/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-mn-polk.json
+++ b/sources/us-mn-polk.json
@@ -4,5 +4,6 @@
     "data": "http://gis.co.polk.mn.us/arcgis/rest/services/PolkAll/MapServer/12",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-mn-pope.json
+++ b/sources/us-mn-pope.json
@@ -4,5 +4,6 @@
     "data": "http://gis.co.pope.mn.us/arcgis/rest/services/PopeAll_101/MapServer/4",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-mn-renville.json
+++ b/sources/us-mn-renville.json
@@ -4,5 +4,6 @@
     "data": "http://gis.co.renville.mn.us/arcgis/rest/services/RENVILLEPUBLIC/MapServer/3",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-mn-roseau.json
+++ b/sources/us-mn-roseau.json
@@ -4,5 +4,6 @@
     "data": "http://gis.co.roseau.mn.us/arcgis/rest/services/Roseau_OperationalData/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-mn-scott.json
+++ b/sources/us-mn-scott.json
@@ -4,5 +4,6 @@
     "data": "ftp://gisftp.metc.state.mn.us/Parcels2009.zip",
     "license": "PD + Indemnification",
     "year": "2009",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mn-st_louis.json
+++ b/sources/us-mn-st_louis.json
@@ -4,5 +4,6 @@
     "data": "http://gis.stlouiscountymn.gov/arcgis/rest/services/Planning/CLE_PLSS_Cadastral_Parcels/MapServer/17/query?outFields=%2A",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-mn-st_paul.json
+++ b/sources/us-mn-st_paul.json
@@ -4,5 +4,6 @@
     "data": "ftp://gisftp.metc.state.mn.us/Parcels2009.zip",
     "license": "PD + Indemnification",
     "year": "2009",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mn-stearns.json
+++ b/sources/us-mn-stearns.json
@@ -4,5 +4,6 @@
     "data": "http://maps.co.stearns.mn.us/uniquesig0767a81117f95d93bd9262ca4c328fca1cbca10efc455a2064f980d7dba6c440/uniquesig0/arcgis/rest/services/MYGOVFLEXPARCELS/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-mn-wadena.json
+++ b/sources/us-mn-wadena.json
@@ -4,5 +4,6 @@
     "data": "http://gis.co.wadena.mn.us/arcgis/rest/services/WADENAPUBLIC/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-mn-washington.json
+++ b/sources/us-mn-washington.json
@@ -4,5 +4,6 @@
     "data": "ftp://gisftp.metc.state.mn.us/Parcels2009.zip",
     "license": "PD + Indemnification",
     "year": "2009",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": ""
 }

--- a/sources/us-mn-wilkimn.json
+++ b/sources/us-mn-wilkimn.json
@@ -4,5 +4,6 @@
     "data": "http://gisweb.co.wilkin.mn.us/arcgis/rest/services/WilkinPublic/MapServer/16",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-mn-winona.json
+++ b/sources/us-mn-winona.json
@@ -4,5 +4,6 @@
     "data": "http://www.gosoutheastmn.com/ArcGIS/rest/services/Streets_Addresses/MapServer/2",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-mn-yellow_medicine.json
+++ b/sources/us-mn-yellow_medicine.json
@@ -4,5 +4,6 @@
     "data": "http://gis.co.ym.mn.gov/arcgis/rest/services/YellowMedicine/YellowMedicine_All/MapServer/39",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-mo-adair.json
+++ b/sources/us-mo-adair.json
@@ -4,5 +4,6 @@
     "data": "https://sites.integritygis.com/Geocortex/Essentials/REST/sites/Adair_County_MO_Public/map/mapservices/1/layers/16",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-mo-barry.json
+++ b/sources/us-mo-barry.json
@@ -1,5 +1,6 @@
 {
     "county": "Barry",
     "data": "http://gis-server.greatriv.com/ArcGIS/rest/services/BarryCo/BarryCo_operational/MapServer/2",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-mo-boone.json
+++ b/sources/us-mo-boone.json
@@ -4,5 +4,6 @@
     "data": "https://maps.showmeboone.com/arcgis/rest/services/BC_Basemap_Address/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-mo-dallas.json
+++ b/sources/us-mo-dallas.json
@@ -4,5 +4,6 @@
     "data": "https://sites.integritygis.com/Geocortex/Essentials/REST/sites/Dallas_County_MO_Public/map/mapservices/1/layers/4",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-mo-greene.json
+++ b/sources/us-mo-greene.json
@@ -4,5 +4,6 @@
     "data": "ftp://msdis.missouri.edu/pub/Cultural_Society_Demography/MO_2012_Greene_County_Situs_Addresses_shp.zip",
     "license": "",
     "year": "2012",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mo-holt.json
+++ b/sources/us-mo-holt.json
@@ -4,5 +4,6 @@
     "data": "https://sites.integritygis.com/Geocortex/Essentials/REST/sites/Holt_County_MO_Public/map/mapservices/1/layers/19",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-mo-kansas_city.json
+++ b/sources/us-mo-kansas_city.json
@@ -4,5 +4,6 @@
     "data": "http://maps.kcmo.org/kcgis/rest/services/external/Platting/MapServer/40",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-mo-lawerence.json
+++ b/sources/us-mo-lawerence.json
@@ -4,5 +4,6 @@
     "data": "https://sites.integritygis.com/Geocortex/Essentials/REST/sites/Lawrence_County_MO_Public/map/mapservices/1/layers/6",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-mo-livingston.json
+++ b/sources/us-mo-livingston.json
@@ -4,5 +4,6 @@
     "data": "https://sites.integritygis.com/Geocortex/Essentials/REST/sites/Livingston_County_MO_Public/map/mapservices/1/layers/8",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-mo-miller.json
+++ b/sources/us-mo-miller.json
@@ -4,5 +4,6 @@
     "data": "https://sites.integritygis.com/Geocortex/Essentials/REST/sites/Miller_County_MO_Public/map/mapservices/0/layers/6",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-mo-morgan.json
+++ b/sources/us-mo-morgan.json
@@ -4,5 +4,6 @@
     "data": "https://sites.integritygis.com/Geocortex/Essentials/REST/sites/Morgan_County_MO_Public/map/mapservices/1/layers/4",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-mo-st_louis.json
+++ b/sources/us-mo-st_louis.json
@@ -4,5 +4,6 @@
     "data": "http://stlcin.missouri.org/citydata/downloads/pargeocd.zip",
     "license": "http://stlcin.missouri.org/citydata/downloads/terms.cfm",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": "zip"
 }

--- a/sources/us-mo-stone.json
+++ b/sources/us-mo-stone.json
@@ -4,5 +4,6 @@
     "data": "https://sites.integritygis.com/Geocortex/Essentials/REST/sites/Stone_County_MO_Public/map/mapservices/1/layers/8",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-mo-west_plains.json
+++ b/sources/us-mo-west_plains.json
@@ -4,5 +4,6 @@
     "data": "https://sites.integritygis.com/Geocortex/Essentials/REST/sites/West_Plains_MO_Public/map/mapservices/0/layers/5",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-mo.columbia.json
+++ b/sources/us-mo.columbia.json
@@ -1,5 +1,6 @@
 {
     "city": "Columbia",
     "data": "http://www.gocolumbiamo.com/arcgis/rest/services/ADDRESSES/MapServer/2",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-mt-beaverhead.json
+++ b/sources/us-mt-beaverhead.json
@@ -1,5 +1,6 @@
 {
     "county": "Beaverhead",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Beaverhead/BeaverheadOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-big_horn.json
+++ b/sources/us-mt-big_horn.json
@@ -1,5 +1,6 @@
 {
     "county": "Big Horn",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Bighorn/BighornOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-blaine.json
+++ b/sources/us-mt-blaine.json
@@ -1,5 +1,6 @@
 {
     "county": "Blaine",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Blaine/BlaineOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-broadwater.json
+++ b/sources/us-mt-broadwater.json
@@ -1,5 +1,6 @@
 {
     "county": "Broadwater",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Broadwater/BroadwaterOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-carbon.json
+++ b/sources/us-mt-carbon.json
@@ -1,5 +1,6 @@
 {
     "county": "Carbon",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Carbon/CarbonOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-carter.json
+++ b/sources/us-mt-carter.json
@@ -1,5 +1,6 @@
 {
     "county": "Carter",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Carter/CarterOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-cascade.json
+++ b/sources/us-mt-cascade.json
@@ -1,5 +1,6 @@
 {
     "county": "Cascade",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Cascade/CascadeOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-chouteau.json
+++ b/sources/us-mt-chouteau.json
@@ -1,5 +1,6 @@
 {
     "county": "Chouteau",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Chouteau/ChouteauOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-custer.json
+++ b/sources/us-mt-custer.json
@@ -1,5 +1,6 @@
 {
     "county": "Custer",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Custer/CusterOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-daniels.json
+++ b/sources/us-mt-daniels.json
@@ -1,5 +1,6 @@
 {
     "county": "Daniels",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Daniels/DanielsOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-dawson.json
+++ b/sources/us-mt-dawson.json
@@ -1,5 +1,6 @@
 {
     "county": "Dawson",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Dawson/DawsonOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-deer_lodge.json
+++ b/sources/us-mt-deer_lodge.json
@@ -1,5 +1,6 @@
 {
     "county": "Deer Lodge",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Deerlodge/DeerlodgeOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-fallon.json
+++ b/sources/us-mt-fallon.json
@@ -1,5 +1,6 @@
 {
     "county": "Fallon",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Fallon/FallonOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-fergus.json
+++ b/sources/us-mt-fergus.json
@@ -1,5 +1,6 @@
 {
     "county": "Fergus",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Fergus/FergusOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-flathead.json
+++ b/sources/us-mt-flathead.json
@@ -1,5 +1,6 @@
 {
     "county": "Flathead",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Flathead/FlatheadOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-gallatin.json
+++ b/sources/us-mt-gallatin.json
@@ -1,5 +1,6 @@
 {
     "county": "Gallatin",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Gallatin/GallatinOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-garfield.json
+++ b/sources/us-mt-garfield.json
@@ -1,5 +1,6 @@
 {
     "county": "Garfield",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Garfield/GarfieldOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-glacier.json
+++ b/sources/us-mt-glacier.json
@@ -1,5 +1,6 @@
 {
     "county": "Glacier",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Glacier/GlacierOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-golden_valley.json
+++ b/sources/us-mt-golden_valley.json
@@ -1,5 +1,6 @@
 {
     "county": "Golden Valley",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Goldenvalley/GoldenvalleyOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-granite.json
+++ b/sources/us-mt-granite.json
@@ -1,5 +1,6 @@
 {
     "county": "Granite",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Granite/GraniteOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-hill.json
+++ b/sources/us-mt-hill.json
@@ -1,5 +1,6 @@
 {
     "county": "Hill",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Hill/HillOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-jefferson.json
+++ b/sources/us-mt-jefferson.json
@@ -1,5 +1,6 @@
 {
     "county": "Jefferson",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Jefferson/JeffersonOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-judith_basin.json
+++ b/sources/us-mt-judith_basin.json
@@ -1,5 +1,6 @@
 {
     "county": "Judith Basin",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Judithbasin/JudithbasinOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-lake.json
+++ b/sources/us-mt-lake.json
@@ -1,5 +1,6 @@
 {
     "county": "Lake",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Lake/LakeOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-lewis_and_clark.json
+++ b/sources/us-mt-lewis_and_clark.json
@@ -1,5 +1,6 @@
 {
     "county": "Lewis and Clark",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Lewisclark/LewisclarkOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-liberty.json
+++ b/sources/us-mt-liberty.json
@@ -1,5 +1,6 @@
 {
     "county": "Liberty",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Liberty/LibertyOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-lincoln.json
+++ b/sources/us-mt-lincoln.json
@@ -1,5 +1,6 @@
 {
     "county": "Lincoln",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Lincoln/LincolnOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-madison.json
+++ b/sources/us-mt-madison.json
@@ -1,5 +1,6 @@
 {
     "county": "Madison",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Madison/MadisonOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-mccone.json
+++ b/sources/us-mt-mccone.json
@@ -1,5 +1,6 @@
 {
     "county": "McCone",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Mccone/McconeOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-meagher.json
+++ b/sources/us-mt-meagher.json
@@ -1,5 +1,6 @@
 {
     "county": "Meagher",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Meagher/MeagherOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-mineral.json
+++ b/sources/us-mt-mineral.json
@@ -1,5 +1,6 @@
 {
     "county": "Mineral",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Mineral/MineralOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-missoula.json
+++ b/sources/us-mt-missoula.json
@@ -1,5 +1,6 @@
 {
     "county": "Missoula",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Missoula/MissoulaOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-musselshell.json
+++ b/sources/us-mt-musselshell.json
@@ -1,5 +1,6 @@
 {
     "county": "Musselshell",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Musselshell/MusselshellOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-park.json
+++ b/sources/us-mt-park.json
@@ -4,5 +4,6 @@
     "data": "http://www.parkcounty.org/arcgis/rest/services/Maps/Clerk_Recorder_Web_Map/MapServer/3",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-mt-petroleum.json
+++ b/sources/us-mt-petroleum.json
@@ -1,5 +1,6 @@
 {
     "county": "Petroleum",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Petroleum/PetroleumOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-phillips.json
+++ b/sources/us-mt-phillips.json
@@ -1,5 +1,6 @@
 {
     "county": "Phillips",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Phillips/PhillipsOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-pondera.json
+++ b/sources/us-mt-pondera.json
@@ -1,5 +1,6 @@
 {
     "county": "Pondera",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Pondera/PonderaOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-powder_river.json
+++ b/sources/us-mt-powder_river.json
@@ -1,5 +1,6 @@
 {
     "county": "Powder River",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Powderriver/PowderriverOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-powell.json
+++ b/sources/us-mt-powell.json
@@ -1,5 +1,6 @@
 {
     "county": "Powell",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Powell/PowellOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-prairie.json
+++ b/sources/us-mt-prairie.json
@@ -1,5 +1,6 @@
 {
     "county": "Prairie",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Prairie/PrairieOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-ravalli.json
+++ b/sources/us-mt-ravalli.json
@@ -1,5 +1,6 @@
 {
     "county": "Ravalli",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Ravalli/RavalliOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-richland.json
+++ b/sources/us-mt-richland.json
@@ -1,5 +1,6 @@
 {
     "county": "Richland",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Richland/RichlandOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-roosevelt.json
+++ b/sources/us-mt-roosevelt.json
@@ -1,5 +1,6 @@
 {
     "county": "Roosevelt",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Roosevelt/RooseveltOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-rosebud.json
+++ b/sources/us-mt-rosebud.json
@@ -1,5 +1,6 @@
 {
     "county": "Rosebud",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Rosebud/RosebudOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-sanders.json
+++ b/sources/us-mt-sanders.json
@@ -1,5 +1,6 @@
 {
     "county": "Sanders",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Sanders/SandersOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-sheridan.json
+++ b/sources/us-mt-sheridan.json
@@ -1,5 +1,6 @@
 {
     "county": "Sheridan",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Sheridan/SheridanOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-silverbow.json
+++ b/sources/us-mt-silverbow.json
@@ -1,5 +1,6 @@
 {
     "county": "Silverbow",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Silverbow/SilverbowOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-stillwater.json
+++ b/sources/us-mt-stillwater.json
@@ -1,5 +1,6 @@
 {
     "county": "Stillwater",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Stillwater/StillwaterOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-sweet_grass.json
+++ b/sources/us-mt-sweet_grass.json
@@ -1,5 +1,6 @@
 {
     "county": "Sweet Grass",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Sweetgrass/SweetgrassOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-teton.json
+++ b/sources/us-mt-teton.json
@@ -1,5 +1,6 @@
 {
     "county": "Teton",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Teton/TetonOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-toole.json
+++ b/sources/us-mt-toole.json
@@ -1,5 +1,6 @@
 {
     "county": "Toole",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Toole/TooleOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-treasure.json
+++ b/sources/us-mt-treasure.json
@@ -1,5 +1,6 @@
 {
     "county": "Treasure",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Treasure/TreasureOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-valley.json
+++ b/sources/us-mt-valley.json
@@ -1,5 +1,6 @@
 {
     "county": "Valley",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Valley/ValleyOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-wheatland.json
+++ b/sources/us-mt-wheatland.json
@@ -1,5 +1,6 @@
 {
     "county": "Wheatland",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Wheatland/WheatlandOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-wibaux.json
+++ b/sources/us-mt-wibaux.json
@@ -1,5 +1,6 @@
 {
     "county": "Wibaux",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Wibaux/WibauxOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-mt-yellowstone.json
+++ b/sources/us-mt-yellowstone.json
@@ -1,5 +1,6 @@
 {
     "county": "Yellowstone",
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Yellowstone/YellowstoneOwnerParcel_shp.zip",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-nc-alexander.json
+++ b/sources/us-nc-alexander.json
@@ -4,5 +4,6 @@
     "data": "http://maps.co.alexander.nc.us/arcgis/rest/services/Regional_Site/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-nc-cary.json
+++ b/sources/us-nc-cary.json
@@ -4,5 +4,6 @@
     "data": "ftp://199.72.17.76/GIS/CaryBuildings.zip",
     "license": "",
     "year": "",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-nc-charlotte.json
+++ b/sources/us-nc-charlotte.json
@@ -4,5 +4,6 @@
     "data": "http://gis.mecklenburgcountync.gov/data/MAT.zip",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": "zip"
 }

--- a/sources/us-nc-columbus.json
+++ b/sources/us-nc-columbus.json
@@ -4,5 +4,6 @@
     "data": "http://www.columbusco.org/GISData/Addresses.zip",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": "zip"
 }

--- a/sources/us-nc-forsyth.json
+++ b/sources/us-nc-forsyth.json
@@ -4,5 +4,6 @@
     "data": "http://www.cityofws.org/portals/0/pdf/planning/GIS/Data-Sets/FCparcel_1-1-13.zip",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": "zip"
 }

--- a/sources/us-nc-high_point.json
+++ b/sources/us-nc-high_point.json
@@ -4,5 +4,6 @@
     "data": "http://gisweb.high-point.net/clearinghouse/shapes/hp_address.zip",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": "zip"
 }

--- a/sources/us-nc-orange.json
+++ b/sources/us-nc-orange.json
@@ -4,5 +4,6 @@
     "data": "http://web.co.orange.nc.us/gisdownloads/addresses.zip",
     "license": "Indemnification",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": "zip"
 }

--- a/sources/us-nc-salisbury.json
+++ b/sources/us-nc-salisbury.json
@@ -4,5 +4,6 @@
     "data": "http://gis.salisburync.gov/ArcGIS/rest/services/SalisburyAddresses/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-nc-union.json
+++ b/sources/us-nc-union.json
@@ -4,5 +4,6 @@
     "data": "http://www.co.union.nc.us/Portals/0/GIS/shapes/address_points.zip",
     "license": "",
     "year": "11/2013",
-    "type": "http"
+    "type": "http",
+    "compression": "zip"
 }

--- a/sources/us-nd-bismarck.json
+++ b/sources/us-nd-bismarck.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.state.nd.us/Landbase10-30-2013.zip",
     "license": "",
     "year": "",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-nd-cass.json
+++ b/sources/us-nd-cass.json
@@ -1,5 +1,6 @@
 {
     "county": "Cass",
     "data": "http://gisweb.casscountynd.gov/arcgis/rest/services/PublicDynamic/MapServer/22",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-ne-lincoln.json
+++ b/sources/us-ne-lincoln.json
@@ -3,5 +3,6 @@
     "county": "",
     "website": "http://lincoln.ne.gov/city/plan/its/gis.htm",
     "license": "",
-    "year": ""
+    "year": "",
+    "compression": ""
 }

--- a/sources/us-ne-omaha.json
+++ b/sources/us-ne-omaha.json
@@ -4,5 +4,6 @@
     "data": "http://gis.dogis.org/arcgis/rest/services/Parcels_Cache/MapServer/0",
     "license": "Imdemnification?",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-nj-woodbridge.json
+++ b/sources/us-nj-woodbridge.json
@@ -4,5 +4,6 @@
     "data": "http://njgin.state.nj.us/download2/parcels/parcels_shp_Woodbridge.zip",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": "zip"
 }

--- a/sources/us-nm-alburquerque.json
+++ b/sources/us-nm-alburquerque.json
@@ -4,5 +4,6 @@
     "data": "http://manzano.cabq.gov/gisshapes/base.zip",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": "zip"
 }

--- a/sources/us-nv-henderson.json
+++ b/sources/us-nv-henderson.json
@@ -4,5 +4,6 @@
     "data": "http://maps.cityofhenderson.com/ArcGIS/rest/services/public/BasemapMAX/MapServer/4",
     "license": "http://www.cityofhenderson.com/gis/disclaimer.php",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-nv-lander.json
+++ b/sources/us-nv-lander.json
@@ -4,5 +4,6 @@
     "data": "http://landernv.mygisonline.com/arcgis/rest/services/NV_Lander/LanderNVfeatures/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-nv-las_vegas.json
+++ b/sources/us-nv-las_vegas.json
@@ -4,5 +4,6 @@
     "data": "http://mapdata.lasvegasnevada.gov/clvgis/rest/services/AdministrativeBoundaries/Condo_Parcels/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-nv-nye.json
+++ b/sources/us-nv-nye.json
@@ -4,5 +4,6 @@
     "data": "http://nyenv.mygisonline.com/arcgis/rest/services/NV_Nye/NyeNVfeatures/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-nv-reno.json
+++ b/sources/us-nv-reno.json
@@ -1,8 +1,9 @@
 {
     "city": "Reno",
     "county": "Washoe",
-    "data": "ftp://wcftp.washoecounty.us/outtoworld/dwh/addresses_oct2013.zipx",
+    "data": "ftp://wcftp.washoecounty.us/outtoworld/dwh/addresses_oct2013.zip",
     "license": "",
     "year": "10/2013",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-ny-allegany.json
+++ b/sources/us-ny-allegany.json
@@ -3,5 +3,6 @@
     "county": "Allegany",
     "website": "http://gis.ny.gov/gisdata/inventories/details.cfm?dsid=921&nysgis=",
     "license": "",
-    "year": ""
+    "year": "",
+    "compression": ""
 }

--- a/sources/us-ny-cattaraugus.json
+++ b/sources/us-ny-cattaraugus.json
@@ -3,5 +3,6 @@
     "county": "Cattaraugus",
     "website": "http://gis.ny.gov/gisdata/inventories/details.cfm?dsid=921&nysgis=",
     "license": "",
-    "year": ""
+    "year": "",
+    "compression": ""
 }

--- a/sources/us-oh-akron.json
+++ b/sources/us-oh-akron.json
@@ -3,5 +3,6 @@
     "county": "Summit",
     "website": "http://fiscaloffice.summitoh.net/index.php/documents-a-forms/viewdownload/68-parcels/503-parcels",
     "license": "",
-    "year": ""
+    "year": "",
+    "compression": ""
 }

--- a/sources/us-oh-cincinnati.json
+++ b/sources/us-oh-cincinnati.json
@@ -4,5 +4,6 @@
     "data": "http://cagisonline.hamilton-co.org/arcgis/rest/services/Countywide_Layers/addressesTables/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-oh-cleveland.json
+++ b/sources/us-oh-cleveland.json
@@ -3,5 +3,6 @@
     "county": "Cuyahoga",
     "website": "http://gis.cuyahogacounty.us/en-US/GIS-Data.aspx",
     "license": "unknown",
-    "year": "published 2010"
+    "year": "published 2010",
+    "compression": ""
 }

--- a/sources/us-oh-columbus.json
+++ b/sources/us-oh-columbus.json
@@ -4,5 +4,6 @@
     "data": "http://mymaps.columbus.gov/ArcGIS/rest/services/i311_SWR/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-oh-geauga.json
+++ b/sources/us-oh-geauga.json
@@ -3,5 +3,6 @@
     "county": "Geauga",
     "website": "http://www.auditor.co.geauga.oh.us/LinkClick.aspx?fileticket=0HhWy6rLrTQ%3d&tabid=1796&portalid=13&mid=3442",
     "license": "",
-    "year": ""
+    "year": "",
+    "compression": ""
 }

--- a/sources/us-oh-toledo.json
+++ b/sources/us-oh-toledo.json
@@ -4,5 +4,6 @@
     "data": "http://services1.arcgis.com/JVJnGNgPBDy0lB85/ArcGIS/rest/services/Address/FeatureServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-or-portland.json
+++ b/sources/us-or-portland.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp02.portlandoregon.gov/CivicApps/address.zip",
     "license": "",
     "year": "",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-pa-philadelphia.json
+++ b/sources/us-pa-philadelphia.json
@@ -4,5 +4,6 @@
     "data": "http://www.pasda.psu.edu/philacity/data/Philadelphia_DOR_Parcels_Active201302.zip",
     "license": "http://www.pasda.psu.edu/uci/PhiladelphiaAgreement.asp",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": "zip"
 }

--- a/sources/us-pa-pittsbugh.json
+++ b/sources/us-pa-pittsbugh.json
@@ -4,5 +4,6 @@
     "data": "ftp://www.pasda.psu.edu/pub/pasda/alleghenycounty/AlleghenyCounty_AddressPoints201311.zip",
     "license": "",
     "year": "",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-sc-berkeley.json
+++ b/sources/us-sc-berkeley.json
@@ -1,5 +1,6 @@
 {
     "county": "Berkeley",
     "data": "http://gis.berkeleycountysc.gov/arcgis/rest/services/mobile/base_test/MapServer/3",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-sc-lexington.json
+++ b/sources/us-sc-lexington.json
@@ -4,5 +4,6 @@
     "data": "http://maps.lex-co.com/arcgis/rest/services/AddressPts/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-sd.json
+++ b/sources/us-sd.json
@@ -1,5 +1,6 @@
 {
     "county": "All?",
     "data": "http://arcgis.sd.gov/arcgis/rest/services/BIT/AddressViewer/MapServer/0",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-tn-jefferson.json
+++ b/sources/us-tn-jefferson.json
@@ -4,5 +4,6 @@
     "data": "http://maps.binarybus.com/arcgis/rest/services/Jefferson/jefferson/MapServer/1",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-tn-memphis.json
+++ b/sources/us-tn-memphis.json
@@ -4,5 +4,6 @@
     "data": "http://mapview.memphistn.gov/ArcGIS/rest/services/Parcels2010/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-tn-nashville_davidson.json
+++ b/sources/us-tn-nashville_davidson.json
@@ -4,5 +4,6 @@
     "data": "http://maps.nashville.gov/MetGIS/rest/services/QueryLayers/AddressPoints/MapServer/1",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-tn-rutherford.json
+++ b/sources/us-tn-rutherford.json
@@ -1,5 +1,6 @@
 {
     "county": "Rutherford",
     "data": "http://maps.rutherfordcountytn.gov/ArcGIS/rest/services/Basemaps/PublicSafety/MapServer/2",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-tx-arlington.json
+++ b/sources/us-tx-arlington.json
@@ -3,5 +3,6 @@
     "county": "(Tarrant)",
     "website": "(Use Tarrant County)",
     "license": "",
-    "year": ""
+    "year": "",
+    "compression": ""
 }

--- a/sources/us-tx-auston.json
+++ b/sources/us-tx-auston.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.ci.austin.tx.us/GIS-Data/Regional/address_points/address_point.zip",
     "license": "",
     "year": "11/8/2013",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-tx-colleyville.json
+++ b/sources/us-tx-colleyville.json
@@ -4,5 +4,6 @@
     "data": "http://gis.dfwmaps.com/ArcGIS/rest/services/Colleyville/Colleyville_BaseLayers_VE/MapServer/1",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-tx-dallas.json
+++ b/sources/us-tx-dallas.json
@@ -4,5 +4,6 @@
     "data": "http://gis.dfwmaps.com/ArcGIS/rest/services/Dallas/DallasLayers_All_VE/MapServer/2",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-tx-desoto.json
+++ b/sources/us-tx-desoto.json
@@ -4,5 +4,6 @@
     "data": "http://gis.dfwmaps.com/ArcGIS/rest/services/Desoto/Desoto_Baselayers_VE/MapServer/2",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-tx-dona_ana.json
+++ b/sources/us-tx-dona_ana.json
@@ -4,5 +4,6 @@
     "data": "http://www.pdnmapa.org/HTML/dacshps/DAC_Address.zip",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": "zip"
 }

--- a/sources/us-tx-el_paso.json
+++ b/sources/us-tx-el_paso.json
@@ -4,5 +4,6 @@
     "data": "http://www.pdnmapa.org/HTML/epshps/parcels.zip",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": "zip"
 }

--- a/sources/us-tx-fort_worth.json
+++ b/sources/us-tx-fort_worth.json
@@ -4,5 +4,6 @@
     "data": "http://gis.dentoncounty.com/ArcGIS/rest/services/CAD/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-tx-houston.json
+++ b/sources/us-tx-houston.json
@@ -4,5 +4,6 @@
     "data": "http://pdata.hcad.org/GIS/Parcels.exe",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-tx-hurst.json
+++ b/sources/us-tx-hurst.json
@@ -4,5 +4,6 @@
     "data": "http://gis.dfwmaps.com/ArcGIS/rest/services/Hurst/Hurst_BaseLayers_VE/MapServer/1",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-tx-keller.json
+++ b/sources/us-tx-keller.json
@@ -4,5 +4,6 @@
     "data": "http://gis.dfwmaps.com/ArcGIS/rest/services/Keller/Keller_All_VE/MapServer/13",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-tx-lubbock.json
+++ b/sources/us-tx-lubbock.json
@@ -4,5 +4,6 @@
     "data": "http://ewebmap.ci.lubbock.tx.us/currentdata/parcels/parcels.zip",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": "zip"
 }

--- a/sources/us-tx-montgomery.json
+++ b/sources/us-tx-montgomery.json
@@ -4,5 +4,6 @@
     "data": "http://www.mcad-tx.org/shapes/GisData20130906.zip",
     "license": "",
     "year": 2013,
-    "type": "http"
+    "type": "http",
+    "compression": "zip"
 }

--- a/sources/us-tx-north_richland_hills.json
+++ b/sources/us-tx-north_richland_hills.json
@@ -4,5 +4,6 @@
     "data": "http://gis.dfwmaps.com/ArcGIS/rest/services/NRH/NRH_Baselayers_VE/MapServer/1",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-tx-plano.json
+++ b/sources/us-tx-plano.json
@@ -4,5 +4,6 @@
     "data": "http://gismaps.collincountytx.gov/ArcGIS/rest/services/county/IdentifyParcels/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-tx-san_antonio.json
+++ b/sources/us-tx-san_antonio.json
@@ -4,5 +4,6 @@
     "data": "https://gis.sanantonio.gov/ArcGIS/rest/services/BaseData/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-tx-snyder.json
+++ b/sources/us-tx-snyder.json
@@ -4,5 +4,6 @@
     "data": "https://sites.integritygis.com/Geocortex/Essentials/REST/sites/Snyder_TX_Public/map/mapservices/3/layers/1",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-tx-university_park.json
+++ b/sources/us-tx-university_park.json
@@ -4,5 +4,6 @@
     "data": "http://gis.dfwmaps.com/ArcGIS/rest/services/UniversityPark/UP_All_VE/MapServer/5",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-tx-waco.json
+++ b/sources/us-tx-waco.json
@@ -1,5 +1,6 @@
 {
     "city": "Waco",
     "data": "http://gis.ci.waco.tx.us/arcgis/rest/services/WacoApps/ParcelPublicAccess/MapServer/2",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-ut-albany.json
+++ b/sources/us-ut-albany.json
@@ -1,5 +1,6 @@
 {
     "county": "Albany",
     "data": "http://arcmobile.co.albany.wy.us/arcgis/rest/services/PublicWebMap/Ownership/MapServer/0",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-ut-carbon.json
+++ b/sources/us-ut-carbon.json
@@ -1,5 +1,6 @@
 {
     "county": "Carbon",
     "data": "http://arcmobile.co.albany.wy.us/arcgis/rest/services/CarbonCounty/CarbonCntyWebMap/MapServer/4",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-ut-laramie.json
+++ b/sources/us-ut-laramie.json
@@ -1,5 +1,6 @@
 {
     "county": "Laramie",
     "data": "http://arcims.laramiecounty.com/arcgis/rest/services/Floodplains/MapServer/0",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-ut.json
+++ b/sources/us-ut.json
@@ -3,5 +3,6 @@
     "data": "ftp://ftp.agrc.utah.gov/UtahSGID_Vector/UTM12_NAD83/LOCATION/UnpackagedData/AddressPoints/_Statewide/AddressPoints_shp.zip",
     "comment": "there is a GDB version available as well.",
     "date": "2014-02-12T00:00:00.000Z",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-va-abingdon.json
+++ b/sources/us-va-abingdon.json
@@ -4,5 +4,6 @@
     "data": "https://sites.integritygis.com/Geocortex/Essentials/REST/sites/Abingdon_VA_Public/map/mapservices/1/layers/4",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-va-arlington.json
+++ b/sources/us-va-arlington.json
@@ -4,5 +4,6 @@
     "data": "http://gis.arlingtonva.us/arlgis/rest/services/public/Addresses/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-va-buchanan.json
+++ b/sources/us-va-buchanan.json
@@ -4,5 +4,6 @@
     "data": "https://sites.integritygis.com/Geocortex/Essentials/REST/sites/Buchanan_County_Public/map/mapservices/1/layers/7",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-va-chesapeake.json
+++ b/sources/us-va-chesapeake.json
@@ -3,5 +3,6 @@
     "county": "",
     "website": "paid FTP site",
     "license": "http://www.cityofchesapeake.net/Government/City-Departments/Departments/Information-Technology-Department/02gis/disclaimer.htm",
-    "year": ""
+    "year": "",
+    "compression": ""
 }

--- a/sources/us-va-prince_william.json
+++ b/sources/us-va-prince_william.json
@@ -4,5 +4,6 @@
     "data": "http://gisweb.pwcgov.org/arcgis/rest/services/Maps/LandRecords/MapServer/2",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-wa-san_juan.json
+++ b/sources/us-wa-san_juan.json
@@ -4,5 +4,6 @@
     "data": "http://www.sjcgis.org/arcgis/rest/services/Polaris/LocationSearch/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-wa-seattle.json
+++ b/sources/us-wa-seattle.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.kingcounty.gov/gis/Web/GISData/address_SHP.zip",
     "license": "http://www5.kingcounty.gov/gisdataportal/",
     "year": "",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-wa-skagit.json
+++ b/sources/us-wa-skagit.json
@@ -1,5 +1,6 @@
 {
     "county": "Skagit",
     "data": "http://www.skagitcounty.net/publicgis/rest/services/Assessor/PropertyMap/MapServer/3",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-wa-snohmish.json
+++ b/sources/us-wa-snohmish.json
@@ -4,5 +4,6 @@
     "data": "ftp://ftp.snoco.org/E-911/Shapefiles/Addresspoints.zip",
     "license": "Unknown",
     "year": "2013",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-wi-adams.json
+++ b/sources/us-wi-adams.json
@@ -4,5 +4,6 @@
     "data": "http://gis2.msa-ps.com/ArcGIS/rest/services/StreetsAddress/MapServer/29",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-wi-bayfield.json
+++ b/sources/us-wi-bayfield.json
@@ -4,5 +4,6 @@
     "data": "http://www.bayfieldcounty.org/ArcGIS/rest/services/BFLRMapBasic/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-wi-brown.json
+++ b/sources/us-wi-brown.json
@@ -3,5 +3,6 @@
     "county": "Brown",
     "website": "http://BrownLIO:Service2013@maps.gis.co.brown.wi.us/web_documents/LIO/addresses/",
     "license": "",
-    "year": ""
+    "year": "",
+    "compression": ""
 }

--- a/sources/us-wi-calumet.json
+++ b/sources/us-wi-calumet.json
@@ -4,5 +4,6 @@
     "data": "ftp://liouser:l!oguest1@ftp.co.calumet.wi.us/websitedata/CalumetAddressPts.zip",
     "license": "",
     "year": "",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-wi-columbia.json
+++ b/sources/us-wi-columbia.json
@@ -4,5 +4,6 @@
     "data": "http://lrs.co.columbia.wi.us/ArcGIS/rest/services/LRS/Addresses/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-wi-crawford.json
+++ b/sources/us-wi-crawford.json
@@ -4,5 +4,6 @@
     "data": "http://gis2.msa-ps.com/ArcGIS/rest/services/StreetsAddress/MapServer/22",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-wi-dodge.json
+++ b/sources/us-wi-dodge.json
@@ -4,5 +4,6 @@
     "data": "http://gis2.msa-ps.com/ArcGIS/rest/services/StreetsAddress/MapServer/47",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-wi-eau_claire.json
+++ b/sources/us-wi-eau_claire.json
@@ -3,5 +3,6 @@
     "county": "Eau Claire",
     "website": "http://eauclairecowi.wgxtreme.com/",
     "license": "",
-    "year": ""
+    "year": "",
+    "compression": ""
 }

--- a/sources/us-wi-fond_du_lac.json
+++ b/sources/us-wi-fond_du_lac.json
@@ -4,5 +4,6 @@
     "data": "http://gisweb.fdlco.wi.gov/ArcGIS/rest/services/VectorMapLayers/MapServer/22",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-wi-forest.json
+++ b/sources/us-wi-forest.json
@@ -3,5 +3,6 @@
     "county": "Forest",
     "website": "http://forestcowi.wgxtreme.com/",
     "license": "",
-    "year": ""
+    "year": "",
+    "compression": ""
 }

--- a/sources/us-wi-green.json
+++ b/sources/us-wi-green.json
@@ -4,5 +4,6 @@
     "data": "http://landrecords.greencountywi.org/arcgis/rest/services/GreenCo_GIS/MapServer/1",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-wi-green_lake.json
+++ b/sources/us-wi-green_lake.json
@@ -4,5 +4,6 @@
     "data": "http://gis.co.green-lake.wi.us/gisweb/GIS_Viewer/asp/proxy.ashx?http://gis.co.green-lake.wi.us:8399/arcgis/rest/services/PARCEL/MapServer/4",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-wi-iron.json
+++ b/sources/us-wi-iron.json
@@ -4,5 +4,6 @@
     "data": "http://maps.ironcountywi.org:6080/arcgis/rest/services/addresses/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-wi-jackson.json
+++ b/sources/us-wi-jackson.json
@@ -3,5 +3,6 @@
     "county": "Jackson",
     "website": "http://jacksoncowi.wgxtreme.com/",
     "license": "",
-    "year": ""
+    "year": "",
+    "compression": ""
 }

--- a/sources/us-wi-jefferson.json
+++ b/sources/us-wi-jefferson.json
@@ -4,5 +4,6 @@
     "data": "http://jeffarcgis.jeffersoncountywi.gov/arcgis/rest/services/Public/Property_Ownership/MapServer/24",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-wi-juneau.json
+++ b/sources/us-wi-juneau.json
@@ -4,5 +4,6 @@
     "data": "http://gis2.msa-ps.com/ArcGIS/rest/services/StreetsAddress/MapServer/2",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-wi-kenosha.json
+++ b/sources/us-wi-kenosha.json
@@ -4,5 +4,6 @@
     "data": "http://kc-web-01.kenoshacounty.org/arcgis/rest/services/Interactive_Mapping/AddressPoints/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-wi-la_crosse.json
+++ b/sources/us-wi-la_crosse.json
@@ -3,5 +3,6 @@
     "county": "La Crosse",
     "website": "http://www.co.la-crosse.wi.us:81/ParcelAddressDimensionLabels/ParcelLabels/1/query",
     "license": "",
-    "year": ""
+    "year": "",
+    "compression": ""
 }

--- a/sources/us-wi-lincoln.json
+++ b/sources/us-wi-lincoln.json
@@ -4,5 +4,6 @@
     "data": "http://gis2.msa-ps.com/ArcGIS/rest/services/StreetsAddress/MapServer/49",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-wi-madison.json
+++ b/sources/us-wi-madison.json
@@ -4,5 +4,6 @@
     "data": "http://dcimapapps.countyofdane.com/arcgis/rest/services/TaxParcel/MapServer/1",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-wi-manitowoc.json
+++ b/sources/us-wi-manitowoc.json
@@ -4,5 +4,6 @@
     "data": "http://webmap2.manitowoc-county.com/agsweb/rest/services/Web_MercClipandShip/MapServer/1",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-wi-milwaukee.json
+++ b/sources/us-wi-milwaukee.json
@@ -3,5 +3,6 @@
     "county": "",
     "website": "http://city.milwaukee.gov/DownloadMapData3497.htm",
     "license": "indemnification",
-    "year": ""
+    "year": "",
+    "compression": ""
 }

--- a/sources/us-wi-oneida.json
+++ b/sources/us-wi-oneida.json
@@ -4,5 +4,6 @@
     "data": "http://gis2.msa-ps.com/ArcGIS/rest/services/StreetsAddress/MapServer/20",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": ""
 }

--- a/sources/us-wi-outagamie.json
+++ b/sources/us-wi-outagamie.json
@@ -4,5 +4,6 @@
     "data": "ftp://FTPGISWEBREAD:ftpgiswebread@ftp.co.outagamie.wi.us/users/ftpgisweb/AddressPointsSHAPE.zip",
     "license": "",
     "year": "",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-wi-portage.json
+++ b/sources/us-wi-portage.json
@@ -4,5 +4,6 @@
     "data": "http://gisinfo.co.portage.wi.us/ArcGIS/rest/services/Basemap/OperationalMSD/MapServer/1",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": "none"
 }

--- a/sources/us-wi-richland.json
+++ b/sources/us-wi-richland.json
@@ -4,5 +4,6 @@
     "data": "http://gis2.msa-ps.com/ArcGIS/rest/services/RichlandCo/RichlandCo_GIS_Public/MapServer/6",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": "none"
 }

--- a/sources/us-wi-sauk.json
+++ b/sources/us-wi-sauk.json
@@ -4,5 +4,6 @@
     "data": "http://gis2.msa-ps.com/ArcGIS/rest/services/StreetsAddress/MapServer/18",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": "none"
 }

--- a/sources/us-wi-superior.json
+++ b/sources/us-wi-superior.json
@@ -4,5 +4,6 @@
     "data": "ftp://maps:CityCounty@216.56.28.54/array1/maps/Web/ADDRPLCS.zip",
     "license": "",
     "year": "",
-    "type": "ftp"
+    "type": "ftp",
+    "compression": "zip"
 }

--- a/sources/us-wi-tremealeau.json
+++ b/sources/us-wi-tremealeau.json
@@ -4,5 +4,6 @@
     "data": "http://www.tremplocounty.com/ArcGIS/rest/services/Public/Landmarks_Addressing/MapServer/2",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": "none"
 }

--- a/sources/us-wi-vernon.json
+++ b/sources/us-wi-vernon.json
@@ -4,5 +4,6 @@
     "data": "http://www.vernoncounty.org/arcgis/rest/services/VCGISpriv/VCSO_Address_Pts/MapServer/2",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": "none"
 }

--- a/sources/us-wi-vilas.json
+++ b/sources/us-wi-vilas.json
@@ -4,5 +4,6 @@
     "data": "http://gis2.msa-ps.com/ArcGIS/rest/services/StreetsAddress/MapServer/4",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": "none"
 }

--- a/sources/us-wi-walworth.json
+++ b/sources/us-wi-walworth.json
@@ -4,5 +4,6 @@
     "data": "http://gisapps.co.walworth.wi.us/ArcGIS/rest/services/gisweb_Intranet/MapServer/3",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": "none"
 }

--- a/sources/us-wi-waukesha.json
+++ b/sources/us-wi-waukesha.json
@@ -4,5 +4,6 @@
     "data": "http://lis.waukeshacounty.gov/ArcGIS/rest/services/E911/MapServer/12",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": "none"
 }

--- a/sources/us-wi-waupaca.json
+++ b/sources/us-wi-waupaca.json
@@ -3,5 +3,6 @@
     "county": "Waupaca",
     "website": "http://www.co.waupaca.wi.us/landinformation/Data.aspx",
     "license": "",
-    "year": ""
+    "year": "",
+    "compression": "none"
 }

--- a/sources/us-wi-wood.json
+++ b/sources/us-wi-wood.json
@@ -4,5 +4,6 @@
     "data": "http://gis.co.wood.wi.us/gis/rest/services/FlexGIS/AddressesWGS/MapServer/0",
     "license": "",
     "year": "",
-    "type": "http"
+    "type": "http",
+    "compression": "none"
 }

--- a/sources/us-wv-harrison.json
+++ b/sources/us-wv-harrison.json
@@ -1,5 +1,6 @@
 {
     "county": "Harrison",
     "data": "http://arcgis.harrisoncountywv.com:6080/arcgis/rest/services/MapData/AddressData/MapServer/0",
-    "type": "http"
+    "type": "http",
+    "compression": "none"
 }

--- a/sources/us-wy-albany.json
+++ b/sources/us-wy-albany.json
@@ -1,5 +1,6 @@
 {
     "county": "Albany",
     "data": "http://arcmobile.co.albany.wy.us/arcgis/rest/services/PublicWebMap/Ownership/MapServer/0",
-    "type": "http"
+    "type": "http",
+    "compression": "none"
 }

--- a/sources/us-wy-carbon.json
+++ b/sources/us-wy-carbon.json
@@ -1,5 +1,6 @@
 {
     "county": "Carbon",
     "data": "http://arcmobile.co.albany.wy.us/arcgis/rest/services/CarbonCounty/CarbonCntyWebMap/MapServer/4",
-    "type": "http"
+    "type": "http",
+    "compression": "none"
 }

--- a/sources/us-wy-laramie.json
+++ b/sources/us-wy-laramie.json
@@ -1,5 +1,7 @@
 {
     "county": "Laramie",
     "data": "http://arcims.laramiecounty.com/arcgis/rest/services/Floodplains/MapServer/0",
-    "type": "http"
+    "type": "",
+    "compression": "none"
+    
 }


### PR DESCRIPTION
Some addresses do not have a compression field, making it necessary to interpret it from the downloaded filename. When using a tool such as openaddresses-download, the user may not know the file type and save the downloaded file without the proper extension, making guessing the compression more difficult.
