### PR TITLE
conform objects and fixing honolulu

### DIFF
--- a/sources/us-al-montgomery.json
+++ b/sources/us-al-montgomery.json
@@ -12,5 +12,13 @@
     "data": "http://gis.montgomeryal.gov/ArcGIS/rest/services/Parcel/MapServer/11",
     "type": "ESRI",
     "website": "http://montgomeryal.gov",
-    "attribution": "City of Montgomery"
+    "attribution": "City of Montgomery",
+    "conform": {
+    	"type": "csv",
+    	"lat": "y",
+    	"lon": "x",
+    	"split": "PROP_ADDRESS_1",
+    	"street": "auto_street",
+    	"number": "auto_number"
+    }
 }

--- a/sources/us-ca-lake_county.json
+++ b/sources/us-ca-lake_county.json
@@ -10,5 +10,12 @@
     "website": "http://gis.co.lake.ca.us/",
     "type": "http",
     "compression": "zip",
-    "note": "Parcel polygons that include situs addresses in the metadata. Provided in response to a public records request in December 2014 and uploaded to GitHub for public hosting. A situs address dbf was provided separately from the parcels shapefile, which were then joined together in QGIS using an 'APN' according to instructions provided a county official."
+    "note": "Parcel polygons that include situs addresses in the metadata. Provided in response to a public records request in December 2014 and uploaded to GitHub for public hosting. A situs address dbf was provided separately from the parcels shapefile, which were then joined together in QGIS using an 'APN' according to instructions provided a county official.",
+    "conform": {
+        "lat": "y",
+        "lon": "x",
+        "type": "shapefile-polygon",
+        "number": "SITUS_SITU",
+        "street": "SITUS_SI_1"
+    }
 }

--- a/sources/us-hi-honolulu.json
+++ b/sources/us-hi-honolulu.json
@@ -1,16 +1,27 @@
 {
     "coverage": {
-      "country": "us",
-      "state": "hi",
-      "county": "honolulu",
-      "city": "honolulu"
+        "US Census": {
+            "geoid": "15003",
+            "name": "City and County of Honolulu",
+            "state": "Hawaii"
+        },
+        "country": "us",
+        "state": "hi",
+        "county": "honolulu"
     },
     "attribution": "City of Honolulu",
-    "data": "https://www.dropbox.com/s/94da2ic6a5c2j50/us-hi-honolulu.zip?dl=0",
-    "website": "ftp://gisftp.hicentral.com/Layers/Cadastral/",
-    "license": "",
+    "data": "ftp://gisftp.hicentral.com/Layers/Cadastral/taxparcel_siteaddress.zip",
+    "website": "http://gis.hicentral.com/data.html",
     "year": "2012",
-    "type": "http",
+    "type": "ftp",
     "compression": "zip",
-    "note": "Includes full parcel shapefile of the island of Oahu. SRS is EPSG: 2784 "
+    "note": "Includes full parcel shapefile of the island of Oahu. SRS is EPSG: 2784",
+    "conform": {
+        "type": "shapefile-polygon",
+        "lat": "y",
+        "lon": "x",
+        "number": "housenumbr",
+        "street": "streename",
+        "city": "city"
+    }
 }

--- a/sources/us-hi-honolulu.json
+++ b/sources/us-hi-honolulu.json
@@ -7,7 +7,8 @@
         },
         "country": "us",
         "state": "hi",
-        "county": "honolulu"
+        "county": "honolulu",
+        "city": "honolulu"
     },
     "attribution": "City of Honolulu",
     "data": "ftp://gisftp.hicentral.com/Layers/Cadastral/taxparcel_siteaddress.zip",


### PR DESCRIPTION
Adding three conform objects.  Also fixing honolulu, which contained a link to an empty shapefile in a dropbox account.