### PR TITLE
Add source for St Joseph County, Indiana

### DIFF
--- a/sources/us-in-st_joseph.json
+++ b/sources/us-in-st_joseph.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "in",
+        "county": "St. Joseph"
+    },
+    "data": "https://data.southbendin.gov/api/geospatial/puej-rcqm?method=export&format=Shapefile",
+    "website": "https://data.southbendin.gov/Geographic-Boundaries/Boundaries-St-Joseph-County-Parcels/puej-rcqm",
+    "license": "Public domain",
+    "type": "http",
+    "compression": "zip",
+    "year": "2014",
+    "note": "Full parcel shapefile set (not points)"
+}


### PR DESCRIPTION
Adding source data for St. Joseph County, Indiana (USA) courtesy of South Bend, Indiana's open data portal. This is a full parcel shapefile (not points).

Address data can be found in the following fields:
- PROP_ADDR (address)
- PROP_CITY (city)
- PROP_ZIP (zip code)
