### PR TITLE
Email website tests

### DIFF
--- a/test/sources.js
+++ b/test/sources.js
@@ -140,7 +140,7 @@ function checkSource(i){
             }
             if (data.website) {
                 t.ok(typeof data.website === 'string',"website must be a string");
-                t.ok(validator.isEmail(data.email),"website must be a valid URL");
+                t.ok(validator.isURL(data.website),"website must be a valid URL");
             }
             if (data.license) {
                 if (typeof data.license === 'string') {

--- a/test/sources.js
+++ b/test/sources.js
@@ -134,8 +134,14 @@ function checkSource(i){
             }
 
             //Optional General Fields
-            t.ok(data.email ? typeof data.email === 'string' : true, "email must be a string");
-            t.ok(data.website ? typeof data.website === 'string' : true, "website must be a string");
+            if (data.email) {
+                t.ok(typeof data.email === 'string',"email must be a string");
+                t.ok(validator.isEmail(data.email),"email must be a valid email address");
+            }
+            if (data.website) {
+                t.ok(typeof data.website === 'string',"website must be a string");
+                t.ok(validator.isEmail(data.email),"website must be a valid URL");
+            }
             if (data.license) {
                 if (typeof data.license === 'string') {
                     t.pass('license supplied as a string [Deprecated]');


### PR DESCRIPTION
Tests `"email"` and `"website"`values to ensure that they are valid email addresses and URLs, respectively.  Uses the default options.

https://github.com/chriso/validator.js/blob/master/README.md