### PR TITLE
added pre- and post-directionals for .zip-based Ohio counties

### DIFF
--- a/sources/us/oh/adams.json
+++ b/sources/us/oh/adams.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
+            "ST_PREFIX",
             "ST_NAME",
-            "ST_TYPE"
+            "ST_TYPE",
+            "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/allen.json
+++ b/sources/us/oh/allen.json
@@ -13,11 +13,13 @@
     "type": "http",
     "compression": "zip",
     "conform": {
-        "number": "HOUSENUM",
-        "street": [
-            "ST_NAME",
-            "ST_TYPE"
-        ],
+      "number": "HOUSENUM",
+      "street": [
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
+      ],
         "type": "shapefile",
         "postcode": "zipcode"
     }

--- a/sources/us/oh/ashland.json
+++ b/sources/us/oh/ashland.json
@@ -13,12 +13,14 @@
     "type": "http",
     "compression": "zip",
     "conform": {
-        "number": "HOUSENUM",
-        "street": [
-            "ST_NAME",
-            "ST_TYPE"
-        ],
-        "type": "shapefile",
-        "postcode": "zipcode"
+      "number": "HOUSENUM",
+      "street": [
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
+      ],
+      "type": "shapefile",
+      "postcode": "zipcode"
     }
 }

--- a/sources/us/oh/ashtabula.json
+++ b/sources/us/oh/ashtabula.json
@@ -13,12 +13,14 @@
     "type": "http",
     "compression": "zip",
     "conform": {
-        "number": "HOUSENUM",
-        "street": [
-            "ST_NAME",
-            "ST_TYPE"
-        ],
-        "type": "shapefile",
-        "postcode": "zipcode"
+      "number": "HOUSENUM",
+      "street": [
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
+      ],
+      "type": "shapefile",
+      "postcode": "zipcode"
     }
 }

--- a/sources/us/oh/athens.json
+++ b/sources/us/oh/athens.json
@@ -13,12 +13,14 @@
     "type": "http",
     "compression": "zip",
     "conform": {
-        "number": "HOUSENUM",
-        "street": [
-            "ST_NAME",
-            "ST_TYPE"
-        ],
-        "type": "shapefile",
-        "postcode": "zipcode"
+      "number": "HOUSENUM",
+      "street": [
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
+      ],
+      "type": "shapefile",
+      "postcode": "zipcode"
     }
 }

--- a/sources/us/oh/auglaize.json
+++ b/sources/us/oh/auglaize.json
@@ -15,9 +15,12 @@
     "conform": {
         "number": "ADDR_NUM",
         "street": [
+            "PRE_DIR",
             "STR_NAME",
-            "STR_TYPE"
+            "STR_TYPE",
+            "SUF_DIR"
         ],
+        "postcode": "zip",
         "type": "shapefile"
     }
 }

--- a/sources/us/oh/brown.json
+++ b/sources/us/oh/brown.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
+            "ST_PREFIX",
             "ST_NAME",
-            "ST_TYPE"
+            "ST_TYPE",
+            "ST_SUFFIX",
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/brown.json
+++ b/sources/us/oh/brown.json
@@ -18,7 +18,7 @@
             "ST_PREFIX",
             "ST_NAME",
             "ST_TYPE",
-            "ST_SUFFIX",
+            "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/butler.json
+++ b/sources/us/oh/butler.json
@@ -13,10 +13,17 @@
     "type": "http",
     "compression": "zip",
     "conform": {
-        "split": "LSN",
-        "number": "auto_number",
-        "street": "auto_street",
-        "type": "shapefile",
-        "postcode": "zipcode"
+      "number": {
+          "function": "regexp",
+          "field": "LSN",
+          "pattern": "^([0-9]+)"
+      },
+      "street": {
+          "function": "regexp",
+          "field": "LSN",
+          "pattern": "^(?:[0-9]+ )(.*)",
+          "replace": "$1"
+      },
+      "postcode": "zipcode"
     }
 }

--- a/sources/us/oh/butler.json
+++ b/sources/us/oh/butler.json
@@ -24,6 +24,7 @@
           "pattern": "^(?:[0-9]+ )(.*)",
           "replace": "$1"
       },
+      "type": "shapefile",
       "postcode": "zipcode"
     }
 }

--- a/sources/us/oh/carroll.json
+++ b/sources/us/oh/carroll.json
@@ -20,6 +20,7 @@
           "STR_TYPE",
           "SUF_DIR"
       ],
