### PR TITLE
Update "conform" documentation for lat/lon.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,8 +109,8 @@ Field names are case insensitive, but contributers are encouraged to try to matc
 ---------- | --- | ----
 `number`   | Yes | The name of the number field. This will either be the name of the field or `auto_number` if the split tool was used.
 `street`   | Yes | The name of the street field. This will either be the name of the field or `auto_street` if the split or merge tools were used.
-`lon`      |     | The longitude column. This is required for CSV sources and should be left empty for other types.
-`lat`      |     | The latitude field. This is required for CSV sources and should be left empty for other types.
+`lon`      |     | The longitude column. This is required for CSV sources and should be omitted for other types.
+`lat`      |     | The latitude field. This is required for CSV sources and should be omitted for other types.
 `accuracy` |     | The accuracy of the data source. See table below. Should never be 0, defaults to 5. If this is not set, address duplicates of higher accuracy will replace the addresses from this source when they are conflated.
 `city`     |     | Name of the City or Municipality in which the address falls
 `postcode` |     | Postcode or zip-code field in which the address falls

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,10 +107,10 @@ Field names are case insensitive, but contributers are encouraged to try to matc
 
  Tag | Required? | Note
 ---------- | --- | ----
-`lon`      | Yes | The longitude field. Due to the way the conversion scripts work this is currently always going to be `x` unless using a `csv`.
-`lat`      | Yes | The latitude field. Due to the way the conversion script work this is currently always going to be `y` unless using a `csv`.
 `number`   | Yes | The name of the number field. This will either be the name of the field or `auto_number` if the split tool was used.
 `street`   | Yes | The name of the street field. This will either be the name of the field or `auto_street` if the split or merge tools were used.
+`lon`      |     | The longitude column. This is required for CSV sources and should be left empty for other types.
+`lat`      |     | The latitude field. This is required for CSV sources and should be left empty for other types.
 `accuracy` |     | The accuracy of the data source. See table below. Should never be 0, defaults to 5. If this is not set, address duplicates of higher accuracy will replace the addresses from this source when they are conflated.
 `city`     |     | Name of the City or Municipality in which the address falls
 `postcode` |     | Postcode or zip-code field in which the address falls


### PR DESCRIPTION
For every type we understand but CSV, the lat/lon is implicitly named
by being in the geometry field, so the contributer doesn't need to
specify it. The Python code will ignore these settings. It's possible
the Node code relies on them being set; if so, the Node code should
assume the names "X" and "Y" to match the rest of how it works.

For details on this change, see https://github.com/openaddresses/machine/issues/73