### PR TITLE
Added us-ca-orange_county.json

### DIFF
--- a/sources/us-ca-orange_county.json
+++ b/sources/us-ca-orange_county.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "US Census": {"geoid": "06059", "name": "Orange County", "state": "California"},
+        "country": "us",
+        "state": "ca",
+        "county": "Orange"
+    },
+    "attribution": "Orange County",
+    "data": "https://github.com/datadesk/us-ca-orange_county-situs_parcels-shp/blob/master/situs_parcels.zip?raw=true",
+    "website": "http://ocpublicworks.com/survey/services/gis",
+    "type": "http",
+    "compression": "zip",
+    "note": "Parcel polygons that include situs addresses in the metadata. Provided in response to a public records request in January 2015 and uploaded to GitHub for public hosting. A situs address dbf was provided separately from the parcels shapefile, which were then joined together in QGIS using an intermediary file's 'APN' value according to instructions provided by a county official."
+}


### PR DESCRIPTION
Parcel polygons that include situs addresses in the metadata. Provided in response to a public records request in January 2015 and uploaded to GitHub for public hosting. A situs address dbf was provided separately from the parcels shapefile, which were then joined together in QGIS using an intermediary file's 'APN' value according to instructions provided by a county official.