### PR TITLE
switched house number field from HouseNumber to HouseInt

### DIFF
--- a/sources/us/de/sussex.json
+++ b/sources/us/de/sussex.json
@@ -11,7 +11,7 @@
     },
     "conform": {
         "type": "geojson",
-        "number": "HouseNumber",
+        "number": "HouseInt",
         "street": "PrimaryName",
         "postcode": "Zip",
         "city": "Alias1"


### PR DESCRIPTION
HouseNumber is a string and can contain unit numbers, as in:

```
-75.3331118,38.7097933,24047 UNIT 21,Lewes Georgetown Highway,,,,19947,
-75.0936202,38.714421,37347 UNIT 2,Rehoboth Avenue Extension,,,,19971,
-75.5931058,38.7552849,16487 UNIT 2,Sussex Highway,,,,19933,
```

Whereas HouseInt contains just the numeric portion.