### PR TITLE
Poland

### DIFF
--- a/sources/pl-dolnoslaskie.json
+++ b/sources/pl-dolnoslaskie.json
@@ -1,0 +1,21 @@
+{
+    "coverage": {
+        "state": "dolnośląskie",
+        "country": "pl"
+    },
+    "license": "Polish Law on Geodesy and Cartography of 17 May 1989 - see https://github.com/openaddresses/openaddresses/issues/187#issuecomment-63327973",
+    "compression": "zip",
+    "conform": {
+        "srs": "EPSG:2180",
+        "lon": "X",
+        "merge": ["ulc_nazwa", "mjs_nazwa"],
+        "street": "auto_street",
+        "number": "pad_numer_porzadkowy",
+        "lat": "Y",
+        "file": "punkty_adr_v2/dolnoslaskie.gml",
+        "type": "xml"
+    },
+    "data": "http://s3.amazonaws.com/data.openaddresses.io/cache/pl.zip",
+    "type": "http",
+    "note": "original source is ftp://91.223.135.109/prg/punkty_adr.zip but zipfile has unfixable character encoding issues"
+}

--- a/sources/pl-kujawsko-pomorskie.json
+++ b/sources/pl-kujawsko-pomorskie.json
@@ -1,0 +1,21 @@
+{
+    "coverage": {
+        "state": "kujawsko-pomorskie",
+        "country": "pl"
+    },
+    "license": "Polish Law on Geodesy and Cartography of 17 May 1989 - see https://github.com/openaddresses/openaddresses/issues/187#issuecomment-63327973",
+    "compression": "zip",
+    "conform": {
+        "srs": "EPSG:2180",
+        "lon": "X",
+        "merge": ["ulc_nazwa", "mjs_nazwa"],
+        "street": "auto_street",
+        "number": "pad_numer_porzadkowy",
+        "lat": "Y",
+        "file": "punkty_adr_v2/kujawsko-pomorskie.gml",
+        "type": "xml"
+    },
+    "data": "http://s3.amazonaws.com/data.openaddresses.io/cache/pl.zip",
+    "type": "http",
+    "note": "original source is ftp://91.223.135.109/prg/punkty_adr.zip but zipfile has unfixable character encoding issues"
+}

--- a/sources/pl-lodzkie.json
+++ b/sources/pl-lodzkie.json
@@ -1,0 +1,21 @@
+{
+    "coverage": {
+        "state": "łódzkie",
+        "country": "pl"
+    },
+    "license": "Polish Law on Geodesy and Cartography of 17 May 1989 - see https://github.com/openaddresses/openaddresses/issues/187#issuecomment-63327973",
+    "compression": "zip",
+    "conform": {
+        "srs": "EPSG:2180",
+        "lon": "X",
+        "merge": ["ulc_nazwa", "mjs_nazwa"],
+        "street": "auto_street",
+        "number": "pad_numer_porzadkowy",
+        "lat": "Y",
+        "file": "punkty_adr_v2/lodzkie.gml",
+        "type": "xml"
+    },
+    "data": "http://s3.amazonaws.com/data.openaddresses.io/cache/pl.zip",
+    "type": "http",
+    "note": "original source is ftp://91.223.135.109/prg/punkty_adr.zip but zipfile has unfixable character encoding issues"
+}

--- a/sources/pl-lubelskie.json
+++ b/sources/pl-lubelskie.json
@@ -1,0 +1,21 @@
+{
+    "coverage": {
+        "state": "lubelskie",
+        "country": "pl"
+    },
+    "license": "Polish Law on Geodesy and Cartography of 17 May 1989 - see https://github.com/openaddresses/openaddresses/issues/187#issuecomment-63327973",
+    "compression": "zip",
+    "conform": {
+        "srs": "EPSG:2180",
+        "lon": "X",
+        "merge": ["ulc_nazwa", "mjs_nazwa"],
+        "street": "auto_street",
+        "number": "pad_numer_porzadkowy",
+        "lat": "Y",
+        "file": "punkty_adr_v2/lubelskie.gml",
+        "type": "xml"
+    },
+    "data": "http://s3.amazonaws.com/data.openaddresses.io/cache/pl.zip",
+    "type": "http",
+    "note": "original source is ftp://91.223.135.109/prg/punkty_adr.zip but zipfile has unfixable character encoding issues"
+}

