### PR TITLE
switched `street` field to use `FULL_STREET` instead of `FULL_ADDRESS`

### DIFF
--- a/sources/us/ak/fairbanks_north_star_borough.json
+++ b/sources/us/ak/fairbanks_north_star_borough.json
@@ -15,6 +15,6 @@
     "conform": {
         "type": "geojson",
         "number": "HSE_NUMB",
-        "street": "FULL_ADDRESS"
+        "street": "FULL_STREET"
     }
 }


### PR DESCRIPTION
`FULL_ADDRESS` has 2 problems:

1. contains house number
2. contains unit/cabin number when available

For example:

```
-147.9156403,64.8557508,349,349 Faith Lane Cabin East,,,,,
-147.6985678,64.995576,720,720 Old Murphy Dome Road Cabin 9,,,,,
-147.6965151,64.9959804,720,720 Old Murphy Dome Road Cabin 5,,,,,
```

This switches the `street` field to `FULL_STREET` which doesn't include house number or unit/cabin number