### PR TITLE
Added us-ca-lassen_county.json

### DIFF
--- a/sources/us-ca-lassen_county.json
+++ b/sources/us-ca-lassen_county.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "US Census": {"geoid": "06035", "name": "Lassen County", "state": "California"},
+        "country": "us",
+        "state": "ca",
+        "county": "Lassen"
+    },
+    "attribution": "Lassen County",
+    "data": "https://github.com/datadesk/us-ca-lassen_county-situs_parcels-shp/blob/master/situs_parcels.zip?raw=true",
+    "website": "http://lassencounty.org/govt/dept/assessor/default.asp",
+    "type": "http",
+    "compression": "zip",
+    "note": "Parcel polygons that include situs addresses in the metadata. Provided in response to a public records request in December 2014 and uploaded to GitHub for public hosting. A situs address dbf was provided separately from the parcels shapefile, which were then joined together in QGIS using an 'APN' according to instructions provided a county official."
+}


### PR DESCRIPTION
Parcel polygons that include situs addresses in the metadata. Provided in response to a public records request in December 2014 and uploaded to GitHub for public hosting. A situs address dbf was provided separately from the parcels shapefile, which were then joined together in QGIS using an 'APN' according to instructions provided a county official.