### PR TITLE
Denmark

### DIFF
--- a/sources/dk.json
+++ b/sources/dk.json
@@ -9,7 +9,7 @@
     "attribution": "Contains information from the Danish Ministry of Housing, Urban and Rural Address Web Services (AWS).",
     "website": "http://download.aws.dk/",
     "type": "http",
-    "notes": "License is disclaimer of liability, allows commercial use & transformation, & has attribution language (unclear if it is a requirement or suggestion)",
+    "note": "License is disclaimer of liability, allows commercial use & transformation, & has attribution language (unclear if it is a requirement or suggestion)",
     "data": "http://dawa.aws.dk/adresser?format=csv",
     "coverage": {        
         "country": "dk"


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/31717/5363958/f0dd9bbe-7fad-11e4-9d4e-1a36107e0b62.png)

Originally discussed [here](https://github.com/openaddresses/openaddresses/issues/134), though it turns out the address data is best sourced from a different domain. Still an open license, though! 3.4m addresses. Big big thanks to [@guan](https://guan.dk/) for his assistance figuring this out and his all-around Danish thought leadership.

Worth noting that the source site also has postcode data available.
