### PR TITLE
Add geometry to chattanooga.json to complete coverage.

### DIFF
--- a/sources/us/tn/chattanooga.json
+++ b/sources/us/tn/chattanooga.json
@@ -1,5 +1,12 @@
 {
     "coverage": {
+        "geometry": {
+            "type": "Point",
+            "coordinates": [
+                -85.267222,
+                35.045556
+            ]
+        },
         "country": "us",
         "state": "tn",
         "city": "Chattanooga"


### PR DESCRIPTION
Should complete coverage info for chattanooga.json.