### PR TITLE
update date for Utah addresses

### DIFF
--- a/sources/us-ut.json
+++ b/sources/us-ut.json
@@ -5,7 +5,7 @@
     },
     "data": "ftp://ftp.agrc.utah.gov/UtahSGID_Vector/UTM12_NAD83/LOCATION/UnpackagedData/AddressPoints/_Statewide/AddressPoints_shp.zip",
     "comment": "there is a GDB version available as well.",
-    "date": "2014-02-12T00:00:00.000Z",
+    "date": "2014-06-23T00:00:00.000Z",
     "type": "ftp",
     "compression": "zip",
     "fingerprint": "4ff46052d3de2f7b4b4942fcd95ad4c2",


### PR DESCRIPTION
Weird, the contributing guide says the field should be 'year' but it's 'date' in this case?

Anyway, updated to reflect latest update by Utah AGRC.
