### PR TITLE
pre- and post-directionals were missing

### DIFF
--- a/sources/us/ak/anchorage.json
+++ b/sources/us/ak/anchorage.json
@@ -20,7 +20,7 @@
         "half_add"
       ],
       "street": [
-          "pre_dir"
+          "pre_dir",
           "st_name",
           "st_type",
           "suf_dir"

--- a/sources/us/ak/anchorage.json
+++ b/sources/us/ak/anchorage.json
@@ -15,12 +15,17 @@
     "type": "http",
     "compression": "zip",
     "conform": {
-        "street": [
-            "st_name",
-            "st_type"
-        ],
-        "number": "house_num",
-        "type": "shapefile",
-        "postcode": "zipcode"
+      "number": [
+        "house_num",
+        "half_add"
+      ],
+      "street": [
+          "pre_dir"
+          "st_name",
+          "st_type",
+          "suf_dir"
+      ],
+      "type": "shapefile",
+      "postcode": "zipcode"
     }
 }


### PR DESCRIPTION
also added `HALF_ADD` to `number` field, which fixes `229 Patterson St` to `229 1/2 Patterson St`