### PR TITLE
added mappings for region, district and city props

### DIFF
--- a/sources/ee.json
+++ b/sources/ee.json
@@ -17,15 +17,15 @@
         "lat": "VIITEPUNKT_Y",
         "region": "TASE1_NIMETUS_LIIGIGA",
         "district": "TASE2_NIMETUS_LIIGIGA",
-        "city": "_merged_A2A3A4",
-        "number": "_merged_A6A7",
+        "city": "_merged_a2a3a4",
+        "number": "_merged_a6a7",
         "street": "TASE5_NIMETUS_LIIGIGA",
         "advanced_merge": {
-            "_merged_A3A4" : {
+            "_merged_a2a3a4" : {
                 "separator": ",",
                 "fields": ["TASE2_NIMETUS_LIIGIGA", "TASE3_NIMETUS_LIIGIGA", "TASE4_NIMETUS_LIIGIGA"]
             },
-            "_merged_A6A7" : {
+            "_merged_a6a7" : {
                 "separator": " ",
                 "fields": ["TASE6_NIMETUS_LIIGIGA", "TASE7_NIMETUS_LIIGIGA"]
             }

--- a/sources/ee.json
+++ b/sources/ee.json
@@ -15,7 +15,20 @@
         "srs": "EPSG:3301",
         "lon": "VIITEPUNKT_X",
         "lat": "VIITEPUNKT_Y",
-        "number": "TASE7_NIMETUS_LIIGIGA",
-        "street": "TASE5_NIMETUS_LIIGIGA"
+        "region": "TASE1_NIMETUS_LIIGIGA",
+        "district": "TASE2_NIMETUS_LIIGIGA",
+        "city": "_merged_A2A3A4",
+        "number": "_merged_A6A7",
+        "street": "TASE5_NIMETUS_LIIGIGA",
+        "advanced_merge": {
+            "_merged_A3A4" : {
+                "separator": ",",
+                "fields": ["TASE2_NIMETUS_LIIGIGA", "TASE3_NIMETUS_LIIGIGA", "TASE4_NIMETUS_LIIGIGA"]
+            },
+            "_merged_A6A7" : {
+                "separator": " ",
+                "fields": ["TASE6_NIMETUS_LIIGIGA", "TASE7_NIMETUS_LIIGIGA"]
+            }
+        }
     }
 }


### PR DESCRIPTION
As discussed in [1077](https://github.com/openaddresses/openaddresses/issues/1077) added field mappings for "region", "district", "city" conform properties. There will be issues regarding "city" for rows that do not have all specified address levels (mainly A4, to some extent A3 aswell) present, meaning there will be city values with trailing ", " present.

Currently did not map A8 level ("appartments"/"flats"/"house parts") to any conform properties.