### PR TITLE
Update Kent County, MI

### DIFF
--- a/sources/us/mi/kent.json
+++ b/sources/us/mi/kent.json
@@ -9,20 +9,28 @@
         "state": "mi",
         "county": "Kent"
     },
-    "data": "http://gis.kentcountymi.gov/public/kcsalesviewerweb/proxy.ashx?http://gis.kentcountymi.gov/prodarcgis/rest/services/External/MapServer/6",
+    "data": "http://gis.kentcountymi.gov/prodarcgis/rest/services/External/MapServer/5",
     "type": "ESRI",
     "website": "https://www.accesskent.com/Departments/GIS/",
     "license": "",
     "note": "Data includes polygon shape of parcels. Polygon is found in the SHAPE column. Address data is found in PROPERTYADDRESS, PROPADDRESSCITY, PROPADDRESSSTATE_ZIPCODE, PROPADDRESSNUMBER, PROPADDSTREET.",
     "conform": {
         "type": "geojson",
-        "number": "AddrNo",
-        "street": [
-            "Prefix",
-            "BaseName",
-            "Type",
-            "Suffix"
-        ],
-        "city": "CITYID"
+        "number": "PROPADDRESSNUMBER",
+        "street": "PROPADDSTREET",
+        "city": "PROP_ADDRESS_CITY",
+        "region": {
+          "function": "regexp",
+          "field": "PROPADDRESSSTATE_ZIPCODE",
+          "pattern": "^([A-Z]{2})",
+          "replace": "$1"
+        },
+        "postcode": {
+          "function": "regexp",
+          "field": "PROPADDRESSSTATE_ZIPCODE",
+          "pattern": "^(^[A-Z]{2})(\\d{5})",
+          "replace": "$1"
+        },
+        "id": "PPN"
     }
 }


### PR DESCRIPTION
As shown in the [build output](http://data.openaddresses.io.s3.amazonaws.com/runs/33309/output.txt),
it doesn't look like the current URL works: it was run through some
proxy which hopefully isn't needed.

This also changes the URL from an ESRI layer that has only address info,
back to one that has full parcel data, as well as super valuable
zipcodes.

This URL was added in PR #359 but then changed in #1244, so if there was
a reason we can change it back. But it looks like this will give full
polygon and address data, where the other won't.

Fixes #1389