### PR TITLE
Revises with updated SHP path and conform object

### DIFF
--- a/sources/us-wa-chelan.json
+++ b/sources/us-wa-chelan.json
@@ -12,8 +12,18 @@
     "license": "Public Domain",
     "type": "ftp",
     "compression": "zip",
-    "note": "point shapefile CCSiteAddressPoints.shp, address columns: FULLADDR, MUNICIPALI",
+    "note": "point shapefile ChelanCoAddresses.shp, address columns: FULLADDR, FULLNAME, MUNICIPALI",
     "year": "2014",
-    "data": "ftp://63.135.55.71/gis/Transportation/CCSiteAddressPoints.zip",
-    "website": "http://www.co.chelan.wa.us/assessor/mapping/default.htm"
+    "data": "ftp://63.135.55.71/gis/Transportation/ChelanCoAddresses.zip",
+    "website": "http://www.co.chelan.wa.us/assessor/mapping/default.htm",
+    "conform": {
+        "type": "shapefile",
+        "lon": "x",
+        "lat": "y",
+        "number": "addrnum",
+        "street": "fullname",
+        "city": "municipali",
+        "district": "county",
+        "addrtype": "address_su"
+    }
 }


### PR DESCRIPTION
This commit revises the SHP dataset name with that found on the previously listed FTP site, and adds a `conform` object. The commit appears to be passing tests from [Travis CI](https://travis-ci.org/mattmakesmaps/openaddresses).

The updated `us-wa-chelan.json` file has been tested using @sbma44's `openaddress-conform` [branch](https://github.com/sbma44/openaddresses-conform/tree/xml) and appeared to produce a correctly formatted `out.csv` file.
