### PR TITLE
add coshocton county, ohio

### DIFF
--- a/sources/us-oh-coshocton.json
+++ b/sources/us-oh-coshocton.json
@@ -1,0 +1,19 @@
+{
+    "coverage": {
+        "US Census": {"geoid": "39031", "name": "Coshocton County", "state": "Ohio"},
+        "country": "us",
+        "state": "oh",
+        "county": "Coshocton"
+    },
+    "conform": {
+        "number": "ADRSNUM",
+        "street": "ROADNME",
+        "postcode": "ZIP",
+        "type": "shapefile",
+        "accuracy": 5
+    },
+    "data": "http://www.coshoctoncounty.net/files/1413456603Address.zip",
+    "website": "http://www.coshoctoncounty.net/agency/taxmap/GISfiles.php",
+    "type": "http",
+    "compression": "zip"
+}

--- a/sources/us-oh-coshocton.json
+++ b/sources/us-oh-coshocton.json
@@ -6,8 +6,13 @@
         "county": "Coshocton"
     },
     "conform": {
+        "merge": [
+            "ROADNME",
+            "S_ROADNME"
+        ],
         "number": "ADRSNUM",
-        "street": "ROADNME",
+        "street": "auto_street",
+
         "postcode": "ZIP",
         "type": "shapefile",
         "accuracy": 5


### PR DESCRIPTION
Before merging, I have a few questions and notes: 

* There are several cases where a particular address is in both a Township and a City. See [this wikipedia entry for more information](https://en.wikipedia.org/wiki/Civil_township#Midwestern.2C_central.2C_and_western_states). 
Some addresses are in a township (column COMMUNITY) and a city (CITY) ; some are only in a township; In one instance, they are in the same CITY and COMMUNITY (West Lafayette)

* Street names and suffixes are in separate columns. In my 2nd commit, I added the street suffixes, based on the syntax in a couple existing entries - [us-tx-brazos](https://github.com/openaddresses/openaddresses/blob/4ecffa3872b925a3a35951ee318caa334402b9aa/sources/us-tx-brazos.json) and us-oh-fairfield). However, this syntax is missing a subproperty(?) named 'separator' described (https://github.com/openaddresses/openaddresses/blob/master/CONTRIBUTING.md#advanced-merge) (Related #378). Which syntax should I use?

     Related to that, there's two additional columns to further describe the address number (one column listing the Apt/Bldg/Lot and another column listing Lot number). I didn't add them yet, waiting to hear your advice. 
 
* There's a fair amount of rows that have null addresses; The only columns that have values in these rows are AVSHPID (a unique identifier for each row) and COMMUNITY. 