### PR TITLE
Fix state name

### DIFF
--- a/sources/us-va.json
+++ b/sources/us-va.json
@@ -8,7 +8,7 @@
     "coverage": {
         "US Census": {
             "geoid": "51",
-            "state": "California"
+            "state": "Virginia"
         },
         "country": "us",
         "state": "va"


### PR DESCRIPTION
Looks like @migurski's 6fd58d95e2d43dd652df701678f0b8281e5a0c22 added an erroneous `California`.
