### PR TITLE
Update Indiana to use a single HTTP download

### DIFF
--- a/sources/us-in.json
+++ b/sources/us-in.json
@@ -8,12 +8,11 @@
         "state": "in"
     },
     "website": "http://maps.indiana.edu/metadata/Infrastructure/Streets_Address_Points_IDHS.html",
-    "data": "http://maps.indiana.edu/arcgis/rest/services/Infrastructure/Streets_Address_Points_IDHS/MapServer/0",
-    "type": "ESRI",
+    "data": "http://maps.indiana.edu/download/Infrastructure/Streets_Address_Points_IDHS.zip",
+    "type": "http",
+    "compression": "zip",
     "conform": {
-    	"type": "csv",
-    	"lon": "x",
-    	"lat": "y",
+    	"type": "shapefile",
     	"merge": ["PREFIX", "ADD_NAME", "ADD_TYPE", "SUFFIX"],
     	"number": "NUMBER",
     	"street": "auto_street",


### PR DESCRIPTION
The ESRI version seemed to be failing, so I found a geodatabase download of the same data.