--- a/sources/pl-lubuskie.json
+++ b/sources/pl-lubuskie.json
@@ -1,0 +1,21 @@
+{
+    "coverage": {
+        "state": "lubuskie",
+        "country": "pl"
+    },
+    "license": "Polish Law on Geodesy and Cartography of 17 May 1989 - see https://github.com/openaddresses/openaddresses/issues/187#issuecomment-63327973",
+    "compression": "zip",
+    "conform": {
+        "srs": "EPSG:2180",
+        "lon": "X",
+        "merge": ["ulc_nazwa", "mjs_nazwa"],
+        "street": "auto_street",
+        "number": "pad_numer_porzadkowy",
+        "lat": "Y",
+        "file": "punkty_adr_v2/lubuskie.gml",
+        "type": "xml"
+    },
+    "data": "http://s3.amazonaws.com/data.openaddresses.io/cache/pl.zip",
+    "type": "http",
+    "note": "original source is ftp://91.223.135.109/prg/punkty_adr.zip but zipfile has unfixable character encoding issues"
+}

--- a/sources/pl-malopolski.json
+++ b/sources/pl-malopolski.json
@@ -1,0 +1,21 @@
+{
+    "coverage": {
+        "state": "małopolskie",
+        "country": "pl"
+    },
+    "license": "Polish Law on Geodesy and Cartography of 17 May 1989 - see https://github.com/openaddresses/openaddresses/issues/187#issuecomment-63327973",
+    "compression": "zip",
+    "conform": {
+        "srs": "EPSG:2180",
+        "lon": "X",
+        "merge": ["ulc_nazwa", "mjs_nazwa"],
+        "street": "auto_street",
+        "number": "pad_numer_porzadkowy",
+        "lat": "Y",
+        "file": "punkty_adr_v2/ma%EAopolskie.gml",
+        "type": "xml"
+    },
+    "data": "http://s3.amazonaws.com/data.openaddresses.io/cache/pl.zip",
+    "type": "http",
+    "note": "original source is ftp://91.223.135.109/prg/punkty_adr.zip but zipfile has unfixable character encoding issues"
+}

--- a/sources/pl-malopolski.json
+++ b/sources/pl-malopolski.json
@@ -12,7 +12,7 @@
         "street": "auto_street",
         "number": "pad_numer_porzadkowy",
         "lat": "Y",
-        "file": "punkty_adr_v2/ma%EAopolskie.gml",
+        "file": "punkty_adr_v2/malopolski.gml",
         "type": "xml"
     },
     "data": "http://s3.amazonaws.com/data.openaddresses.io/cache/pl.zip",

--- a/sources/pl-mazowieckie.json
+++ b/sources/pl-mazowieckie.json
@@ -1,0 +1,21 @@
+{
+    "coverage": {
+        "state": "mazowieckie",
+        "country": "pl"
+    },
+    "license": "Polish Law on Geodesy and Cartography of 17 May 1989 - see https://github.com/openaddresses/openaddresses/issues/187#issuecomment-63327973",
+    "compression": "zip",
+    "conform": {
+        "srs": "EPSG:2180",
+        "lon": "X",
+        "merge": ["ulc_nazwa", "mjs_nazwa"],
+        "street": "auto_street",
+        "number": "pad_numer_porzadkowy",
+        "lat": "Y",
+        "file": "punkty_adr_v2/mazowieckie.gml",
+        "type": "xml"
+    },
+    "data": "http://s3.amazonaws.com/data.openaddresses.io/cache/pl.zip",
+    "type": "http",
+    "note": "original source is ftp://91.223.135.109/prg/punkty_adr.zip but zipfile has unfixable character encoding issues"
+}

