### PR TITLE
au-queensland

### DIFF
--- a/sources/au-queensland.json
+++ b/sources/au-queensland.json
@@ -1,24 +1,27 @@
 {
-    "coverage": {
-        "country": "au",
-        "state": "queensland"
-    },
-    "data": "http://qldspatial.information.qld.gov.au/downloadservice/Download.aspx?token=gkacqbfrl99eYLj7rgXmtOmmis9jnA2fV8khpjqyvX9aTJEhXS8NubVgf77jsAXZbE38h%2FuLMqZq%0ALzJCDFM2PMid6wbDp%2FI42Sljf%2FM5FcDHm91kaSUyAJiIageJe0VW6nS56RBB1jpM38g%2BegOLg8%2BL%0AGSjoiGJ4gQcSgo6QepdIzlv58LY5eIuWnEHObuoNsX1kLPfea2dOOdeAMogk7Qi8aMRsh%2F0DACcQ%0AGXwtA83uTuT458KaXdqu0ghuMRrIum%2BEwoDl3DLo%2FPPZCVo4rV%2BxfsAFE6Vc6NQkYehZVWhFTceW%0AupWNIPMt8jR3eSNSJvFQ2x%2FzfVQyoLnz0ksHjlfsLShu6zguGW2Gm%2B%2FBF2b%2BqWczkYX0DTiedBcY%0AhOGjxbCNc%2FjZb7wAZJ9EFLZjWDcFrWMZKLXUoG4S53A8%2BNszRCHDfFrHbv%2FohfOWzVCgq3eG6eXo%0Ar%2BjPpi12VN4opUQLiD%2FFW%2BvzuAkJKT%2FJJpOx%2Bfq33pbSKYZ0%2BCa0NLRCmozGBQgt0u34G6d2RgYG%0AKjCWYvwOUXOEUMDt%2FX0M%2B1pjTwanP%2B5LisigMDidO%2F2aOsU6LsENuFhk4wRaxEfL2bJJeneUKOLG%0AFIRcODNEB6fXJmzrV05Y8FmLucatC13rQorwoAX7EkMeBOuQGQP%2ByMZrENdtKHijhLyVng3D6MA%3D%0A",
-    "license": "http://dds.information.qld.gov.au/DDS/GetLicenseImage.license?ID=15",
-    "website": "https://data.qld.gov.au/dataset/property-address-queensland--data-package/resource/544b9d7f-aadd-4eba-b5d2-7a1f1ef0c83f",
     "compression": "zip",
-    "type": "http",
-    "cache": "http://s3.amazonaws.com/openaddresses/au-queensland.zip",
     "conform": {
-        "type": "csv",
-        "file": "DP_PROP_LOCATION_INDEXQLD/WholeOfState_20140530.txt",
-        "csvsplit": "|",
         "headers": -1,
+        "merge": [
+            "COLUMN14",
+            "COLUMN15"
+        ],
+        "type": "csv",
         "lon": "COLUMN21",
+        "street": "auto_street",
+        "csvsplit": "|",
         "lat": "COLUMN20",
-        "merge": ["COLUMN14", "COLUMN15"],
-        "number": "COLUMN10",
-        "street": "auto_street"
+        "file": "DP_PROP_LOCATION_INDEXQLD/WholeOfState_20140530.txt",
+        "number": "COLUMN10"
     },
-    "note": "data URL expires; must use web interface & email workflow to download fresh data. cached archive acquired 2014-11-20. License URL has changed; I have contacted the government for confirmation of CC-BY-like provisions."
+    "website": "https://data.qld.gov.au/dataset/property-address-queensland--data-package/resource/544b9d7f-aadd-4eba-b5d2-7a1f1ef0c83f",
+    "data": "http://qldspatial.information.qld.gov.au/downloadservice/Download.aspx?token=gkacqbfrl99eYLj7rgXmtOmmis9jnA2fV8khpjqyvX9aTJEhXS8NubVgf77jsAXZbE38h%2FuLMqZq%0ALzJCDFM2PMid6wbDp%2FI42Sljf%2FM5FcDHm91kaSUyAJiIageJe0VW6nS56RBB1jpM38g%2BegOLg8%2BL%0AGSjoiGJ4gQcSgo6QepdIzlv58LY5eIuWnEHObuoNsX1kLPfea2dOOdeAMogk7Qi8aMRsh%2F0DACcQ%0AGXwtA83uTuT458KaXdqu0ghuMRrIum%2BEwoDl3DLo%2FPPZCVo4rV%2BxfsAFE6Vc6NQkYehZVWhFTceW%0AupWNIPMt8jR3eSNSJvFQ2x%2FzfVQyoLnz0ksHjlfsLShu6zguGW2Gm%2B%2FBF2b%2BqWczkYX0DTiedBcY%0AhOGjxbCNc%2FjZb7wAZJ9EFLZjWDcFrWMZKLXUoG4S53A8%2BNszRCHDfFrHbv%2FohfOWzVCgq3eG6eXo%0Ar%2BjPpi12VN4opUQLiD%2FFW%2BvzuAkJKT%2FJJpOx%2Bfq33pbSKYZ0%2BCa0NLRCmozGBQgt0u34G6d2RgYG%0AKjCWYvwOUXOEUMDt%2FX0M%2B1pjTwanP%2B5LisigMDidO%2F2aOsU6LsENuFhk4wRaxEfL2bJJeneUKOLG%0AFIRcODNEB6fXJmzrV05Y8FmLucatC13rQorwoAX7EkMeBOuQGQP%2ByMZrENdtKHijhLyVng3D6MA%3D%0A",
+    "note": "data URL expires; must use web interface & email workflow to download fresh data. cached archive acquired 2014-11-20. License URL has changed; I have contacted the government for confirmation of CC-BY-like provisions.",
+    "type": "http",
+    "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/au-queensland.zip",
+    "coverage": {
+        "state": "queensland",
+        "country": "au"
+    },
+    "license": "http://dds.information.qld.gov.au/DDS/GetLicenseImage.license?ID=15"
 }


### PR DESCRIPTION
Originally discussed https://github.com/openaddresses/openaddresses/issues/132 by @CloCkWeRX 

Depends on https://github.com/openaddresses/openaddresses-conform/pull/30 -- this dataset is a CSV that is pipe-separated and lacks headers, which necessitated additional conform options.

See JSON for license notes. It was clearly listed as a CC-BY equivalent, but the license URL now redirects to the front page of their open data portal. I've emailed the relevant staff for clarification. As with `au-victoria`, delivery is via a web/email temporary link workflow. The unchanged file is cached in OA's S3 bucket.

![image](https://cloud.githubusercontent.com/assets/31717/5154507/a15ea08c-722f-11e4-86b3-7e18f6aa1cb7.png)
