### PR TITLE
Add statewide JSON for Puerto Rico

### DIFF
--- a/sources/us/pr/statewide.json
+++ b/sources/us/pr/statewide.json
@@ -1,0 +1,32 @@
+
+{
+    "data": "https://data.pr.gov/api/views/h9md-ic24/rows.csv?accessType=DOWNLOAD",
+    "website": "https://data.pr.gov/en/Desarrollo-e-Infraestructura/Direcciones-Estandarizadas-Bay-Car-SJ/h9md-ic24",
+    "license": {
+        "text": "public domain",
+        "attribution": false,
+        "share-alike": false
+    },
+    "type": "http",
+    "year": 2014,
+    "coverage": {
+        "US Census": {
+            "geoid": "72",
+            "state": "Puerto Rico"
+        },
+        "country": "us",
+        "state": "pr"
+    },
+    "conform": {
+        "type": "csv",
+        "file": "rows.csv",
+        "lon": "LONG",
+        "lat": "LAT",
+        "number": "NRO",
+        "street": "CALLE",
+        "city": "POBL",
+        "district": "PMB",
+        "region": "PAIS",
+        "postcode": "COD_POST"
+    }
+}

--- a/sources/us/pr/statewide.json
+++ b/sources/us/pr/statewide.json
@@ -19,7 +19,7 @@
     },
     "conform": {
         "type": "csv",
-        "lon": "LONG",
+        "lon": "LON",
         "lat": "LAT",
         "number": "NRO",
         "street": "CALLE",

--- a/sources/us/pr/statewide.json
+++ b/sources/us/pr/statewide.json
@@ -19,7 +19,6 @@
     },
     "conform": {
         "type": "csv",
-        "file": "rows.csv",
         "lon": "LONG",
         "lat": "LAT",
         "number": "NRO",


### PR DESCRIPTION
This is using Puerto Rico's statewide address points file, _but it only includes a small subset of the commonwealth's addresses._ There are just 135,000 in all, including San Juan and neighboring Bayamón and Carolina. I have no idea if why PR's statewide address points file only includes these addresses.