### PR TITLE
Corrected data type for us-ca-placer_county.json

### DIFF
--- a/sources/us-ca-placer_county.json
+++ b/sources/us-ca-placer_county.json
@@ -8,6 +8,6 @@
     "data": "ftp://ftp1.placer.ca.gov/cdra/gis/parcel_point_ByAddress.zip",
     "attribution": "County of Placer",
     "license": "http://www.placer.ca.gov/departments/communitydevelopment/gis/gis_download",
-    "type": "http",
+    "type": "ftp",
     "compression": "zip"
 }


### PR DESCRIPTION
Shouldn't this be FTP? If so, sorry for my earlier mistake.