+      "type": "shapefile",
       "postcode": "zip"
     }
 }

--- a/sources/us/oh/carroll.json
+++ b/sources/us/oh/carroll.json
@@ -13,10 +13,13 @@
     "type": "http",
     "compression": "zip",
     "conform": {
-        "split": "LSN",
-        "number": "auto_number",
-        "street": "auto_street",
-        "type": "shapefile",
-        "postcode": "zip"
+      "number": "ADDR_NUM",
+      "street": [
+          "PRE_DIR",
+          "STR_NAME",
+          "STR_TYPE",
+          "SUF_DIR"
+      ],
+      "postcode": "zip"
     }
 }

--- a/sources/us/oh/clark.json
+++ b/sources/us/oh/clark.json
@@ -13,10 +13,14 @@
     "type": "http",
     "compression": "zip",
     "conform": {
-        "split": "LSN",
-        "number": "auto_number",
-        "street": "auto_street",
-        "type": "shapefile",
-        "postcode": "zipcode"
+      "number": "HOUSENUM",
+      "street": [
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
+      ],
+      "type": "shapefile",
+      "postcode": "zipcode"
     }
 }

--- a/sources/us/oh/clinton.json
+++ b/sources/us/oh/clinton.json
@@ -13,10 +13,14 @@
     "type": "http",
     "compression": "zip",
     "conform": {
-        "split": "LSN",
-        "number": "auto_number",
-        "street": "auto_street",
-        "type": "shapefile",
-        "postcode": "zipcode"
+      "number": "HOUSENUM",
+      "street": [
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
+      ],
+      "type": "shapefile",
+      "postcode": "zipcode"
     }
 }

--- a/sources/us/oh/clinton.json
+++ b/sources/us/oh/clinton.json
@@ -21,6 +21,7 @@
           "ST_SUFFIX"
       ],
       "type": "shapefile",
+      "file": "CLI_ADDS.shp",
       "postcode": "zipcode"
     }
 }

--- a/sources/us/oh/columbiana.json
+++ b/sources/us/oh/columbiana.json
@@ -13,10 +13,14 @@
     "type": "http",
     "compression": "zip",
     "conform": {
-        "split": "LSN",
-        "number": "auto_number",
-        "street": "auto_street",
-        "type": "shapefile",
-        "postcode": "zipcode"
+      "number": "HOUSENUM",
+      "street": [
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
+      ],
+      "type": "shapefile",
+      "postcode": "zipcode"
     }
 }

--- a/sources/us/oh/coshocton.json
+++ b/sources/us/oh/coshocton.json
@@ -12,6 +12,7 @@
     "conform": {
         "number": "ADRSNUM",
         "street": [
+            "P_ROADNME",
             "ROADNME",
             "S_ROADNME"
         ],

--- a/sources/us/oh/crawford.json
+++ b/sources/us/oh/crawford.json
@@ -13,10 +13,14 @@
     "type": "http",
     "compression": "zip",
     "conform": {
-        "split": "LSN",
-        "number": "auto_number",
-        "street": "auto_street",
-        "type": "shapefile",
-        "postcode": "zipcode"
+      "number": "HOUSENUM",
+      "street": [
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
+      ],
+      "type": "shapefile",
+      "postcode": "zipcode"
     }
 }

--- a/sources/us/oh/cuyahoga.json
+++ b/sources/us/oh/cuyahoga.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "ADDR_NUM",
         "street": [
+            "PRE_DIR",
             "STR_NAME",
-            "STR_TYPE"
+            "STR_TYPE",
+            "SUF_DIR"
         ],
         "type": "shapefile",
         "postcode": "zip"

--- a/sources/us/oh/darke.json
+++ b/sources/us/oh/darke.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/defiance.json
+++ b/sources/us/oh/defiance.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/delaware.json
+++ b/sources/us/oh/delaware.json
@@ -14,7 +14,13 @@
     "compression": "zip",
     "conform": {
         "number": "ADDR_NUM",
-        "street": "BIGNAME",
+        "street": [
+            "PRE_DIR",
+            "STR_NAME",
+            "STR_TYPE",
+            "SUF_DIR"
+        ],
+        "postcode": "zip",
         "type": "shapefile"
     }
 }

