### PR TITLE
Japan (block-level address points)

### DIFF
--- a/sources/jp-aichi.json
+++ b/sources/jp-aichi.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-aichi.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u611b\u77e5\u770c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u611b\u77e5\u770c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/23000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/23000-12.0a.zip"
 }

--- a/sources/jp-akita.json
+++ b/sources/jp-akita.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-akita.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u79cb\u7530\u770c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u79cb\u7530\u770c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/05000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/05000-12.0a.zip"
 }

--- a/sources/jp-aomori.json
+++ b/sources/jp-aomori.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-aomori.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u9752\u68ee\u770c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u9752\u68ee\u770c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/02000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/02000-12.0a.zip"
 }

--- a/sources/jp-chiba.json
+++ b/sources/jp-chiba.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-chiba.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u5343\u8449\u770c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u5343\u8449\u770c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/12000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/12000-12.0a.zip"
 }

--- a/sources/jp-ehime.json
+++ b/sources/jp-ehime.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-ehime.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u611b\u5a9b\u770c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u611b\u5a9b\u770c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/38000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/38000-12.0a.zip"
 }

--- a/sources/jp-fukui.json
+++ b/sources/jp-fukui.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-fukui.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u798f\u4e95\u770c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u798f\u4e95\u770c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/18000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/18000-12.0a.zip"
 }

--- a/sources/jp-fukuoka.json
+++ b/sources/jp-fukuoka.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-fukuoka.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u798f\u5ca1\u770c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u798f\u5ca1\u770c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/40000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/40000-12.0a.zip"
 }

--- a/sources/jp-fukushima.json
+++ b/sources/jp-fukushima.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-fukushima.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u798f\u5cf6\u770c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u798f\u5cf6\u770c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/07000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/07000-12.0a.zip"
 }

--- a/sources/jp-gifu.json
+++ b/sources/jp-gifu.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-gifu.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u5c90\u961c\u770c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u5c90\u961c\u770c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/21000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/21000-12.0a.zip"
 }

--- a/sources/jp-gunma.json
+++ b/sources/jp-gunma.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-gunma.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u7fa4\u99ac\u770c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u7fa4\u99ac\u770c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/10000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/10000-12.0a.zip"
 }

--- a/sources/jp-hiroshima.json
+++ b/sources/jp-hiroshima.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-hiroshima.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u5e83\u5cf6\u770c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u5e83\u5cf6\u770c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/34000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/34000-12.0a.zip"
 }

--- a/sources/jp-hokkaido.json
+++ b/sources/jp-hokkaido.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-hokkaido.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u5317\u6d77\u9053"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u5317\u6d77\u9053"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/01000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/01000-12.0a.zip"
 }

--- a/sources/jp-hyogo.json
+++ b/sources/jp-hyogo.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-hyogo.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u5175\u5eab\u770c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u5175\u5eab\u770c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/28000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/28000-12.0a.zip"
 }

--- a/sources/jp-ibaraki.json
+++ b/sources/jp-ibaraki.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-ibaraki.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u8328\u57ce\u770c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u8328\u57ce\u770c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/08000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/08000-12.0a.zip"
 }

--- a/sources/jp-ishikawa.json
+++ b/sources/jp-ishikawa.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-ishikawa.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u77f3\u5ddd\u770c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u77f3\u5ddd\u770c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/17000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/17000-12.0a.zip"
 }

--- a/sources/jp-iwate.json
+++ b/sources/jp-iwate.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-iwate.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u5ca9\u624b\u770c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u5ca9\u624b\u770c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/03000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/03000-12.0a.zip"
 }

--- a/sources/jp-kagawa.json
+++ b/sources/jp-kagawa.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-kagawa.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u9999\u5ddd\u770c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u9999\u5ddd\u770c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/37000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/37000-12.0a.zip"
 }

--- a/sources/jp-kagoshima.json
+++ b/sources/jp-kagoshima.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-kagoshima.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u9e7f\u5150\u5cf6\u770c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u9e7f\u5150\u5cf6\u770c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/46000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/46000-12.0a.zip"
 }

--- a/sources/jp-kanagawa.json
+++ b/sources/jp-kanagawa.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-kanagawa.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u795e\u5948\u5ddd\u770c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u795e\u5948\u5ddd\u770c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/14000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/14000-12.0a.zip"
 }

