### PR TITLE
switched to regexp for more accurate address parsing

### DIFF
--- a/sources/us/co/city_of_loveland.json
+++ b/sources/us/co/city_of_loveland.json
@@ -22,9 +22,17 @@
     "compression": "zip",
     "website": "http://www.ci.loveland.co.us/index.aspx?page=436",
     "conform": {
-        "split": "ADDRESS",
-        "number": "auto_number",
-        "street": "auto_street",
-        "type": "shapefile"
+      "type": "shapefile",
+      "number": {
+          "function": "regexp",
+          "field": "ADDRESS",
+          "pattern": "^([0-9]+)"
+      },
+      "street": {
+          "function": "regexp",
+          "field": "ADDRESS",
+          "pattern": "^(?:[0-9]+ )(.*) ?(#[0-9A-Z]+|GAR[0-9]+|BLDG?#?[0-9]+|1/2)?$",
+          "replace": "$1"
+      }
     }
 }


### PR DESCRIPTION
source data unfortunately includes entries like:

```
* 1141 N Washington Ave 1/2
* 4105 N Garfield Ave #78
* 1401 E 16Th St #A
* 3760 E 15Th St Bldg2
* 2080 Tonopas Ct Gar12
```

There are a large number of variations that the regex will hopefully get but it isn't foolproof, the data is way too dirty.