### PR TITLE
fixing busted custom projection for Brussels data

### DIFF
--- a/sources/be-wa-brussels-fr.json
+++ b/sources/be-wa-brussels-fr.json
@@ -1,6 +1,6 @@
 {
     "type": "http",
-    "data": "https://s.irisnet.be/v1/AUTH_b4e6bcc3-db61-442e-8b59-e0ce9142d182/Region/UrbAdm_SHP.zip",
+    "data": "http://data.openaddresses.io/cache/be-wa-brussels-4326.zip",
     "website": "http://bric.brussels/",
     "compression": "zip",
     "coverage": {
@@ -10,13 +10,10 @@
     },    
     "license": "http://bric.brussels/en/our-solutions/urbis-solutions/Licence%20Open%20data%20Fr%20v4.pdf",
     "conform": {
-        "file": "UrbAdm_SHP/shp/UrbAdm_AdPt.shp",
         "number": "ADRN",        
         "lat": "Y",
         "lon": "X",
         "type": "shapefile",
-        "street": "PW_NAME_FR",
-        "srs": "EPSG:31300"
-
+        "street": "PW_NAME_FR"
     }
 }

--- a/sources/be-wa-brussels-nl.json
+++ b/sources/be-wa-brussels-nl.json
@@ -1,6 +1,6 @@
 {
     "type": "http",
-    "data": "https://s.irisnet.be/v1/AUTH_b4e6bcc3-db61-442e-8b59-e0ce9142d182/Region/UrbAdm_SHP.zip",
+    "data": "http://data.openaddresses.io/cache/be-wa-brussels-4326.zip",
     "website": "http://bric.brussels/",
     "compression": "zip",
     "coverage": {
@@ -10,13 +10,11 @@
     },    
     "license": "http://bric.brussels/en/our-solutions/urbis-solutions/Licence%20Open%20data%20Fr%20v4.pdf",
     "conform": {
-        "file": "UrbAdm_SHP/shp/UrbAdm_AdPt.shp",
         "number": "ADRN",        
         "lat": "Y",
         "lon": "X",
         "type": "shapefile",
-        "street": "PW_NAME_DU",
-        "srs": "EPSG:31300"
+        "street": "PW_NAME_DU"
 
     }
 }


### PR DESCRIPTION
per https://github.com/openaddresses/openaddresses.io/issues/39, fixing a bad SRS in the source data. Easiest to repair locally and cache -- the alternative is supporting WKT custom projections in `conform` which doesn't sound like a ton of fun.