### PR TITLE
Add protocol prefix to data field

### DIFF
--- a/sources/us-va-williamsburg.json
+++ b/sources/us-va-williamsburg.json
@@ -4,7 +4,7 @@
         "state": "va",
         "city": "Williamsburg"
     },
-    "data": "www.williamsburgva.gov/Modules/ShowDocument.aspx?documentid=3604",
+    "data": "http://www.williamsburgva.gov/Modules/ShowDocument.aspx?documentid=3604",
     "type": "http",
     "compression": "zip",
     "website": "http://www.williamsburgva.gov/index.aspx?page=36",


### PR DESCRIPTION
Lacking the `http://` prefix, Python [thinks this is a local file](http://data.openaddresses.io/runs/1428275390.559/us-va-williamsburg.txt).