### PR TITLE
Adds conform for `us-wa-douglas.json`

### DIFF
--- a/sources/us-wa-douglas.json
+++ b/sources/us-wa-douglas.json
@@ -15,5 +15,15 @@
     "note": "point shapefile dc_address_pts.shp, address columns: FULL_ADDY, CITY, ZIP",
     "year": "2014",
     "data": "ftp://ftp.douglascountywa.net/Downloads/GIS_Base/Addressing/dc_address_pts.zip",
-    "website": "http://www.douglascountywa.net/departments/tls/gis/"
+    "website": "http://www.douglascountywa.net/departments/tls/gis/",
+    "conform": {
+        "type": "shapefile",
+        "lon": "x",
+        "lat": "y",
+        "number": "BLDG_NUM",
+        "street": "STREET",
+        "city": "CITY",
+        "postcode": "ZIP",
+        "addrtype": "Category"
+    }
 }


### PR DESCRIPTION
The updated source appears to pass [Travis-CI tests](https://travis-ci.org/mattmakesmaps/openaddresses/builds) and generates an expected looking `out.csv` file when running `openaddresses-conform` locally.
