### PR TITLE
Update San Diego County coverage and details

### DIFF
--- a/sources/us-ca-san_diego_county.json
+++ b/sources/us-ca-san_diego_county.json
@@ -1,12 +1,19 @@
 {
     "coverage": {
+        "US Census": {
+          "geoid": "06073",
+          "name": "San Diego County",
+          "state": "California"
+        },
         "country": "us",
         "state": "ca",
-        "city": "San Diego"
+        "county": "San Diego"
     },
-    "attribution": "City of San Diego",
+    "attribution": "San Diego Geographic Information Source - JPA",
     "data": "http://rdw.sandag.org/file_store/Address/Address_APN.zip",
-    "license": "http://rdw.sandag.org/",
+    "license": "http://www.sangis.org/Legal_Notice.htm",
+    "notes": "Metadata available at http://rdw.sandag.org/file_store%5CAddress/Address_APN.pdf",
+    "website": "http://rdw.sandag.org/",
     "year": "",
     "type": "http",
     "compression": "zip",

--- a/sources/us-ca-san_diego_county.json
+++ b/sources/us-ca-san_diego_county.json
@@ -12,7 +12,7 @@
     "attribution": "San Diego Geographic Information Source - JPA",
     "data": "http://rdw.sandag.org/file_store/Address/Address_APN.zip",
     "license": "http://www.sangis.org/Legal_Notice.htm",
-    "notes": "Metadata available at http://rdw.sandag.org/file_store%5CAddress/Address_APN.pdf",
+    "note": "Metadata available at http://rdw.sandag.org/file_store%5CAddress/Address_APN.pdf",
     "website": "http://rdw.sandag.org/",
     "year": "",
     "type": "http",


### PR DESCRIPTION
This PR improves the San Diego data source:

- Corrected source to say that the data covers the _county_ of San Diego (rather just than the city)
(per the [metadata file](http://rdw.sandag.org/file_store%5CAddress/Address_APN.pdf), `ADDRJUR` specifies the jurisdiction within the county [city or unincorporated area name] )
- Renamed file to denote county coverage
- Added US Census coverage data (eg, geoid)
- Corrected attribution
- Added link to specific license/terms
- Added link to metadata in the notes field

cc @palewire since he did a little San Diego work in #743 that had changes related to this but which were not merged