--- a/sources/jp-kochi.json
+++ b/sources/jp-kochi.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-kochi.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u9ad8\u77e5\u770c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u9ad8\u77e5\u770c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/39000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/39000-12.0a.zip"
 }

--- a/sources/jp-kumamoto.json
+++ b/sources/jp-kumamoto.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-kumamoto.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u718a\u672c\u770c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u718a\u672c\u770c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/43000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/43000-12.0a.zip"
 }

--- a/sources/jp-kyoto.json
+++ b/sources/jp-kyoto.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-kyoto.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u4eac\u90fd\u5e9c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u4eac\u90fd\u5e9c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/26000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/26000-12.0a.zip"
 }

--- a/sources/jp-mie.json
+++ b/sources/jp-mie.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-mie.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u4e09\u91cd\u770c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u4e09\u91cd\u770c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/24000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/24000-12.0a.zip"
 }

--- a/sources/jp-miyagi.json
+++ b/sources/jp-miyagi.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-miyagi.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u5bae\u57ce\u770c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u5bae\u57ce\u770c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/04000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/04000-12.0a.zip"
 }

--- a/sources/jp-miyazaki.json
+++ b/sources/jp-miyazaki.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-miyazaki.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u5bae\u5d0e\u770c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u5bae\u5d0e\u770c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/45000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/45000-12.0a.zip"
 }

--- a/sources/jp-nagano.json
+++ b/sources/jp-nagano.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-nagano.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u9577\u91ce\u770c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u9577\u91ce\u770c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/20000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/20000-12.0a.zip"
 }

--- a/sources/jp-nagasaki.json
+++ b/sources/jp-nagasaki.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-nagasaki.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u9577\u5d0e\u770c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u9577\u5d0e\u770c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/42000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/42000-12.0a.zip"
 }

--- a/sources/jp-nara.json
+++ b/sources/jp-nara.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-nara.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u5948\u826f\u770c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u5948\u826f\u770c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/29000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/29000-12.0a.zip"
 }

--- a/sources/jp-niigata.json
+++ b/sources/jp-niigata.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-niigata.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u65b0\u6f5f\u770c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u65b0\u6f5f\u770c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/15000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/15000-12.0a.zip"
 }

--- a/sources/jp-oita.json
+++ b/sources/jp-oita.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-oita.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u5927\u5206\u770c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u5927\u5206\u770c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/44000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/44000-12.0a.zip"
 }

--- a/sources/jp-okayama.json
+++ b/sources/jp-okayama.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-okayama.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u5ca1\u5c71\u770c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u5ca1\u5c71\u770c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/33000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/33000-12.0a.zip"
 }

--- a/sources/jp-okinawa.json
+++ b/sources/jp-okinawa.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-okinawa.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u6c96\u7e04\u770c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u6c96\u7e04\u770c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/47000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/47000-12.0a.zip"
 }

--- a/sources/jp-osaka.json
+++ b/sources/jp-osaka.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-osaka.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u5927\u962a\u5e9c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u5927\u962a\u5e9c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/27000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/27000-12.0a.zip"
 }

--- a/sources/jp-saga.json
+++ b/sources/jp-saga.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-saga.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u4f50\u8cc0\u770c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u4f50\u8cc0\u770c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/41000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/41000-12.0a.zip"
 }

--- a/sources/jp-saitama.json
+++ b/sources/jp-saitama.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-saitama.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u57fc\u7389\u770c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u57fc\u7389\u770c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/11000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/11000-12.0a.zip"
 }

--- a/sources/jp-shiga.json
+++ b/sources/jp-shiga.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-shiga.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u6ecb\u8cc0\u770c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u6ecb\u8cc0\u770c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/25000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/25000-12.0a.zip"
 }

--- a/sources/jp-shimane.json
+++ b/sources/jp-shimane.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-shimane.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u5cf6\u6839\u770c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u5cf6\u6839\u770c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/32000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/32000-12.0a.zip"
 }

--- a/sources/jp-shizuoka.json
+++ b/sources/jp-shizuoka.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-shizuoka.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u9759\u5ca1\u770c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u9759\u5ca1\u770c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/22000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/22000-12.0a.zip"
 }

--- a/sources/jp-tochigi.json
+++ b/sources/jp-tochigi.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-tochigi.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u6803\u6728\u770c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u6803\u6728\u770c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/09000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/09000-12.0a.zip"
 }

--- a/sources/jp-tokushima.json
+++ b/sources/jp-tokushima.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-tokushima.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u5fb3\u5cf6\u770c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u5fb3\u5cf6\u770c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/36000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/36000-12.0a.zip"
 }

