### PR TITLE
add us-ma sources from MassGIS assessor DBF LOC_ID field x and y

### DIFF
--- a/sources/us-ma-abington.json
+++ b/sources/us-ma-abington.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "abington"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-abington.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-acton.json
+++ b/sources/us-ma-acton.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "acton"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-acton.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-acushnet.json
+++ b/sources/us-ma-acushnet.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "acushnet"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-acushnet.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-adams.json
+++ b/sources/us-ma-adams.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "adams"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-adams.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-agawam.json
+++ b/sources/us-ma-agawam.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "agawam"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-agawam.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-alford.json
+++ b/sources/us-ma-alford.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "alford"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-alford.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-amesbury.json
+++ b/sources/us-ma-amesbury.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "amesbury"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-amesbury.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2014",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-amherst.json
+++ b/sources/us-ma-amherst.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "amherst"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-amherst.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-andover.json
+++ b/sources/us-ma-andover.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "andover"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-andover.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-aquinnah.json
+++ b/sources/us-ma-aquinnah.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "aquinnah"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-aquinnah.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-arlington.json
+++ b/sources/us-ma-arlington.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "arlington"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-arlington.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-ashburnham.json
+++ b/sources/us-ma-ashburnham.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "ashburnham"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-ashburnham.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-ashby.json
+++ b/sources/us-ma-ashby.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "ashby"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-ashby.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-ashfield.json
+++ b/sources/us-ma-ashfield.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "ashfield"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-ashfield.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-ashland.json
+++ b/sources/us-ma-ashland.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "ashland"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-ashland.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-athol.json
+++ b/sources/us-ma-athol.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "athol"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-athol.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-attleboro.json
+++ b/sources/us-ma-attleboro.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "attleboro"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-attleboro.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-auburn.json
+++ b/sources/us-ma-auburn.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "auburn"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-auburn.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-avon.json
+++ b/sources/us-ma-avon.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "avon"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-avon.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-ayer.json
+++ b/sources/us-ma-ayer.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "ayer"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-ayer.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-barnstable.json
+++ b/sources/us-ma-barnstable.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "barnstable"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-barnstable.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-barre.json
+++ b/sources/us-ma-barre.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "barre"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-barre.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-becket.json
+++ b/sources/us-ma-becket.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "becket"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-becket.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-bedford.json
+++ b/sources/us-ma-bedford.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "bedford"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-bedford.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-belchertown.json
+++ b/sources/us-ma-belchertown.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "belchertown"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-belchertown.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-bellingham.json
+++ b/sources/us-ma-bellingham.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "bellingham"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-bellingham.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-belmont.json
+++ b/sources/us-ma-belmont.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "belmont"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-belmont.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2014",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-berkley.json
+++ b/sources/us-ma-berkley.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "berkley"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-berkley.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-berlin.json
+++ b/sources/us-ma-berlin.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "berlin"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-berlin.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-bernardston.json
+++ b/sources/us-ma-bernardston.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "bernardston"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-bernardston.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-beverly.json
+++ b/sources/us-ma-beverly.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "beverly"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-beverly.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-billerica.json
+++ b/sources/us-ma-billerica.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "billerica"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-billerica.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-blackstone.json
+++ b/sources/us-ma-blackstone.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "blackstone"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-blackstone.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-blandford.json
+++ b/sources/us-ma-blandford.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "blandford"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-blandford.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-bolton.json
+++ b/sources/us-ma-bolton.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "bolton"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-bolton.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-bourne.json
+++ b/sources/us-ma-bourne.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "bourne"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-bourne.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-boxborough.json
+++ b/sources/us-ma-boxborough.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "boxborough"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-boxborough.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-boxford.json
+++ b/sources/us-ma-boxford.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "boxford"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-boxford.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-boylston.json
+++ b/sources/us-ma-boylston.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "boylston"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-boylston.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-braintree.json
+++ b/sources/us-ma-braintree.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "braintree"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-braintree.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-brewster.json
+++ b/sources/us-ma-brewster.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "brewster"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-brewster.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-bridgewater.json
+++ b/sources/us-ma-bridgewater.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "bridgewater"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-bridgewater.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-brimfield.json
+++ b/sources/us-ma-brimfield.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "brimfield"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-brimfield.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-brockton.json
+++ b/sources/us-ma-brockton.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "brockton"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-brockton.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-brookfield.json
+++ b/sources/us-ma-brookfield.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "brookfield"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-brookfield.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-buckland.json
+++ b/sources/us-ma-buckland.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "buckland"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-buckland.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-burlington.json
+++ b/sources/us-ma-burlington.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "burlington"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-burlington.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-canton.json
+++ b/sources/us-ma-canton.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "canton"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-canton.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-carlisle.json
+++ b/sources/us-ma-carlisle.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "carlisle"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-carlisle.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-carver.json
+++ b/sources/us-ma-carver.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "carver"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-carver.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2014",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-charlemont.json
+++ b/sources/us-ma-charlemont.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "charlemont"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-charlemont.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-charlton.json
+++ b/sources/us-ma-charlton.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "charlton"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-charlton.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-chatham.json
+++ b/sources/us-ma-chatham.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "chatham"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-chatham.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-chelmsford.json
+++ b/sources/us-ma-chelmsford.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "chelmsford"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-chelmsford.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-chelsea.json
+++ b/sources/us-ma-chelsea.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "chelsea"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-chelsea.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-cheshire.json
+++ b/sources/us-ma-cheshire.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "cheshire"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-cheshire.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-chester.json
+++ b/sources/us-ma-chester.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "chester"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-chester.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-chesterfield.json
+++ b/sources/us-ma-chesterfield.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "chesterfield"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-chesterfield.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-chilmark.json
+++ b/sources/us-ma-chilmark.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "chilmark"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-chilmark.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-clarksburg.json
+++ b/sources/us-ma-clarksburg.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "clarksburg"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-clarksburg.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-clinton.json
+++ b/sources/us-ma-clinton.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "clinton"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-clinton.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-cohasset.json
+++ b/sources/us-ma-cohasset.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "cohasset"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-cohasset.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-colrain.json
+++ b/sources/us-ma-colrain.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "colrain"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-colrain.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-concord.json
+++ b/sources/us-ma-concord.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "concord"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-concord.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-conway.json
+++ b/sources/us-ma-conway.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "conway"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-conway.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-cummington.json
+++ b/sources/us-ma-cummington.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "cummington"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-cummington.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-dalton.json
+++ b/sources/us-ma-dalton.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "dalton"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-dalton.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-danvers.json
+++ b/sources/us-ma-danvers.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "danvers"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-danvers.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-dartmouth.json
+++ b/sources/us-ma-dartmouth.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "dartmouth"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-dartmouth.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-dedham.json
+++ b/sources/us-ma-dedham.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "dedham"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-dedham.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-dennis.json
+++ b/sources/us-ma-dennis.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "dennis"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-dennis.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-dighton.json
+++ b/sources/us-ma-dighton.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "dighton"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-dighton.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-douglas.json
+++ b/sources/us-ma-douglas.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "douglas"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-douglas.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-dover.json
+++ b/sources/us-ma-dover.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "dover"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-dover.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-dracut.json
+++ b/sources/us-ma-dracut.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "dracut"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-dracut.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-dudley.json
+++ b/sources/us-ma-dudley.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "dudley"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-dudley.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-dunstable.json
+++ b/sources/us-ma-dunstable.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "dunstable"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-dunstable.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2015",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-duxbury.json
+++ b/sources/us-ma-duxbury.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "duxbury"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-duxbury.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-eastbridgewater.json
+++ b/sources/us-ma-eastbridgewater.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "eastbridgewater"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-eastbridgewater.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-eastbrookfield.json
+++ b/sources/us-ma-eastbrookfield.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "eastbrookfield"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-eastbrookfield.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-eastham.json
+++ b/sources/us-ma-eastham.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "eastham"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-eastham.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-eastlongmeadow.json
+++ b/sources/us-ma-eastlongmeadow.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "eastlongmeadow"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-eastlongmeadow.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-easton.json
+++ b/sources/us-ma-easton.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "easton"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-easton.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-edgartown.json
+++ b/sources/us-ma-edgartown.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "edgartown"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-edgartown.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-egremont.json
+++ b/sources/us-ma-egremont.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "egremont"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-egremont.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-erving.json
+++ b/sources/us-ma-erving.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "erving"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-erving.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-essex.json
+++ b/sources/us-ma-essex.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "essex"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-essex.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-everett.json
+++ b/sources/us-ma-everett.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "everett"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-everett.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-fairhaven.json
+++ b/sources/us-ma-fairhaven.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "fairhaven"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-fairhaven.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-fallriver.json
+++ b/sources/us-ma-fallriver.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "fallriver"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-fallriver.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-falmouth.json
+++ b/sources/us-ma-falmouth.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "falmouth"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-falmouth.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-fitchburg.json
+++ b/sources/us-ma-fitchburg.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "fitchburg"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-fitchburg.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-florida.json
+++ b/sources/us-ma-florida.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "florida"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-florida.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-foxborough.json
+++ b/sources/us-ma-foxborough.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "foxborough"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-foxborough.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-framingham.json
+++ b/sources/us-ma-framingham.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "framingham"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-framingham.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-franklin.json
+++ b/sources/us-ma-franklin.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "franklin"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-franklin.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-freetown.json
+++ b/sources/us-ma-freetown.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "freetown"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-freetown.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-gardner.json
+++ b/sources/us-ma-gardner.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "gardner"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-gardner.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-georgetown.json
+++ b/sources/us-ma-georgetown.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "georgetown"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-georgetown.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-gill.json
+++ b/sources/us-ma-gill.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "gill"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-gill.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-gloucester.json
+++ b/sources/us-ma-gloucester.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "gloucester"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-gloucester.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-goshen.json
+++ b/sources/us-ma-goshen.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "goshen"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-goshen.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-grafton.json
+++ b/sources/us-ma-grafton.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "grafton"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-grafton.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-granby.json
+++ b/sources/us-ma-granby.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "granby"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-granby.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-granville.json
+++ b/sources/us-ma-granville.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "granville"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-granville.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-greatbarrington.json
+++ b/sources/us-ma-greatbarrington.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "greatbarrington"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-greatbarrington.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2014",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-greenfield.json
+++ b/sources/us-ma-greenfield.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "greenfield"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-greenfield.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-groton.json
+++ b/sources/us-ma-groton.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "groton"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-groton.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-groveland.json
+++ b/sources/us-ma-groveland.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "groveland"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-groveland.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-hadley.json
+++ b/sources/us-ma-hadley.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "hadley"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-hadley.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-halifax.json
+++ b/sources/us-ma-halifax.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "halifax"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-halifax.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-hamilton.json
+++ b/sources/us-ma-hamilton.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "hamilton"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-hamilton.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-hampden.json
+++ b/sources/us-ma-hampden.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "hampden"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-hampden.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-hancock.json
+++ b/sources/us-ma-hancock.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "hancock"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-hancock.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-hanover.json
+++ b/sources/us-ma-hanover.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "hanover"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-hanover.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-hanson.json
+++ b/sources/us-ma-hanson.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "hanson"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-hanson.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-hardwick.json
+++ b/sources/us-ma-hardwick.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "hardwick"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-hardwick.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-harvard.json
+++ b/sources/us-ma-harvard.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "harvard"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-harvard.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-harwich.json
+++ b/sources/us-ma-harwich.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "harwich"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-harwich.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-hatfield.json
+++ b/sources/us-ma-hatfield.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "hatfield"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-hatfield.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-haverhill.json
+++ b/sources/us-ma-haverhill.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "haverhill"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-haverhill.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-hawley.json
+++ b/sources/us-ma-hawley.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "hawley"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-hawley.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2015",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-heath.json
+++ b/sources/us-ma-heath.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "heath"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-heath.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-hingham.json
+++ b/sources/us-ma-hingham.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "hingham"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-hingham.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-hinsdale.json
+++ b/sources/us-ma-hinsdale.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "hinsdale"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-hinsdale.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-holbrook.json
+++ b/sources/us-ma-holbrook.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "holbrook"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-holbrook.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-holden.json
+++ b/sources/us-ma-holden.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "holden"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-holden.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-holland.json
+++ b/sources/us-ma-holland.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "holland"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-holland.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-holliston.json
+++ b/sources/us-ma-holliston.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "holliston"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-holliston.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-holyoke.json
+++ b/sources/us-ma-holyoke.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "holyoke"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-holyoke.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-hopedale.json
+++ b/sources/us-ma-hopedale.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "hopedale"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-hopedale.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-hopkinton.json
+++ b/sources/us-ma-hopkinton.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "hopkinton"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-hopkinton.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-hubbardston.json
+++ b/sources/us-ma-hubbardston.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "hubbardston"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-hubbardston.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-hudson.json
+++ b/sources/us-ma-hudson.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "hudson"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-hudson.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-hull.json
+++ b/sources/us-ma-hull.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "hull"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-hull.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-huntington.json
+++ b/sources/us-ma-huntington.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "huntington"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-huntington.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-ipswich.json
+++ b/sources/us-ma-ipswich.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "ipswich"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-ipswich.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-kingston.json
+++ b/sources/us-ma-kingston.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "kingston"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-kingston.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-lakeville.json
+++ b/sources/us-ma-lakeville.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "lakeville"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-lakeville.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-lancaster.json
+++ b/sources/us-ma-lancaster.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "lancaster"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-lancaster.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-lanesborough.json
+++ b/sources/us-ma-lanesborough.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "lanesborough"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-lanesborough.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-lawrence.json
+++ b/sources/us-ma-lawrence.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "lawrence"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-lawrence.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-lee.json
+++ b/sources/us-ma-lee.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "lee"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-lee.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-leicester.json
+++ b/sources/us-ma-leicester.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "leicester"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-leicester.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-lenox.json
+++ b/sources/us-ma-lenox.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "lenox"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-lenox.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-leominster.json
+++ b/sources/us-ma-leominster.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "leominster"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-leominster.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-leverett.json
+++ b/sources/us-ma-leverett.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "leverett"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-leverett.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-lexington.json
+++ b/sources/us-ma-lexington.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "lexington"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-lexington.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-leyden.json
+++ b/sources/us-ma-leyden.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "leyden"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-leyden.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-lincoln.json
+++ b/sources/us-ma-lincoln.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "lincoln"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-lincoln.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-littleton.json
+++ b/sources/us-ma-littleton.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "littleton"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-littleton.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-longmeadow.json
+++ b/sources/us-ma-longmeadow.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "longmeadow"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-longmeadow.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-lowell.json
+++ b/sources/us-ma-lowell.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "lowell"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-lowell.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-ludlow.json
+++ b/sources/us-ma-ludlow.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "ludlow"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-ludlow.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2014",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-lunenburg.json
+++ b/sources/us-ma-lunenburg.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "lunenburg"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-lunenburg.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-lynn.json
+++ b/sources/us-ma-lynn.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "lynn"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-lynn.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-lynnfield.json
+++ b/sources/us-ma-lynnfield.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "lynnfield"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-lynnfield.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-malden.json
+++ b/sources/us-ma-malden.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "malden"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-malden.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-manchester.json
+++ b/sources/us-ma-manchester.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "manchester"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-manchester.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-mansfield.json
+++ b/sources/us-ma-mansfield.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "mansfield"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-mansfield.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-marblehead.json
+++ b/sources/us-ma-marblehead.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "marblehead"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-marblehead.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-marion.json
+++ b/sources/us-ma-marion.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "marion"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-marion.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2014",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-marlborough.json
+++ b/sources/us-ma-marlborough.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "marlborough"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-marlborough.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-marshfield.json
+++ b/sources/us-ma-marshfield.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "marshfield"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-marshfield.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-mashpee.json
+++ b/sources/us-ma-mashpee.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "mashpee"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-mashpee.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-mattapoisett.json
+++ b/sources/us-ma-mattapoisett.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "mattapoisett"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-mattapoisett.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-maynard.json
+++ b/sources/us-ma-maynard.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "maynard"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-maynard.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-medfield.json
+++ b/sources/us-ma-medfield.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "medfield"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-medfield.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-medford.json
+++ b/sources/us-ma-medford.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "medford"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-medford.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-medway.json
+++ b/sources/us-ma-medway.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "medway"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-medway.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-melrose.json
+++ b/sources/us-ma-melrose.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "melrose"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-melrose.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-mendon.json
+++ b/sources/us-ma-mendon.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "mendon"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-mendon.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-merrimac.json
+++ b/sources/us-ma-merrimac.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "merrimac"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-merrimac.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-methuen.json
+++ b/sources/us-ma-methuen.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "methuen"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-methuen.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-middleborough.json
+++ b/sources/us-ma-middleborough.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "middleborough"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-middleborough.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-middlefield.json
+++ b/sources/us-ma-middlefield.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "middlefield"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-middlefield.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-middleton.json
+++ b/sources/us-ma-middleton.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "middleton"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-middleton.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-milford.json
+++ b/sources/us-ma-milford.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "milford"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-milford.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-millbury.json
+++ b/sources/us-ma-millbury.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "millbury"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-millbury.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-millis.json
+++ b/sources/us-ma-millis.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "millis"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-millis.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-millville.json
+++ b/sources/us-ma-millville.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "millville"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-millville.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-milton.json
+++ b/sources/us-ma-milton.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "milton"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-milton.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-monroe.json
+++ b/sources/us-ma-monroe.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "monroe"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-monroe.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-montague.json
+++ b/sources/us-ma-montague.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "montague"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-montague.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-monterey.json
+++ b/sources/us-ma-monterey.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "monterey"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-monterey.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-montgomery.json
+++ b/sources/us-ma-montgomery.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "montgomery"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-montgomery.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-mountwashington.json
+++ b/sources/us-ma-mountwashington.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "mountwashington"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-mountwashington.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-nahant.json
+++ b/sources/us-ma-nahant.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "nahant"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-nahant.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-nantucket.json
+++ b/sources/us-ma-nantucket.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "nantucket"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-nantucket.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-natick.json
+++ b/sources/us-ma-natick.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "natick"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-natick.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-needham.json
+++ b/sources/us-ma-needham.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "needham"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-needham.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-newbedford.json
+++ b/sources/us-ma-newbedford.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "newbedford"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-newbedford.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-newbraintree.json
+++ b/sources/us-ma-newbraintree.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "newbraintree"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-newbraintree.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-newbury.json
+++ b/sources/us-ma-newbury.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "newbury"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-newbury.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2014",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-newburyport.json
+++ b/sources/us-ma-newburyport.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "newburyport"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-newburyport.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2014",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-newmarlborough.json
+++ b/sources/us-ma-newmarlborough.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "newmarlborough"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-newmarlborough.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-newsalem.json
+++ b/sources/us-ma-newsalem.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "newsalem"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-newsalem.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-newton.json
+++ b/sources/us-ma-newton.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "newton"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-newton.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-norfolk.json
+++ b/sources/us-ma-norfolk.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "norfolk"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-norfolk.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-northadams.json
+++ b/sources/us-ma-northadams.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "northadams"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-northadams.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-northampton.json
+++ b/sources/us-ma-northampton.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "northampton"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-northampton.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-northandover.json
+++ b/sources/us-ma-northandover.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "northandover"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-northandover.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-northattleborough.json
+++ b/sources/us-ma-northattleborough.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "northattleborough"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-northattleborough.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-northborough.json
+++ b/sources/us-ma-northborough.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "northborough"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-northborough.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-northbridge.json
+++ b/sources/us-ma-northbridge.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "northbridge"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-northbridge.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-northbrookfield.json
+++ b/sources/us-ma-northbrookfield.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "northbrookfield"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-northbrookfield.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-northfield.json
+++ b/sources/us-ma-northfield.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "northfield"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-northfield.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-northreading.json
+++ b/sources/us-ma-northreading.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "northreading"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-northreading.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-norton.json
+++ b/sources/us-ma-norton.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "norton"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-norton.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-norwell.json
+++ b/sources/us-ma-norwell.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "norwell"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-norwell.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-norwood.json
+++ b/sources/us-ma-norwood.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "norwood"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-norwood.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-oakbluffs.json
+++ b/sources/us-ma-oakbluffs.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "oakbluffs"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-oakbluffs.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-oakham.json
+++ b/sources/us-ma-oakham.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "oakham"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-oakham.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-orange.json
+++ b/sources/us-ma-orange.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "orange"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-orange.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-orleans.json
+++ b/sources/us-ma-orleans.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "orleans"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-orleans.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-otis.json
+++ b/sources/us-ma-otis.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "otis"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-otis.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-oxford.json
+++ b/sources/us-ma-oxford.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "oxford"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-oxford.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-palmer.json
+++ b/sources/us-ma-palmer.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "palmer"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-palmer.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-paxton.json
+++ b/sources/us-ma-paxton.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "paxton"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-paxton.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-peabody.json
+++ b/sources/us-ma-peabody.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "peabody"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-peabody.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-pelham.json
+++ b/sources/us-ma-pelham.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "pelham"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-pelham.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-pembroke.json
+++ b/sources/us-ma-pembroke.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "pembroke"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-pembroke.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-pepperell.json
+++ b/sources/us-ma-pepperell.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "pepperell"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-pepperell.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-peru.json
+++ b/sources/us-ma-peru.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "peru"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-peru.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-petersham.json
+++ b/sources/us-ma-petersham.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "petersham"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-petersham.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-phillipston.json
+++ b/sources/us-ma-phillipston.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "phillipston"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-phillipston.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-pittsfield.json
+++ b/sources/us-ma-pittsfield.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "pittsfield"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-pittsfield.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-plainfield.json
+++ b/sources/us-ma-plainfield.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "plainfield"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-plainfield.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-plainville.json
+++ b/sources/us-ma-plainville.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "plainville"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-plainville.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-plymouth.json
+++ b/sources/us-ma-plymouth.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "plymouth"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-plymouth.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-plympton.json
+++ b/sources/us-ma-plympton.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "plympton"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-plympton.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-princeton.json
+++ b/sources/us-ma-princeton.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "princeton"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-princeton.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-provincetown.json
+++ b/sources/us-ma-provincetown.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "provincetown"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-provincetown.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-quincy.json
+++ b/sources/us-ma-quincy.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "quincy"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-quincy.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-randolph.json
+++ b/sources/us-ma-randolph.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "randolph"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-randolph.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-raynham.json
+++ b/sources/us-ma-raynham.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "raynham"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-raynham.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-reading.json
+++ b/sources/us-ma-reading.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "reading"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-reading.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-rehoboth.json
+++ b/sources/us-ma-rehoboth.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "rehoboth"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-rehoboth.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-revere.json
+++ b/sources/us-ma-revere.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "revere"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-revere.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-richmond.json
+++ b/sources/us-ma-richmond.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "richmond"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-richmond.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-rochester.json
+++ b/sources/us-ma-rochester.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "rochester"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-rochester.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-rockland.json
+++ b/sources/us-ma-rockland.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "rockland"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-rockland.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-rockport.json
+++ b/sources/us-ma-rockport.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "rockport"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-rockport.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-rowe.json
+++ b/sources/us-ma-rowe.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "rowe"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-rowe.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-rowley.json
+++ b/sources/us-ma-rowley.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "rowley"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-rowley.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2014",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-royalston.json
+++ b/sources/us-ma-royalston.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "royalston"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-royalston.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-rutland.json
+++ b/sources/us-ma-rutland.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "rutland"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-rutland.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-salem.json
+++ b/sources/us-ma-salem.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "salem"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-salem.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-salisbury.json
+++ b/sources/us-ma-salisbury.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "salisbury"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-salisbury.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-sandisfield.json
+++ b/sources/us-ma-sandisfield.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "sandisfield"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-sandisfield.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-sandwich.json
+++ b/sources/us-ma-sandwich.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "sandwich"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-sandwich.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-saugus.json
+++ b/sources/us-ma-saugus.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "saugus"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-saugus.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-savoy.json
+++ b/sources/us-ma-savoy.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "savoy"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-savoy.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-scituate.json
+++ b/sources/us-ma-scituate.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "scituate"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-scituate.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-seekonk.json
+++ b/sources/us-ma-seekonk.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "seekonk"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-seekonk.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-sharon.json
+++ b/sources/us-ma-sharon.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "sharon"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-sharon.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-sheffield.json
+++ b/sources/us-ma-sheffield.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "sheffield"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-sheffield.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-shelburne.json
+++ b/sources/us-ma-shelburne.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "shelburne"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-shelburne.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-sherborn.json
+++ b/sources/us-ma-sherborn.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "sherborn"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-sherborn.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-shirley.json
+++ b/sources/us-ma-shirley.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "shirley"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-shirley.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-shrewsbury.json
+++ b/sources/us-ma-shrewsbury.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "shrewsbury"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-shrewsbury.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-shutesbury.json
+++ b/sources/us-ma-shutesbury.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "shutesbury"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-shutesbury.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-somerset.json
+++ b/sources/us-ma-somerset.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "somerset"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-somerset.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-somerville.json
+++ b/sources/us-ma-somerville.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "somerville"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-somerville.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-southampton.json
+++ b/sources/us-ma-southampton.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "southampton"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-southampton.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-southborough.json
+++ b/sources/us-ma-southborough.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "southborough"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-southborough.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-southbridge.json
+++ b/sources/us-ma-southbridge.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "southbridge"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-southbridge.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-southhadley.json
+++ b/sources/us-ma-southhadley.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "southhadley"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-southhadley.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-southwick.json
+++ b/sources/us-ma-southwick.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "southwick"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-southwick.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-spencer.json
+++ b/sources/us-ma-spencer.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "spencer"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-spencer.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-springfield.json
+++ b/sources/us-ma-springfield.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "springfield"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-springfield.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-sterling.json
+++ b/sources/us-ma-sterling.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "sterling"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-sterling.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-stockbridge.json
+++ b/sources/us-ma-stockbridge.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "stockbridge"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-stockbridge.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-stoneham.json
+++ b/sources/us-ma-stoneham.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "stoneham"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-stoneham.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-stoughton.json
+++ b/sources/us-ma-stoughton.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "stoughton"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-stoughton.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-stow.json
+++ b/sources/us-ma-stow.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "stow"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-stow.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-sturbridge.json
+++ b/sources/us-ma-sturbridge.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "sturbridge"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-sturbridge.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-sudbury.json
+++ b/sources/us-ma-sudbury.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "sudbury"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-sudbury.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-sunderland.json
+++ b/sources/us-ma-sunderland.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "sunderland"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-sunderland.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-sutton.json
+++ b/sources/us-ma-sutton.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "sutton"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-sutton.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-swampscott.json
+++ b/sources/us-ma-swampscott.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "swampscott"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-swampscott.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-swansea.json
+++ b/sources/us-ma-swansea.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "swansea"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-swansea.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-taunton.json
+++ b/sources/us-ma-taunton.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "taunton"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-taunton.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-templeton.json
+++ b/sources/us-ma-templeton.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "templeton"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-templeton.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-tewksbury.json
+++ b/sources/us-ma-tewksbury.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "tewksbury"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-tewksbury.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-tisbury.json
+++ b/sources/us-ma-tisbury.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "tisbury"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-tisbury.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-tolland.json
+++ b/sources/us-ma-tolland.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "tolland"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-tolland.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-topsfield.json
+++ b/sources/us-ma-topsfield.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "topsfield"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-topsfield.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-townsend.json
+++ b/sources/us-ma-townsend.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "townsend"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-townsend.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2015",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-truro.json
+++ b/sources/us-ma-truro.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "truro"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-truro.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-tyngsborough.json
+++ b/sources/us-ma-tyngsborough.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "tyngsborough"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-tyngsborough.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-upton.json
+++ b/sources/us-ma-upton.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "upton"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-upton.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-uxbridge.json
+++ b/sources/us-ma-uxbridge.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "uxbridge"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-uxbridge.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-wakefield.json
+++ b/sources/us-ma-wakefield.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "wakefield"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-wakefield.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-wales.json
+++ b/sources/us-ma-wales.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "wales"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-wales.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-walpole.json
+++ b/sources/us-ma-walpole.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "walpole"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-walpole.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-waltham.json
+++ b/sources/us-ma-waltham.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "waltham"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-waltham.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-ware.json
+++ b/sources/us-ma-ware.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "ware"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-ware.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-wareham.json
+++ b/sources/us-ma-wareham.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "wareham"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-wareham.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-warren.json
+++ b/sources/us-ma-warren.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "warren"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-warren.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-warwick.json
+++ b/sources/us-ma-warwick.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "warwick"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-warwick.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-washington.json
+++ b/sources/us-ma-washington.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "washington"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-washington.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-watertown.json
+++ b/sources/us-ma-watertown.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "watertown"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-watertown.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-wayland.json
+++ b/sources/us-ma-wayland.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "wayland"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-wayland.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-webster.json
+++ b/sources/us-ma-webster.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "webster"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-webster.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-wellesley.json
+++ b/sources/us-ma-wellesley.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "wellesley"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-wellesley.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-wellfleet.json
+++ b/sources/us-ma-wellfleet.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "wellfleet"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-wellfleet.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-wendell.json
+++ b/sources/us-ma-wendell.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "wendell"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-wendell.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-wenham.json
+++ b/sources/us-ma-wenham.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "wenham"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-wenham.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-westborough.json
+++ b/sources/us-ma-westborough.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "westborough"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-westborough.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-westboylston.json
+++ b/sources/us-ma-westboylston.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "westboylston"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-westboylston.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-westbridgewater.json
+++ b/sources/us-ma-westbridgewater.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "westbridgewater"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-westbridgewater.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-westbrookfield.json
+++ b/sources/us-ma-westbrookfield.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "westbrookfield"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-westbrookfield.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-westfield.json
+++ b/sources/us-ma-westfield.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "westfield"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-westfield.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-westford.json
+++ b/sources/us-ma-westford.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "westford"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-westford.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-westhampton.json
+++ b/sources/us-ma-westhampton.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "westhampton"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-westhampton.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-westminster.json
+++ b/sources/us-ma-westminster.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "westminster"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-westminster.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-westnewbury.json
+++ b/sources/us-ma-westnewbury.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "westnewbury"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-westnewbury.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2014",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-weston.json
+++ b/sources/us-ma-weston.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "weston"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-weston.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-westport.json
+++ b/sources/us-ma-westport.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "westport"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-westport.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-westspringfield.json
+++ b/sources/us-ma-westspringfield.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "westspringfield"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-westspringfield.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-weststockbridge.json
+++ b/sources/us-ma-weststockbridge.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "weststockbridge"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-weststockbridge.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-westtisbury.json
+++ b/sources/us-ma-westtisbury.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "westtisbury"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-westtisbury.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-westwood.json
+++ b/sources/us-ma-westwood.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "westwood"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-westwood.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-weymouth.json
+++ b/sources/us-ma-weymouth.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "weymouth"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-weymouth.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-whately.json
+++ b/sources/us-ma-whately.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "whately"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-whately.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-whitman.json
+++ b/sources/us-ma-whitman.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "whitman"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-whitman.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-williamsburg.json
+++ b/sources/us-ma-williamsburg.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "williamsburg"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-williamsburg.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-williamstown.json
+++ b/sources/us-ma-williamstown.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "williamstown"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-williamstown.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-wilmington.json
+++ b/sources/us-ma-wilmington.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "wilmington"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-wilmington.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-winchendon.json
+++ b/sources/us-ma-winchendon.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "winchendon"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-winchendon.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-winchester.json
+++ b/sources/us-ma-winchester.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "winchester"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-winchester.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-windsor.json
+++ b/sources/us-ma-windsor.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "windsor"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-windsor.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-winthrop.json
+++ b/sources/us-ma-winthrop.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "winthrop"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-winthrop.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2011",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-woburn.json
+++ b/sources/us-ma-woburn.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "woburn"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-woburn.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-worcester.json
+++ b/sources/us-ma-worcester.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "worcester"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-worcester.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-worthington.json
+++ b/sources/us-ma-worthington.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "worthington"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-worthington.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-wrentham.json
+++ b/sources/us-ma-wrentham.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "wrentham"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-wrentham.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2013",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}