--- a/sources/pl-opolskie.json
+++ b/sources/pl-opolskie.json
@@ -1,0 +1,21 @@
+{
+    "coverage": {
+        "state": "opolskie",
+        "country": "pl"
+    },
+    "license": "Polish Law on Geodesy and Cartography of 17 May 1989 - see https://github.com/openaddresses/openaddresses/issues/187#issuecomment-63327973",
+    "compression": "zip",
+    "conform": {
+        "srs": "EPSG:2180",
+        "lon": "X",
+        "merge": ["ulc_nazwa", "mjs_nazwa"],
+        "street": "auto_street",
+        "number": "pad_numer_porzadkowy",
+        "lat": "Y",
+        "file": "punkty_adr_v2/opolskie.gml",
+        "type": "xml"
+    },
+    "data": "http://s3.amazonaws.com/data.openaddresses.io/cache/pl.zip",
+    "type": "http",
+    "note": "original source is ftp://91.223.135.109/prg/punkty_adr.zip but zipfile has unfixable character encoding issues"
+}

--- a/sources/pl-podkarpackie.json
+++ b/sources/pl-podkarpackie.json
@@ -1,0 +1,21 @@
+{
+    "coverage": {
+        "state": "podkarpackie",
+        "country": "pl"
+    },
+    "license": "Polish Law on Geodesy and Cartography of 17 May 1989 - see https://github.com/openaddresses/openaddresses/issues/187#issuecomment-63327973",
+    "compression": "zip",
+    "conform": {
+        "srs": "EPSG:2180",
+        "lon": "X",
+        "merge": ["ulc_nazwa", "mjs_nazwa"],
+        "street": "auto_street",
+        "number": "pad_numer_porzadkowy",
+        "lat": "Y",
+        "file": "punkty_adr_v2/podkarpackie.gml",
+        "type": "xml"
+    },
+    "data": "http://s3.amazonaws.com/data.openaddresses.io/cache/pl.zip",
+    "type": "http",
+    "note": "original source is ftp://91.223.135.109/prg/punkty_adr.zip but zipfile has unfixable character encoding issues"
+}

--- a/sources/pl-podlaskie.json
+++ b/sources/pl-podlaskie.json
@@ -1,0 +1,21 @@
+{
+    "coverage": {
+        "state": "podlaskie",
+        "country": "pl"
+    },
+    "license": "Polish Law on Geodesy and Cartography of 17 May 1989 - see https://github.com/openaddresses/openaddresses/issues/187#issuecomment-63327973",
+    "compression": "zip",
+    "conform": {
+        "srs": "EPSG:2180",
+        "lon": "X",
+        "merge": ["ulc_nazwa", "mjs_nazwa"],
+        "street": "auto_street",
+        "number": "pad_numer_porzadkowy",
+        "lat": "Y",
+        "file": "punkty_adr_v2/podlaskie.gml",
+        "type": "xml"
+    },
+    "data": "http://s3.amazonaws.com/data.openaddresses.io/cache/pl.zip",
+    "type": "http",
+    "note": "original source is ftp://91.223.135.109/prg/punkty_adr.zip but zipfile has unfixable character encoding issues"
+}

--- a/sources/pl-pomorskie.json
+++ b/sources/pl-pomorskie.json
@@ -1,0 +1,21 @@
+{
+    "coverage": {
+        "state": "pomorskie",
+        "country": "pl"
+    },
+    "license": "Polish Law on Geodesy and Cartography of 17 May 1989 - see https://github.com/openaddresses/openaddresses/issues/187#issuecomment-63327973",
+    "compression": "zip",
+    "conform": {
+        "srs": "EPSG:2180",
+        "lon": "X",
+        "merge": ["ulc_nazwa", "mjs_nazwa"],
+        "street": "auto_street",
+        "number": "pad_numer_porzadkowy",
+        "lat": "Y",
+        "file": "punkty_adr_v2/pomorskie.gml",
+        "type": "xml"
+    },
+    "data": "http://s3.amazonaws.com/data.openaddresses.io/cache/pl.zip",
+    "type": "http",
+    "note": "original source is ftp://91.223.135.109/prg/punkty_adr.zip but zipfile has unfixable character encoding issues"
+}

