### PR TITLE
conform object added for VT e911 addresses - should now be parse-able

### DIFF
--- a/sources/us-vt.json
+++ b/sources/us-vt.json
@@ -1,12 +1,29 @@
 {
     "coverage": {
+        "US Census": {
+            "geoid": "50",
+            "name": "Vermont"
+        },
         "country": "us",
         "state": "vt"
     },
     "website": "http://vcgi.vermont.gov/warehouse/theme_index",
-    "data": "http://maps.vcgi.org/gisdata/vcgi/packaged_zips/EmergencyE911_GDBE911.zip",
+    "data": "http://maps.vcgi.org/gisdata/vcgi/packaged_zips/EmergencyE911_ESITE.zip",
     "license": "http://vcgi.vermont.gov/sites/vcgi/files/warehouse/VCGI_Warranty_Copyright_Notice_2013.pdf",
+    "attribution": "VT Enhanced 911 Board, VCGI",
+    "year": "2013",
     "type": "http",
     "compression": "zip",
-    "note": "All E911 data layers in File Geodatabase format (v10.2.2); Feature Types: point, line, poly"
+    "note": "E911 Site locations including buildings, hydrants, public phones",
+    "conform": {
+        "type": "shapefile",
+        "lon": "GPSX",
+        "lat": "GPSY",
+        "number": "HOUSENUMBE",
+        "street": "PRIMARYNAM",
+        "city": "TOWNNAME",
+        "postcode": "ZIP",
+        "addrtype": "SITETYPE",
+        "accuracy": 1
+    }
 }

--- a/sources/us-vt.json
+++ b/sources/us-vt.json
@@ -23,7 +23,6 @@
         "street": "PRIMARYNAM",
         "city": "TOWNNAME",
         "postcode": "ZIP",
-        "addrtype": "SITETYPE",
-        "accuracy": 1
+        "addrtype": "SITETYPE"
     }
 }


### PR DESCRIPTION
These should be GTG. @iandees - is it okay for `accuracy` to be numeric? I couldn't find a good example.

Rooftops of VT, inbound:

![2015-01-02_2203](https://cloud.githubusercontent.com/assets/735463/5601452/14889654-92cd-11e4-8ec8-b3444659cac3.png)
