### PR TITLE
Added us-ca-santa_clara_county.json

### DIFF
--- a/sources/us-ca-santa_clara_county.json
+++ b/sources/us-ca-santa_clara_county.json
@@ -1,0 +1,13 @@
+{
+    "coverage": {
+        "US Census": {"geoid": "06085", "name": "Santa Clara County", "state": "California"},
+        "country": "us",
+        "state": "ca",
+        "county": "Santa Clara"
+    },
+    "data": "https://github.com/datadesk/us-ca-santa_clara_county-gis-shp/blob/master/Q4_FY14_Address_Point.zip?raw=true",
+    "website": "https://sftp.sccgov.org/courier/web/1000@/wmLogin.html",
+    "type": "http",
+    "compression": "zip",
+    "notes": "File download is behind a registration wall on government site so the zip was downloaded in November 2014 and uploaded to GitHub for public hosting."
+}


### PR DESCRIPTION
File download is behind a registration wall on government site so the zip was downloaded in November 2014 and uploaded to GitHub for public hosting. A public records request was necessary to get access to the system.
