### PR TITLE
switched field for `number` from `Full_Add_Num` to `Add_Num`

### DIFF
--- a/sources/us/al/shelby.json
+++ b/sources/us/al/shelby.json
@@ -14,7 +14,7 @@
     "attribution": "Shelby County",
     "conform": {
         "type": "geojson",
-        "number": "Full_Add_Num",
+        "number": "Add_Num",
         "street": "Full_Street_Name",
         "postcode": "Zip5"
     }


### PR DESCRIPTION
`Full_Add_Num` includes unit # whereas `Add_Num` doesn't