### PR TITLE
Pipe test output through tap-min

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Manage, test and download a global register of addresses.",
   "main": "download.js",
   "scripts": {
-    "test": "tape test/*.js"
+    "test": "tape test/*.js | tap-min"
   },
   "license": "BSD",
   "engines": {
@@ -13,7 +13,8 @@
   },
   "devDependencies": {
     "glob": "4.2.x",
-    "tape": "3.0.x"
+    "tape": "3.0.x",
+    "tap": "^1.0.0"
   },
   "dependencies": {
     "request": "^2.51.0"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "glob": "4.2.x",
     "tape": "3.0.x",
-    "tap": "^1.0.0"
+    "tap-min": "^1.0.0"
   },
   "dependencies": {
     "request": "^2.51.0"


### PR DESCRIPTION
Agree with @migurski that it's often hard to find where Travis fails.  Proposing this change as suggested by @ingalls which should close #845 