### PR TITLE
fix netherlands

### DIFF
--- a/sources/nl.json
+++ b/sources/nl.json
@@ -3,14 +3,14 @@
         "ISO 3166": {"alpha2": "NL", "country": "Netherlands"},
         "country": "nl"
     },
-    "data": "http://s3.amazonaws.com/openaddresses/manual/nl-addresses.zip",
+    "data": "http://data.openaddresses.io/cache/nl.zip",
     "type": "http",
     "compression": "zip",
     "conform": {
-        "lon": "x",
-        "lat": "y",
-        "number": "num",
-        "street": "name",
-        "type": "shapefile"
+        "lon": "lon",
+        "lat": "lat",
+        "number": "number",
+        "street": "street",
+        "type": "csv"
     }
 }


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/31717/5562487/104d1c18-8df0-11e4-9c66-ad1991d336d7.png)

14.8m addresses. Existing CSV only has lat/lon, no street names--not sure why. Reran & update @ingalls' code, updated source to point at the new cached zipfile. 

There are a few countries like this, that require processing pre-conform (Poland and Spain come to mind). I might just make a new directory in the main openaddresses repo for these sorts of scripts, if that sounds alright. 
