### PR TITLE
Update lat lon tests

### DIFF
--- a/test/sources.js
+++ b/test/sources.js
@@ -68,13 +68,15 @@ function checkSource(i){
                     t.ok(conformOptions.indexOf(conformKey) !== -1, "conform - " + conformKey + " is supported");
                 });
 
-                //Mandator Conform Fields
-                t.ok(data.conform.lon && typeof data.conform.lon === 'string', "conform - lon attribute required");
-                t.ok(data.conform.lat && typeof data.conform.lat === 'string', "conform - lat attribute required");
+                //Mandatory Conform Fields
                 t.ok(data.conform.number && typeof data.conform.number === 'string', "conform - number attribute required");
                 t.ok(data.conform.street && typeof data.conform.street === 'string', "conform - street attribute required");
                 t.ok(data.conform.type && typeof data.conform.type === 'string', "conform - type attribute required");
                 t.ok(['shapefile', 'shapefile-polygon', 'csv', 'geojson', 'xml'].indexOf(data.conform.type) !== -1, "conform - type is supported");
+                if (data.conform.type === 'csv') {
+                	t.ok(data.conform.lon && typeof data.conform.lon === 'string', "conform - lon attribute required for type csv");
+                    t.ok(data.conform.lat && typeof data.conform.lat === 'string', "conform - lat attribute required for type csv");
+                }
 
                 //Optional Conform Fields
                 t.ok(data.conform.merge ? Array.isArray(data.conform.merge) : true, "conform - Merge is an array");

--- a/test/sources.js
+++ b/test/sources.js
@@ -74,7 +74,7 @@ function checkSource(i){
                 t.ok(data.conform.type && typeof data.conform.type === 'string', "conform - type attribute required");
                 t.ok(['shapefile', 'shapefile-polygon', 'csv', 'geojson', 'xml'].indexOf(data.conform.type) !== -1, "conform - type is supported");
                 if (data.conform.type === 'csv') {
-                	t.ok(data.conform.lon && typeof data.conform.lon === 'string', "conform - lon attribute required for type csv");
+                    t.ok(data.conform.lon && typeof data.conform.lon === 'string', "conform - lon attribute required for type csv");
                     t.ok(data.conform.lat && typeof data.conform.lat === 'string', "conform - lat attribute required for type csv");
                 }
 


### PR DESCRIPTION
SHA: bf39fa3bd07db54e3b11887fc239e1cbf5e2e229 removed lat/lon as required fields for all conform objects in the contributing doc.  This updates the tests so lat/lon only tested for type csv