### PR TITLE
add conform data for 3 Michigan counties

### DIFF
--- a/sources/us-mi-kent.json
+++ b/sources/us-mi-kent.json
@@ -9,5 +9,12 @@
     "type": "ESRI",
     "website": "https://www.accesskent.com/Departments/GIS/",
     "license": "",
-    "note": "Data includes polygon shape of parcels. Polygon is found in the SHAPE column. Address data is found in PROPERTYADDRESS, PROPADDRESSCITY, PROPADDRESSSTATE_ZIPCODE, PROPADDRESSNUMBER, PROPADDSTREET."
+    "note": "Data includes polygon shape of parcels. Polygon is found in the SHAPE column. Address data is found in PROPERTYADDRESS, PROPADDRESSCITY, PROPADDRESSSTATE_ZIPCODE, PROPADDRESSNUMBER, PROPADDSTREET.",
+    "conform": {
+        "lon": "x",
+        "lat": "y",
+        "number": "PROPADDRESSNUMBER",
+        "street": "PROPADDSTREET",
+        "type": "geojson"
+    }
 }

--- a/sources/us-mi-muskegon.json
+++ b/sources/us-mi-muskegon.json
@@ -9,5 +9,13 @@
     "type": "ESRI",
     "website": "http://www.muskegoncountygis.com/",
     "license": "",
-    "note": "Data includes polygon shape of parcels. Address data is found in PROP_COMBINED_ADDRESS, PROP_CITY, PROP_STATE, PROP_ZIP."
+    "note": "Data includes polygon shape of parcels. Address data is found in PROP_COMBINED_ADDRESS, PROP_CITY, PROP_STATE, PROP_ZIP.",
+    "conform": {
+        "split": "PROP_COMBINED_ADDRESS",
+        "lon": "x",
+        "lat": "y",
+        "number": "auto_number",
+        "street": "auto_street",
+        "type": "geojson"
+    }
 }

--- a/sources/us-mi-ottawa.json
+++ b/sources/us-mi-ottawa.json
@@ -9,5 +9,13 @@
     "type": "ESRI",
     "website": "http://www.gis.co.ottawa.mi.us/",
     "license": "",
-    "note": "Data includes polygon shape of parcels. Address data is found in PROPSTREETNUM, PROPSTREETNAME, ADDRESS, PROPCITY, PROPSTATE, PROPZIP. Polygon is found in the SHAPE column."
+    "note": "Data includes polygon shape of parcels. Address data is found in PROPSTREETNUM, PROPSTREETNAME, ADDRESS, PROPCITY, PROPSTATE, PROPZIP. Polygon is found in the SHAPE column.",
+    "conform": {
+        "lon": "x",
+        "lat": "y",
+        "number": "PROPSTREETNUM",
+        "street": "PROPSTREETNAME",
+        "postal_code": "PROPZIP",
+        "type": "geojson"
+    }
 }


### PR DESCRIPTION
This adds the conform details for Kent, Muskegon, and Ottawa counties.
