### PR TITLE
Add support for new ID tag

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,6 +134,7 @@ Attribute tags are functions or field names for mapping the source data into a g
 `postcode` |     | Postcode or zip-code field in which the address falls
 `district` |     | District/County/Sub-Region in which the address falls
 `region`   |     | State/Region/Province in which the address falls
+`id`       |     | Unique identifier, [such as a parcel APN](https://en.wikipedia.org/wiki/Assessor%27s_parcel_number).
 `addrtype` |     | Type of address. `industrial`, `residential`, etc.
 `notes`    |     | Legal description of address or notes about the property.
 

--- a/sources/us/ca/amador.json
+++ b/sources/us/ca/amador.json
@@ -16,6 +16,7 @@
     "year": 2012,
     "compression": "zip",
     "conform": {
+        "id": "APN",
         "number": "ADDRNUM",
         "street": [
             "ADDRPREFIX",

--- a/sources/us/ca/berkeley.json
+++ b/sources/us/ca/berkeley.json
@@ -16,6 +16,7 @@
     "compression": "zip",
     "note": "Metadata at http://www.ci.berkeley.ca.us/uploadedFiles/IT/GIS/Parcels.shp(1).xml",
     "conform": {
+        "id": "APN",
         "number": "StreetNum",
         "street": [
             "StreetName",

--- a/sources/us/ca/el_dorado_county.json
+++ b/sources/us/ca/el_dorado_county.json
@@ -16,6 +16,7 @@
     "compression": "zip",
     "note": "Parcel polygons that include situs addresses in the metadata. Provided in response to a public records request in December 2014 and uploaded to GitHub for public hosting.",
     "conform": {
+        "id": "PRCL_ID",
         "type": "shapefile-polygon",
         "city": "CITY",
         "number": "SITUSNUMBR",

--- a/sources/us/ca/lake_county.json
+++ b/sources/us/ca/lake_county.json
@@ -16,6 +16,7 @@
     "compression": "zip",
     "note": "Parcel polygons that include situs addresses in the metadata. Provided in response to a public records request in December 2014 and uploaded to GitHub for public hosting. A situs address dbf was provided separately from the parcels shapefile, which were then joined together in QGIS using an 'APN' according to instructions provided a county official.",
     "conform": {
+        "id": "PARCEL",
         "type": "shapefile-polygon",
         "number": "SITUS_SITU",
         "street": "SITUS_SI_1"

--- a/sources/us/ca/orange.json
+++ b/sources/us/ca/orange.json
@@ -10,6 +10,7 @@
         "county": "Orange"
     },
     "conform": {
+        "id": "ParcelAttr",
         "type": "shapefile-polygon",
         "split": "ParcelAt_2",
         "number": "auto_number",

--- a/sources/us/ca/sacramento_county.json
+++ b/sources/us/ca/sacramento_county.json
@@ -15,6 +15,7 @@
     "type": "http",
     "compression": "zip",
     "conform": {
+        "id": "APN",
         "number": "STREET_NBR",
         "street": "STREET_NAM",
         "type": "shapefile-polygon",

--- a/sources/us/ca/san_bernardino_county.json
+++ b/sources/us/ca/san_bernardino_county.json
@@ -10,6 +10,7 @@
         "county": "San Bernardino"
     },
     "conform": {
+        "id": "APN",
         "type": "shapefile-polygon",
         "postcode": "ZIP",
         "city": "CITY",

--- a/sources/us/ca/san_joaquin_county.json
+++ b/sources/us/ca/san_joaquin_county.json
@@ -10,6 +10,7 @@
         "county": "San Joaquin"
     },
     "conform": {
+        "id": "APN_CHR",
         "type": "shapefile-polygon",
         "number": "situs_NO",
         "street": [

--- a/sources/us/ca/santa_barbara_county.json
+++ b/sources/us/ca/santa_barbara_county.json
@@ -15,6 +15,7 @@
     "type": "http",
     "compression": "zip",
     "conform": {
+        "id": "APN",
         "type": "shapefile-polygon",
         "number": "SNum",
         "street": [

--- a/sources/us/ca/yolo_county.json
+++ b/sources/us/ca/yolo_county.json
@@ -18,6 +18,7 @@
     "year": 2015,
     "note": "SITUS/Address + City + ZIP , parcel polygon",
     "conform": {
+        "id": "APN",
         "type": "shapefile-polygon",
         "split": "SITUS",
         "number": "auto_number",

--- a/test/sources.js
+++ b/test/sources.js
@@ -121,15 +121,15 @@ function checkSource(i){
                 
                 //Optional Conform Fields
                 t.ok(data.conform.id ? typeof data.conform.id === 'string' : true, "conform - id should be a string");
-                t.ok(data.conform.addrtype ? typeof data.conform.addrtype === 'string' : true, "conform - addrtype is a string");
-                t.ok(data.conform.accuracy ? typeof data.conform.accuracy === 'number' : true, "conform - accuracy is a number");
+                t.ok(data.conform.addrtype ? typeof data.conform.addrtype === 'string' : true, "conform - addrtype should be a string");
+                t.ok(data.conform.accuracy ? typeof data.conform.accuracy === 'number' : true, "conform - accuracy should be a number");
                 t.ok(data.conform.accuracy ? data.conform.accuracy !== 0 : true, "conform - accuracy is not 0");
-                t.ok(data.conform.csvsplit ? typeof data.conform.csvsplit === 'string' : true, "conform - csvsplit is a string");
-                t.ok(data.conform.split ? typeof data.conform.split === 'string' : true, "conform - split is a string");
-                t.ok(data.conform.srs ? typeof data.conform.srs === 'string' : true, "conform - srs is a string");
-                t.ok(data.conform.file ? typeof data.conform.file === 'string' : true, "conform - file is a string");
-                t.ok(data.conform.encoding ? typeof data.conform.encoding === 'string' : true, "conform - encoding is a string");
-                t.ok(data.conform.addrtype ? typeof data.conform.addrtype === 'string' : true, "conform - addrtype is a string");
+                t.ok(data.conform.csvsplit ? typeof data.conform.csvsplit === 'string' : true, "conform - csvsplit should be a string");
+                t.ok(data.conform.split ? typeof data.conform.split === 'string' : true, "conform - split should be a string");
+                t.ok(data.conform.srs ? typeof data.conform.srs === 'string' : true, "conform - srs should be a string");
+                t.ok(data.conform.file ? typeof data.conform.file === 'string' : true, "conform - file should be a string");
+                t.ok(data.conform.encoding ? typeof data.conform.encoding === 'string' : true, "conform - encoding should be a string");
+                t.ok(data.conform.addrtype ? typeof data.conform.addrtype === 'string' : true, "conform - addrtype should be a string");
             }
 
             //Optional General Fields

--- a/test/sources.js
+++ b/test/sources.js
@@ -72,9 +72,14 @@ function checkSource(i){
 
             if (data.conform) {
                 //Ensure people don't make up new values
-                var conformOptions = ['type', 'csvsplit', 'advanced_merge', 'split', 'srs', 'file', 'encoding', 'headers', 'skiplines', 'lon', 'lat', 'number', 'street', 'city', 'postcode', 'district', 'region', 'addrtype', 'notes', 'accuracy'];
+                var conformOptions = [
+                    'type', 'csvsplit', 'advanced_merge', 'split', 'srs',
+                    'file', 'encoding', 'headers', 'skiplines', 'lon', 'lat',
+                    'number', 'street', 'city', 'postcode', 'district',
+                    'region', 'addrtype', 'notes', 'accuracy', 'id'
+                    ];
                 Object.keys(data.conform).forEach(function (conformKey) {
-                    t.ok(conformOptions.indexOf(conformKey) !== -1, "conform - " + conformKey + " is supported");
+                    t.ok(conformOptions.indexOf(conformKey) !== -1, 'conform - "' + conformKey + '" is not a recognized attribute tag');
                 });
 
                 //Mandatory Conform Fields
@@ -115,6 +120,7 @@ function checkSource(i){
                 });
                 
                 //Optional Conform Fields
+                t.ok(data.conform.id ? typeof data.conform.id === 'string' : true, "conform - id should be a string");
                 t.ok(data.conform.addrtype ? typeof data.conform.addrtype === 'string' : true, "conform - addrtype is a string");
                 t.ok(data.conform.accuracy ? typeof data.conform.accuracy === 'number' : true, "conform - accuracy is a number");
                 t.ok(data.conform.accuracy ? data.conform.accuracy !== 0 : true, "conform - accuracy is not 0");


### PR DESCRIPTION
Machine has [new support for ID attribute tags](https://github.com/openaddresses/machine/pull/214), part of the 2.2.0 release.

* [x] Add parcel IDs to selected sources.
* [x] Add ID to [attribute tag documentation](https://github.com/openaddresses/openaddresses/blob/master/CONTRIBUTING.md#attribute-tags).
* [x] Add ID to tests.
* [x] Merge after Machine 2.2.0 is deployed.