### PR TITLE
Added us-ca-lake_county.json

### DIFF
--- a/sources/us-ca-lake_county.json
+++ b/sources/us-ca-lake_county.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "US Census": {"geoid": "06033", "name": "Lake County", "state": "California"},
+        "country": "us",
+        "state": "ca",
+        "county": "Lake"
+    },
+    "attribution": "Lake County",
+    "data": "https://github.com/datadesk/us-ca-lake_county-situs_parcels-shp/blob/master/situs_parcels.zip?raw=true",
+    "website": "http://gis.co.lake.ca.us/",
+    "type": "http",
+    "compression": "zip",
+    "note": "Parcel polygons that include situs addresses in the metadata. Provided in response to a public records request in December 2014 and uploaded to GitHub for public hosting. A situs address dbf was provided separately from the parcels shapefile, which were then joined together in QGIS using an 'APN' according to instructions provided a county official."
+}


### PR DESCRIPTION
Situs DBF and parcel SHP provided separately via a public records request and then joined together in QGIS using an "APN" identifier according to instructions provided by a county official.
