### PR TITLE
update us-pa-allegheny.json

### DIFF
--- a/sources/us-pa-allegheny.json
+++ b/sources/us-pa-allegheny.json
@@ -9,9 +9,9 @@
         "state": "pa",
         "county": "Allegheny"
     },
-    "data": "ftp://www.pasda.psu.edu/pub/pasda/alleghenycounty/AlleghenyCounty_AddressPoints201403.zip",
+    "data": "ftp://www.pasda.psu.edu/pub/pasda/alleghenycounty/AlleghenyCounty_AddressPoints201503.zip",
     "license": "",
-    "year": "2014-03",
+    "year": "2015-03",
     "type": "ftp",
     "compression": "zip",
     "conform": {
@@ -24,6 +24,6 @@
         "number": "ADDR_NUM",
         "street": "auto_street",
         "type": "shapefile",
-        "postcode": "zip_code"
+        "postcode": "ZIP_CODE"
     }
 }


### PR DESCRIPTION
updated the ftp reference to the latest zip file and ensured zip code attribute is uppercase.

the actual .shp is in a subdirectory, so this may need a file tag. I was also tempted to remove the license tag since the contributor info says to elide empty values, but decided to leave that be for now.