### PR TITLE
Fixed conform fields for San Juan County WA.

### DIFF
--- a/sources/us-wa-san_juan.json
+++ b/sources/us-wa-san_juan.json
@@ -12,11 +12,12 @@
     "data": "http://sjcgis.org/arcgis/rest/services/Polaris/Buildings/MapServer/0",
     "type": "ESRI",
     "conform": {
-        "split": "address",
+        "split": "FULLADRR",
         "lon": "x",
         "lat": "y",
         "number": "auto_number",
         "street": "auto_street",
+        "addrtype": "BLDGTYPE",
         "type": "geojson"
     }
 }


### PR DESCRIPTION
Fixes conform split and addrtype fields as mentioned by @migurski in #894.