### PR TITLE
au-tasmania

### DIFF
--- a/sources/au-tasmania.json
+++ b/sources/au-tasmania.json
@@ -1,20 +1,23 @@
 {
-    "coverage": {
-        "country": "au",
-        "state": "tasmania"
-    },
+    "type": "http",
+    "note": "data URL expires; must use web interface & email workflow to download fresh data. cached archive acquired 2014-11-17. License provisions in archive are outdated as per conversation with LIST staff available at https://soundcloud.com/sbma444/confirmation-of-tasmanias-list-dataset-being-cc-by",
+    "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/au-tasmania.zip",
     "license": "CCBY",
     "website": "https://www.thelist.tas.gov.au/app/content/data/geo-meta-data-record?profileType=&groupName=&bboxNorth=&bboxWest=&bboxSouth=&bboxEast=&query=address&_keywordCategory=-1&isTasmania=true&custodian=&detailRecordUID=403743d1-4d87-4fa4-8a51-91928f5935d6&searchCriteriaURL=query%3Daddress%26perPage%3D10%26sortBy%3DTitle%3AASC",
-    "compression": "zip",
-    "type": "http",
-    "cache": "http://s3.amazonaws.com/openaddresses/au-tasmania.zip",
     "conform": {
         "type": "shapefile",
         "lon": "X",
-        "lat": "Y",
-        "merge": ["STREET", "ST_TYPE"],
+        "merge": [
+            "STREET",
+            "ST_TYPE"
+        ],
         "number": "ST_NO_FROM",
+        "lat": "Y",
         "street": "auto_street"
     },
-    "note": "data URL expires; must use web interface & email workflow to download fresh data. cached archive acquired 2014-11-17. License provisions in archive are outdated as per conversation with LIST staff available at https://soundcloud.com/sbma444/confirmation-of-tasmanias-list-dataset-being-cc-by"
+    "coverage": {
+        "state": "tasmania",
+        "country": "au"
+    },
+    "compression": "zip"
 }


### PR DESCRIPTION
Tasmania's LIST dataset has recently been made CC-BY (with a $250 delivery fee which Mapbox has covered). I have received confirmation of the CC-BY status both during initial email contact and in a [subsequent phone call with a different government staffer](https://soundcloud.com/sbma444/confirmation-of-tasmanias-list-dataset-being-cc-by). But the archive _does_ contain a legacy autogenerated license document with much more restrictive licensing. I think the above recording should be sufficient to establish that this document can be ignored/that the data is under an open license. But I expect email confirmation from my original contact next week (she's been out of the office). Happy to supply that when I have it if people aren't comfortable merging this PR yet.

![image](https://cloud.githubusercontent.com/assets/31717/5154567/9df3075a-7232-11e4-9916-7131b5d8f09e.png)
