### PR TITLE
Update us-mn-chisago.json

### DIFF
--- a/sources/us-mn-chisago.json
+++ b/sources/us-mn-chisago.json
@@ -16,12 +16,12 @@
         "street": "auto_street",
         "city":"CITY",
         "postcode":"ZIP",
-        "lon": "LONGITUDE",
-        "lat": "LATITUDE"
+        "lon": "x",
+        "lat": "y"
     },
     "license": "Indemnification",
     "type": "ESRI",
     "data": "http://gis.chisagocounty.us/arcgis/rest/services/GISData/MapServer/1",
     "website": "http://gis.chisagocounty.us/Link/jsfe/index.aspx",
-    "note":"Unsure if the Esri-style SRS of EPSG:103721 will work as an EPSG. Shp download has no .prj file. Omitting since Lat-Lng fields are included."
+    "note":"Shp download has no .prj file, but available at http://gis.chisagocounty.us/ZipFiles/addresses.zip"
 }


### PR DESCRIPTION
Not sure why this is failing in logs. I can get a successful query here: https://gis.chisagocounty.us/arcgis/rest/services/GISData/MapServer/1/query?where=&text=&objectIds=&time=&geometry=-92.900648%2C45.383080%2C-92.878418%2C45.398450&geometryType=esriGeometryEnvelope&inSR=4326+&spatialRel=esriSpatialRelIntersects&relationParam=&outFields=*&returnGeometry=true&maxAllowableOffset=&geometryPrecision=&outSR=4326+&returnIdsOnly=false&returnCountOnly=false&orderByFields=&groupByFieldsForStatistics=&outStatistics=&returnZ=false&returnM=false&gdbVersion=&returnDistinctValues=false&f=pjson