### PR TITLE
Add source for Providence, RI, USA

### DIFF
--- a/sources/us-ri-providence.json
+++ b/sources/us-ri-providence.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ri",
+        "city": "Providence"
+    },
+    "data": "https://data.providenceri.gov/api/geospatial/ynak-nf84?method=export&format=Original",
+    "website": "https://data.providenceri.gov/Reference/Providence-Parcel-Boundaries/ynak-nf84",
+    "license": "",
+    "type": "http",
+    "compression": "zip",
+    "year": "2014",
+    "note": "Full parcel shapefile set (not points); address string is stored in the Property_A attribute; current as of Winter 2014"
+}


### PR DESCRIPTION
Notes:
- Full parcel shapefile set (not points)
- Address string is stored in the `Property_A` attribute
- Current as of Winter 2014

There's no explicit license noted, but this comes from their open data portal: https://data.providenceri.gov/Reference/Providence-Parcel-Boundaries/ynak-nf84 
