### PR TITLE
Add street directionals to street name

### DIFF
--- a/sources/us/pa/allegheny.json
+++ b/sources/us/pa/allegheny.json
@@ -17,6 +17,7 @@
     "conform": {
         "number": "ADDR_NUM",
         "street": [
+            "ST_PREFIX",
             "ST_NAME",
             "ST_TYPE"
         ],


### PR DESCRIPTION
Allegheny county data has street directional in the ST_PREFIX column that should be added to the street name.