### PR TITLE
Add directionals to kenai ak

### DIFF
--- a/sources/us/ak/kenai_peninsula_borough.json
+++ b/sources/us/ak/kenai_peninsula_borough.json
@@ -16,8 +16,10 @@
     "compression": "zip",
     "conform": {
         "street": [
+            "STREET_PRE",
             "STREET_NAM",
-            "STREET_SUF"
+            "STREET_SUF",
+            "STREET_POS"
         ],
         "number": "HouseNumbe",
         "type": "shapefile",

--- a/sources/us/ak/kenai_peninsula_borough.json
+++ b/sources/us/ak/kenai_peninsula_borough.json
@@ -24,6 +24,6 @@
         "number": "HouseNumbe",
         "type": "shapefile",
         "postcode": "ZIP_CODE",
-        "city": "COMM_NAM"
+        "city": "COMM_NAME"
     }
 }


### PR DESCRIPTION
I think the invalid `city` field name is why Kenai data was not being exported.