### PR TITLE
Updated Oregon Metro Terms

### DIFF
--- a/sources/us-or-portland_metro.json
+++ b/sources/us-or-portland_metro.json
@@ -5,7 +5,7 @@
         "city": "Portland Metro"
     },
     "data": "http://library.oregonmetro.gov/rlisdiscovery/master_address.zip",
-    "license": "http://rlisdiscovery.oregonmetro.gov/view/terms.htm",
+    "license": "http://www.oregonmetro.gov/sites/default/files/Open_Database_and_Content_Licenses.pdf",
     "type": "http",
     "compression": "zip",
     "fingerprint": "940a664e4584c037bceaa8de84362d12",


### PR DESCRIPTION
As a representative of Oregon Metro Data Resource Center, I made a change to correct the link to our new terms of use/license.
