### PR TITLE
Fix Washtenaw County, MI, USA

### DIFF
--- a/sources/us/mi/washtenaw.json
+++ b/sources/us/mi/washtenaw.json
@@ -14,6 +14,7 @@
         "number": "PROP_STREET_NUM",
         "street": "PROP_STREET",
         "city": "PROP_CITY",
+        "region": "PROP_STATE",
         "postcode": "PROP_ZIP"
     },
     "data": "http://webmaps.ewashtenaw.org/arcgisshared/rest/services/ParcelPublish/MapServer/1",

--- a/sources/us/mi/washtenaw.json
+++ b/sources/us/mi/washtenaw.json
@@ -16,7 +16,7 @@
         "city": "PROP_CITY",
         "postcode": "PROP_ZIP"
     },
-    "data": "http://webmaps.ewashtenaw.org/arcgisshared/rest/services/ParcelPublish/MapServer/layers",
+    "data": "http://webmaps.ewashtenaw.org/arcgisshared/rest/services/ParcelPublish/MapServer/1",
     "type": "ESRI",
     "website": "http://www.ewashtenaw.org/government/departments/gis/MapWashtenaw_Main.htm"
 }

--- a/sources/us/mi/washtenaw.json
+++ b/sources/us/mi/washtenaw.json
@@ -12,7 +12,12 @@
     "conform": {
         "type": "geojson",
         "number": "PROP_STREET_NUM",
-        "street": "PROP_STREET",
+        "street": {
+            "function": "regexp",
+            "field": "PROP_STREET",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "city": "PROP_CITY",
         "region": "PROP_STATE",
         "postcode": "PROP_ZIP"

--- a/sources/us/mi/washtenaw.json
+++ b/sources/us/mi/washtenaw.json
@@ -11,14 +11,12 @@
     },
     "conform": {
         "type": "geojson",
-        "number": "PRPANUMB",
-        "street": "PRPASTRT",
-        "city": "PRPACITY",
-        "postcode": "PRPAZIP",
-        "region": "PRPASTATE",
-        "notes": "LLEGALDESC"
+        "number": "PROP_STREET_NUM",
+        "street": "PROP_STREET",
+        "city": "PROP_CITY",
+        "postcode": "PROP_ZIP"
     },
-    "data": "http://webmaps.ewashtenaw.org/arcgisshared/rest/services/A2Base/MapServer/22",
+    "data": "http://webmaps.ewashtenaw.org/arcgisshared/rest/services/ParcelPublish/MapServer/layers",
     "type": "ESRI",
     "website": "http://www.ewashtenaw.org/government/departments/gis/MapWashtenaw_Main.htm"
 }


### PR DESCRIPTION
The data URL pointed to an ESRI endpoint that only contained a list of
buildings on a floodplain. This new URL contains all parcels in the
county.

Note: for some reason I wasn't able to test this URL in QGis but it
looks to contain the right data. I'm still a QGis/ESRI noob so I'm
simply going to rely on the automated tests in Github to see if I got it
right. In other words, other commits may be coming.