--- a/sources/pl-slaskie.json
+++ b/sources/pl-slaskie.json
@@ -1,0 +1,21 @@
+{
+    "coverage": {
+        "state": "śląskie",
+        "country": "pl"
+    },
+    "license": "Polish Law on Geodesy and Cartography of 17 May 1989 - see https://github.com/openaddresses/openaddresses/issues/187#issuecomment-63327973",
+    "compression": "zip",
+    "conform": {
+        "srs": "EPSG:2180",
+        "lon": "X",
+        "merge": ["ulc_nazwa", "mjs_nazwa"],
+        "street": "auto_street",
+        "number": "pad_numer_porzadkowy",
+        "lat": "Y",
+        "file": "punkty_adr_v2/slaskie.gml",
+        "type": "xml"
+    },
+    "data": "http://s3.amazonaws.com/data.openaddresses.io/cache/pl.zip",
+    "type": "http",
+    "note": "original source is ftp://91.223.135.109/prg/punkty_adr.zip but zipfile has unfixable character encoding issues"
+}

--- a/sources/pl-swietokrzyskie.json
+++ b/sources/pl-swietokrzyskie.json
@@ -1,0 +1,21 @@
+{
+    "coverage": {
+        "state": "świętokrzyskie",
+        "country": "pl"
+    },
+    "license": "Polish Law on Geodesy and Cartography of 17 May 1989 - see https://github.com/openaddresses/openaddresses/issues/187#issuecomment-63327973",
+    "compression": "zip",
+    "conform": {
+        "srs": "EPSG:2180",
+        "lon": "X",
+        "merge": ["ulc_nazwa", "mjs_nazwa"],
+        "street": "auto_street",
+        "number": "pad_numer_porzadkowy",
+        "lat": "Y",
+        "file": "punkty_adr_v2/swietokrzyskie.gml",
+        "type": "xml"
+    },
+    "data": "http://s3.amazonaws.com/data.openaddresses.io/cache/pl.zip",
+    "type": "http",
+    "note": "original source is ftp://91.223.135.109/prg/punkty_adr.zip but zipfile has unfixable character encoding issues"
+}

--- a/sources/pl-warminsko-mazurskie.json
+++ b/sources/pl-warminsko-mazurskie.json
@@ -1,0 +1,21 @@
+{
+    "coverage": {
+        "state": "warmińsko-mazurskie",
+        "country": "pl"
+    },
+    "license": "Polish Law on Geodesy and Cartography of 17 May 1989 - see https://github.com/openaddresses/openaddresses/issues/187#issuecomment-63327973",    
+    "compression": "zip",
+    "conform": {
+        "srs": "EPSG:2180",
+        "lon": "X",
+        "merge": ["ulc_nazwa", "mjs_nazwa"],
+        "street": "auto_street",
+        "number": "pad_numer_porzadkowy",
+        "lat": "Y",
+        "file": "punkty_adr_v2/warminsko-mazurskie.gml",
+        "type": "xml"
+    },
+    "data": "http://s3.amazonaws.com/data.openaddresses.io/cache/pl.zip",
+    "type": "http",
+    "note": "original source is ftp://91.223.135.109/prg/punkty_adr.zip but zipfile has unfixable character encoding issues"
+}