--- a/sources/us/oh/erie.json
+++ b/sources/us/oh/erie.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/fairfield.json
+++ b/sources/us/oh/fairfield.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
+            "PREFIX",
             "NAME",
-            "TYPE"
+            "TYPE",
+            "SUFFIX"
         ],
         "type": "shapefile"
     }

--- a/sources/us/oh/fayette.json
+++ b/sources/us/oh/fayette.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/franklin.json
+++ b/sources/us/oh/franklin.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "ADDR_NUM",
         "street": [
+            "PRE_DIR",
             "STR_NAME",
-            "STR_TYPE"
+            "STR_TYPE",
+            "SUF_DIR"
         ],
         "type": "shapefile",
         "postcode": "zip"

--- a/sources/us/oh/fulton.json
+++ b/sources/us/oh/fulton.json
@@ -15,6 +15,7 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
+            "ST_PREFIX",
             "ST_NAME",
             "ST_TYPE"
         ],

--- a/sources/us/oh/gallia.json
+++ b/sources/us/oh/gallia.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/greene.json
+++ b/sources/us/oh/greene.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/guernsey.json
+++ b/sources/us/oh/guernsey.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/hancock.json
+++ b/sources/us/oh/hancock.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/hardin.json
+++ b/sources/us/oh/hardin.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/harrison.json
+++ b/sources/us/oh/harrison.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "ADDR_NUM",
         "street": [
+            "PRE_DIR",
             "STR_NAME",
-            "STR_TYPE"
+            "STR_TYPE",
+            "SUF_DIR"
         ],
         "type": "shapefile",
         "postcode": "zip"

--- a/sources/us/oh/henry.json
+++ b/sources/us/oh/henry.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "ADDR_NUM",
         "street": [
+            "PRE_DIR",
             "STR_NAME",
-            "STR_TYPE"
+            "STR_TYPE",
+            "SUF_DIR"
         ],
         "type": "shapefile",
         "postcode": "zip"

--- a/sources/us/oh/highland.json
+++ b/sources/us/oh/highland.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "ADDR_NUM",
         "street": [
+            "PRE_DIR",
             "STR_NAME",
-            "STR_TYPE"
+            "STR_TYPE",
+            "SUF_DIR"
         ],
         "type": "shapefile",
         "postcode": "zip"

--- a/sources/us/oh/hocking.json
+++ b/sources/us/oh/hocking.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/holmes.json
+++ b/sources/us/oh/holmes.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/huron.json
+++ b/sources/us/oh/huron.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/jackson.json
+++ b/sources/us/oh/jackson.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/jefferson.json
+++ b/sources/us/oh/jefferson.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/knox.json
+++ b/sources/us/oh/knox.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/lake.json
+++ b/sources/us/oh/lake.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/lawrence.json
+++ b/sources/us/oh/lawrence.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "ADDR_NUM",
         "street": [
+            "PRE_DIR",
             "STR_NAME",
-            "STR_TYPE"
+            "STR_TYPE",
+            "SUF_DIR"
         ],
         "type": "shapefile",
         "postcode": "zip"

--- a/sources/us/oh/licking.json
+++ b/sources/us/oh/licking.json
@@ -13,10 +13,14 @@
     "type": "http",
     "compression": "zip",
     "conform": {
-        "split": "LSN",
-        "number": "auto_number",
-        "street": "auto_street",
-        "type": "shapefile",
-        "postcode": "zip"
+      "number": "ADDR_NUM",
+      "street": [
+          "PRE_DIR",
+          "STR_NAME",
+          "STR_TYPE",
+          "SUF_DIR"
+      ],
+      "type": "shapefile",
+      "postcode": "zip"
     }
 }

--- a/sources/us/oh/logan.json
+++ b/sources/us/oh/logan.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/lucas.json
+++ b/sources/us/oh/lucas.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/madison.json
+++ b/sources/us/oh/madison.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/mahoning.json
+++ b/sources/us/oh/mahoning.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "ADDR_NUM",
         "street": [
+            "PRE_DIR",
             "STR_NAME",
-            "STR_TYPE"
+            "STR_TYPE",
+            "SUF_DIR"
         ],
         "type": "shapefile",
         "postcode": "zip"