--- a/sources/jp-tokyo.json
+++ b/sources/jp-tokyo.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-tokyo.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u6771\u4eac\u90fd"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u6771\u4eac\u90fd"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/13000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/13000-12.0a.zip"
 }

--- a/sources/jp-tottori.json
+++ b/sources/jp-tottori.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-tottori.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u9ce5\u53d6\u770c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u9ce5\u53d6\u770c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/31000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/31000-12.0a.zip"
 }

--- a/sources/jp-toyama.json
+++ b/sources/jp-toyama.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-toyama.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u5bcc\u5c71\u770c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u5bcc\u5c71\u770c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/16000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/16000-12.0a.zip"
 }

--- a/sources/jp-wakayama.json
+++ b/sources/jp-wakayama.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-wakayama.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u548c\u6b4c\u5c71\u770c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u548c\u6b4c\u5c71\u770c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/30000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/30000-12.0a.zip"
 }

--- a/sources/jp-yamagata.json
+++ b/sources/jp-yamagata.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-yamagata.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u5c71\u5f62\u770c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u5c71\u5f62\u770c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/06000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/06000-12.0a.zip"
 }

--- a/sources/jp-yamaguchi.json
+++ b/sources/jp-yamaguchi.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-yamaguchi.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u5c71\u53e3\u770c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u5c71\u53e3\u770c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/35000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/35000-12.0a.zip"
 }

--- a/sources/jp-yamanashi.json
+++ b/sources/jp-yamanashi.json
@@ -1,7 +1,19 @@
 {
+    "type": "http",
     "cache": "http://s3.amazonaws.com/data.openaddresses.io/cache/jp-yamanashi.zip",
+    "website": "http://nlftp.mlit.go.jp/isj/index.html",
+    "compression": "zip",
+    "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
+    "coverage": {
+        "country": "jp",
+        "state": "\u5c71\u68a8\u770c"
+    },
     "conform": {
-        "encoding": "SHIFT_JISX0213",
+        "type": "csv",
+        "lat": "\u7def\u5ea6",
+        "srs": "EPSG:4612",
+        "number": "auto_number",
+        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
         "advanced_merge": {
             "auto_number": {
                 "separator": "-",
@@ -11,20 +23,9 @@
                 ]
             }
         },
-        "street": "\u5927\u5b57\u30fb\u753a\u4e01\u76ee\u540d",
-        "srs": "EPSG:4612",
-        "number": "auto_number",
-        "lat": "\u7def\u5ea6",
         "lon": "\u7d4c\u5ea6",
-        "type": "csv"
-    },
-    "compression": "zip",
-    "website": "http://nlftp.mlit.go.jp/isj/index.html",
-    "coverage": {
-        "country": "jp",
-        "state": "\u5c71\u68a8\u770c"
+        "encoding": "SHIFT_JISX0213"
     },
     "license": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
-    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/19000-12.0a.zip",
-    "type": "http"
+    "data": "http://nlftp.mlit.go.jp/isj/dls/data/12.0a/19000-12.0a.zip"
 }


### PR DESCRIPTION
depends on https://github.com/openaddresses/openaddresses-conform/pull/30
source URL: http://nlftp.mlit.go.jp/isj/data.html
license: http://nlftp.mlit.go.jp/ksj/other/yakkan.html (I don't speak Japanese, but based on Google Translate it looks pretty good to me)

There's coverage for all 47 prefectures, 12.7 million points in total. Note that this purports to be block-level points, not individual addresses. [Japan's address scheme is a hierarchy based on blocks, not streets](en.wikipedia.org/wiki/Japanese_addressing_system). House numbers exist but I'm not aware of a good open dataset of them (they don't appear to be that useful anyway -- I've heard anecdotally that directions are usually conveyed by faxed maps, not simply addresses; [the system is definitely imposing](http://www.planettokyo.com/trip-planning/getting-around/the-black-art-of-finding-a-japanese-address/)). Experimentation with existing consumer mapping sites makes it seem as though geolocation often ends at the block level, so this might be sufficient for many applications.

via the Japanese Ministry of Land, Infrastructure & Transport (MLIT).

Sample plot from `jp-tokyo.json`

![image](https://cloud.githubusercontent.com/assets/31717/5156166/60084d8e-727c-11e4-8392-d671d316a498.png)
