### PR TITLE
Now including directional prefixes and suffixes for us-va-arlington

### DIFF
--- a/sources/us-va-arlington.json
+++ b/sources/us-va-arlington.json
@@ -10,14 +10,10 @@
     "version": "20140814",
     "cache": "http://s3.amazonaws.com/openaddresses/20140814/us-va-arlington.json",
     "conform": {
-        "merge": [
-            "strtname",
-            "strttype"
-        ],
         "lon": "x",
         "lat": "y",
         "number": "stnum",
-        "street": "auto_street",
+        "street": "stname",
         "type": "geojson"
     },
     "processed": "http://s3.amazonaws.com/openaddresses/us-va-arlington.csv"


### PR DESCRIPTION
Here's an example of a feature in `us-va-arlington`, I changed it to use `stname` instead of `strtname` and `strttype` so directional suffixes and prefixes are properly included.

This is my first PR so I hope I got the format right ;)

``` json
  {
      "type": "Feature",
      "properties": {
        "OBJECTID": 15163,
        "STNUM": 2765,
        "STCODE": "NQCYST",
        "STRTDIR": "N",
        "STRTDIRPREFIX": "N",
        "STRTNAME": "QUINCY",
        "STRTTYPE": "ST",
        "STRTDIRSUFFIX": "",
        "FULL_ADDRESS": "2765 N QUINCY ST",
        "STATUS": "VERIFIED",
        "UNITCOUNT": 1,
        "STNAME": "N QUINCY ST",
        "UNIT": null,
        "UPDATE_DATE": 1156291200000,
        "ZIP5": 22207
      },
      "geometry": {
        "type": "Point",
        "coordinates": [
          -77.1007728,
          38.908486
        ]
      }
    }
```