--- a/sources/us/oh/marion.json
+++ b/sources/us/oh/marion.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/meigs.json
+++ b/sources/us/oh/meigs.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/mercer.json
+++ b/sources/us/oh/mercer.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/miami.json
+++ b/sources/us/oh/miami.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/monroe.json
+++ b/sources/us/oh/monroe.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/morgan.json
+++ b/sources/us/oh/morgan.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/morrow.json
+++ b/sources/us/oh/morrow.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/muskingum.json
+++ b/sources/us/oh/muskingum.json
@@ -13,9 +13,14 @@
     "type": "http",
     "compression": "zip",
     "conform": {
-        "split": "LSN",
-        "number": "auto_number",
-        "street": "auto_street",
-        "type": "shapefile"
+      "number": "HOUSENUM",
+      "street": [
+        "ST_PREFIX",
+        "ST_NAME",
+        "ST_TYPE",
+        "ST_SUFFIX"
+      ],
+      "postcode": "zipcode",
+      "type": "shapefile"
     }
 }

--- a/sources/us/oh/noble.json
+++ b/sources/us/oh/noble.json
@@ -13,10 +13,14 @@
     "type": "http",
     "compression": "zip",
     "conform": {
-        "split": "LSN",
-        "number": "auto_number",
-        "street": "auto_street",
-        "type": "shapefile",
-        "postcode": "zipcode"
+      "number": "HOUSENUM",
+      "street": [
+        "ST_PREFIX",
+        "ST_NAME",
+        "ST_TYPE",
+        "ST_SUFFIX"
+      ],
+      "type": "shapefile",
+      "postcode": "zipcode"
     }
 }

--- a/sources/us/oh/ottawa.json
+++ b/sources/us/oh/ottawa.json
@@ -13,12 +13,14 @@
     "type": "http",
     "compression": "zip",
     "conform": {
-        "number": "HOUSENUM",
-        "street": [
-            "ST_NAME",
-            "ST_TYPE"
-        ],
-        "type": "shapefile",
-        "postcode": "zipcode"
+      "number": "HOUSENUM",
+      "street": [
+        "ST_PREFIX",
+        "ST_NAME",
+        "ST_TYPE",
+        "ST_SUFFIX"
+      ],
+      "type": "shapefile",
+      "postcode": "zipcode"
     }
 }

--- a/sources/us/oh/paulding.json
+++ b/sources/us/oh/paulding.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/perry.json
+++ b/sources/us/oh/perry.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/pickaway.json
+++ b/sources/us/oh/pickaway.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/pike.json
+++ b/sources/us/oh/pike.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/portage.json
+++ b/sources/us/oh/portage.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/preble.json
+++ b/sources/us/oh/preble.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/putnam.json
+++ b/sources/us/oh/putnam.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/richland.json
+++ b/sources/us/oh/richland.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/ross.json
+++ b/sources/us/oh/ross.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/sandusky.json
+++ b/sources/us/oh/sandusky.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/seneca.json
+++ b/sources/us/oh/seneca.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/shelby.json
+++ b/sources/us/oh/shelby.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/stark.json
+++ b/sources/us/oh/stark.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/tuscarawas.json
+++ b/sources/us/oh/tuscarawas.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "ADDR_NUM",
         "street": [
+            "PRE_DIR",
             "STR_NAME",
-            "STR_TYPE"
+            "STR_TYPE",
+            "SUF_DIR"
         ],
         "type": "shapefile",
         "postcode": "zip"

--- a/sources/us/oh/van_wert.json
+++ b/sources/us/oh/van_wert.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/vinton.json
+++ b/sources/us/oh/vinton.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/washington.json
+++ b/sources/us/oh/washington.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/wayne.json
+++ b/sources/us/oh/wayne.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/williams.json
+++ b/sources/us/oh/williams.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/wood.json
+++ b/sources/us/oh/wood.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
+            "ST_PREFIX",
             "ST_NAME",
-            "ST_TYPE"
+            "ST_TYPE",
+            "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"

--- a/sources/us/oh/wyandot.json
+++ b/sources/us/oh/wyandot.json
@@ -15,8 +15,10 @@
     "conform": {
         "number": "HOUSENUM",
         "street": [
-            "ST_NAME",
-            "ST_TYPE"
+          "ST_PREFIX",
+          "ST_NAME",
+          "ST_TYPE",
+          "ST_SUFFIX"
         ],
         "type": "shapefile",
         "postcode": "zipcode"


### PR DESCRIPTION
A large number of Ohio counties were missing pre- and post-directional fields available in the source data.  This PR fixes that.  