### PR TITLE
Corrections for Utah Addresses

### DIFF
--- a/sources/us/ut/statewide.json
+++ b/sources/us/ut/statewide.json
@@ -13,11 +13,19 @@
     "conform": {
         "type": "shapefile",
         "file": "AddressPoints/AddressPoints.shp",
-        "number": "AddNum",
+        "number": [
+            "AddNum",
+            "AddNumSuff"],
         "street": [
+            "PrefixDir",
             "StreetName",
-            "StreetType"
+            "StreetType",
+            "SuffixDir"
         ],
-        "postcode": "zipcode"
+        "city": "City",
+        "postcode": "ZipCode",
+        "region": "State",
+        "id": "ParcelID",
+
     }
 }

--- a/sources/us/ut/statewide.json
+++ b/sources/us/ut/statewide.json
@@ -25,7 +25,7 @@
         "city": "City",
         "postcode": "ZipCode",
         "region": "State",
-        "id": "ParcelID",
+        "id": "ParcelID"
 
     }
 }


### PR DESCRIPTION
Utah Addresses have several core fields missing, rendering grid addresses in Salt Lake City unsearchable. This means we were missing out on ~ 475,000 addresses for the state.

This cleanup adds:
* Address number suffix (123 **1/2** fake street)
* Prefix Street directionals (123 **S** fake street)
* Suffix Directionals (123 S Fake Street **E**)

Bonus points:
* City
* State
* Parcel ID's


Huge shoutout to @stephenkhess for actually finding this issue, who along with @orangejulius helped write the importer with me.