--- a/sources/us-ma-yarmouth.json
+++ b/sources/us-ma-yarmouth.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ma",
+        "city": "yarmouth"
+    },
+    "data": "ftp://128.239.103.87/misc/us-ma-yarmouth.zip",
+    "website": "http://www.mass.gov/anf/research-and-tech/it-serv-and-support/application-serv/office-of-geographic-information-massgis/datalayers/ftpl3parcels.html",
+    "license": "Public Domain",
+    "year": "2012",
+    "type": "ftp",
+    "compression": "zip",
+    "note": "Parcel polygons are available from MassGIS. These x,y are derived from MassGIS LOC_ID and appear to be parcel polyon centroids.  SRS is EPSG:26986"
+}


### PR DESCRIPTION
Added sources with links to FTP.
These are point shapefile for each town in Massachusetts, USA that is not currently in the sources and that has reasonable coverage from MassGIS for both street name and street number.
Data are public domain.
While parcel polygons are available I've used points with xy taken from assessor DBFs' LOC_ID field, converting from US survey feet to meters as necessary.
However that xy made by MassGIS is really just parcel centroids anyway.

Spatial reference system is EPSG:26986, Massachusetts State Plane Mainland Zone.
There's a possibility that the towns in Dukes and Nantucket county really ought to be Massachusetts State Plane Island Zone but I haven't gone that far.

Here's a png of point shapefile BBOXs for these towns:

![us-ma-towns](https://cloud.githubusercontent.com/assets/495444/4005215/0540d970-298e-11e4-8eae-9f7180683db3.png).

Have I contributed correctly?
Thanks!