--- a/sources/pl-wielkopolskie.json
+++ b/sources/pl-wielkopolskie.json
@@ -1,0 +1,21 @@
+{
+    "coverage": {
+        "state": "wielkopolskie",
+        "country": "pl"
+    },
+    "license": "Polish Law on Geodesy and Cartography of 17 May 1989 - see https://github.com/openaddresses/openaddresses/issues/187#issuecomment-63327973",    
+    "compression": "zip",
+    "conform": {
+        "srs": "EPSG:2180",
+        "lon": "X",
+        "merge": ["ulc_nazwa", "mjs_nazwa"],
+        "street": "auto_street",
+        "number": "pad_numer_porzadkowy",
+        "lat": "Y",
+        "file": "punkty_adr_v2/wielkopolskie.gml",
+        "type": "xml"
+    },
+    "data": "http://s3.amazonaws.com/data.openaddresses.io/cache/pl.zip",
+    "type": "http",
+    "note": "original source is ftp://91.223.135.109/prg/punkty_adr.zip but zipfile has unfixable character encoding issues"
+}

--- a/sources/pl-zachodniopomorskie.json
+++ b/sources/pl-zachodniopomorskie.json
@@ -1,0 +1,21 @@
+{
+    "coverage": {
+        "state": "zachodniopomorskie",
+        "country": "pl"
+    },
+    "license": "Polish Law on Geodesy and Cartography of 17 May 1989 - see https://github.com/openaddresses/openaddresses/issues/187#issuecomment-63327973",
+    "compression": "zip",
+    "conform": {
+        "srs": "EPSG:2180",
+        "lon": "X",
+        "merge": ["ulc_nazwa", "mjs_nazwa"],
+        "street": "auto_street",
+        "number": "pad_numer_porzadkowy",
+        "lat": "Y",
+        "file": "punkty_adr_v2/zachodniopomorskie.gml",
+        "type": "xml"
+    },
+    "data": "http://s3.amazonaws.com/data.openaddresses.io/cache/pl.zip",
+    "type": "http",
+    "note": "original source is ftp://91.223.135.109/prg/punkty_adr.zip but zipfile has unfixable character encoding issues"
+}

--- a/test/sources.js
+++ b/test/sources.js
@@ -61,7 +61,7 @@ function checkSource(i){
                 t.ok(data.conform.number && typeof data.conform.number === 'string', "conform - number attribute required");
                 t.ok(data.conform.street && typeof data.conform.street === 'string', "conform - street attribute required");
                 t.ok(data.conform.type && typeof data.conform.type === 'string', "conform - type attribute required");
-                t.ok(['shapefile', 'shapefile-polygon', 'csv', 'geojson'].indexOf(data.conform.type) !== -1, "conform - type is supported");
+                t.ok(['shapefile', 'shapefile-polygon', 'csv', 'geojson', 'xml'].indexOf(data.conform.type) !== -1, "conform - type is supported");
 
                 //Optional Conform Fields
                 t.ok(data.conform.merge ? Array.isArray(data.conform.merge) : true, "conform - Merge is an array");


### PR DESCRIPTION
This PR adds addresses for Poland's 16 vovoideships. This is a slightly nonstandard import for a few reasons:

- It relies on [new `conform` functionality to support GML](https://github.com/openaddresses/openaddresses-conform/pull/36) (not so nonstandard for my PRs :sweat_smile: )
- The source zipfile has serious character encoding issues in its filenames--some layer of URL encoding on top of an unspecified character encoding, except with something else going on, too. It's bad enough that I ultimately decided it could not be fixed in an automated way. This is a known defect in the zip format. I wound up decompressing, researching, renaming and recompressing the files. I don't believe that their contents are affected, only the filenames.
- Many of the records do not have a street field specified (`ULC_NAZWA`) -- it's blank. This appears to be due to addressing for rural properties relying upon village names (`MJS_NAZWA`). For this reason I have merged the two fields. This is nonstandard for OpenAddresses, but I think it's an approach that will work correctly in many geocoding applications. If not, we'll need to talk about changes to the output data scheme.