### PR TITLE
Adding State of Maryland

### DIFF
--- a/sources/us-md.json
+++ b/sources/us-md.json
@@ -2,7 +2,7 @@
     "coverage": {
         "US Census": {
             "geoid": "24",
-            "name": "State of Maryland"
+            "state": "Maryland"
         },
         "country": "us",
         "state": "md"

--- a/sources/us-md.json
+++ b/sources/us-md.json
@@ -1,0 +1,26 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "24",
+            "name": "State of Maryland"
+        },
+        "country": "us",
+        "state": "md"
+    },
+    "note": "Does not cover the entire state. Referred to link from https://www.arcgis.com/home/item.html?id=20878dd2c20949a8a14a5a282ab98807",
+    "data": "http://geodata.md.gov/imap/rest/directories/arcgisoutput/PLAN_ParcelPoints_MDP.zip",
+    "website": "http://geodata.md.gov/imap/rest/services/PlanningCadastre/MD_PropertyData/MapServer/exts/MDiMapDataDownload/customLayers/0",
+    "type": "http",
+    "compression": "zip",
+    "conform": {
+        "type": "shapefile",
+        "merge": ["STRTNAM", "STRTTYP"],
+        "lon": "x",
+        "lat": "y",
+        "number": "STRTNUM",
+        "street": "auto_street",
+        "city": "CITY",
+        "postcode": "ZIPCODE",
+        "accuracy": 2
+    }
+}


### PR DESCRIPTION
Just added Montgomery County, MD in #902 but then realized there's a state layer already referenced in #726 with coverage of the same area.  However, this shapefile source is a different data url as #726 was one the troublesome Esri portal sources.  Does not cover entire State so some other individual county sources may be added.

If we're not including duplicates introduced by overlapping state and county sources then we'll need to figure out a way to rectify that.