### PR TITLE
Add Clay County, FL

### DIFF
--- a/sources/us-fl-clay.json
+++ b/sources/us-fl-clay.json
@@ -1,0 +1,27 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "12019",
+            "name": "Clay County",
+            "state": "Florida"
+        },
+        "country": "us",
+        "state": "fl",
+        "county": "Clay"
+    },
+    "data": "http://www.ccpao.com/public/Parcel.zip",
+    "website": "http://www.ccpao.com/datadownloadGIS_all.html",
+    "type": "http",
+    "compression": "zip",
+    "conform": {
+        "file": "parcel/parcel.shp",
+        "lon": "x",
+        "lat": "y",
+        "split": "ADDRESS_1",
+        "number": "auto_number",
+        "street": "auto_street",
+        "city": "CITY_NAME",
+        "postcode": "ZIPCODE",
+        "type": "shapefile-polygon"
+    }
+}


### PR DESCRIPTION
Adding this source for Clay County. `number` and `street` are in a single field, so using the `split` operation for processing. Can someone confirm I used this correctly?
