### PR TITLE
Add conform object for Chisago County MN

### DIFF
--- a/sources/us-mn-chisago.json
+++ b/sources/us-mn-chisago.json
@@ -9,8 +9,19 @@
         "state": "mn",
         "county": "Chisago"
     },
+    "conform": {
+        "type": "csv",
+        "split": "ADDRESS",
+        "number": "auto_number",
+        "street": "auto_street",
+        "city":"CITY",
+        "postcode":"ZIP",
+        "lon": "LONGITUDE",
+        "lat": "LATITUDE"
+    },
     "license": "Indemnification",
     "type": "ESRI",
     "data": "http://gis.chisagocounty.us/arcgis/rest/services/GISData/MapServer/1",
-    "website": "http://gis.chisagocounty.us/Link/jsfe/index.aspx"
+    "website": "http://gis.chisagocounty.us/Link/jsfe/index.aspx",
+    "note":"Unsure if the Esri-style SRS of EPSG:103721 will work as an EPSG. Shp download has no .prj file. Omitting since Lat-Lng fields are included."
 }


### PR DESCRIPTION
They also have an x and y field, but with the weird SRS I thought using the lat/longs would work better. Looks like they have several hundred addresses with no lat/long, but that's out of over 21K addresses. And without a clear EPSG for Esri's 103721 srs, not sure what the lesser evil is.