### PR TITLE
BE-Flanders: Corrected EPSG string and character encoding

### DIFF
--- a/sources/be-flanders.json
+++ b/sources/be-flanders.json
@@ -12,7 +12,7 @@
         "file": "Shapefile/CrabAdr.shp",
         "number": "HUISNR",
         "type": "shapefile",
-        "encoding": "utf-8",
+        "encoding": "iso-8859-1",
         "street": "STRAATNM",
         "lon": "X",
         "lat": "Y",

--- a/sources/be-flanders.json
+++ b/sources/be-flanders.json
@@ -12,11 +12,11 @@
         "file": "Shapefile/CrabAdr.shp",
         "number": "HUISNR",
         "type": "shapefile",
-        "encoding": "iso-8859-1",
+        "encoding": "utf-8",
         "street": "STRAATNM",
         "lon": "X",
         "lat": "Y",
-        "srs": "EPSG:31300",
+        "srs": "EPSG:31370",
         "headers": 1,
         "skiplines": 1
     }

--- a/sources/be-flanders.json
+++ b/sources/be-flanders.json
@@ -16,7 +16,7 @@
         "street": "STRAATNM",
         "lon": "X",
         "lat": "Y",
-        "srs": "EPSG:31370",
+        "srs": "EPSG:3812",
         "headers": 1,
         "skiplines": 1
     }

--- a/sources/be-flanders.json
+++ b/sources/be-flanders.json
@@ -16,7 +16,7 @@
         "street": "STRAATNM",
         "lon": "X",
         "lat": "Y",
-        "srs": "EPSG:3812",
+        "srs": "EPSG:31370",
         "headers": 1,
         "skiplines": 1
     }


### PR DESCRIPTION
According to the metadata file, this should be correct