### PR TITLE
mass conversion to regexp instead of split/auto_number/auto_street

### DIFF
--- a/sources/us/ak/matanuska_susitna_borough.json
+++ b/sources/us/ak/matanuska_susitna_borough.json
@@ -14,9 +14,17 @@
     "attribution": "Matanuska-Susitna Borough",
     "type": "ESRI",
     "conform": {
-        "split": "ADDRESS",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "ADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "ADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "geojson"
     }
 }

--- a/sources/us/az/pinal.json
+++ b/sources/us/az/pinal.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "FullAddress",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "FullAddress",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "FullAddress",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/az/santa_cruz.json
+++ b/sources/us/az/santa_cruz.json
@@ -14,8 +14,16 @@
     "note": "SITEADDR has the city after the road name, so the split is going to be crummy",
     "conform": {
         "type": "geojson",
-        "split": "SITEADDR",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "SITEADDR",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "SITEADDR",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ca/madera.json
+++ b/sources/us/ca/madera.json
@@ -11,9 +11,17 @@
     },
     "conform": {
         "type": "shapefile",
-        "split": "Address",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "Address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "Address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     },
     "data": "https://github.com/datadesk/us-ca-madera_county-situs-shp/blob/master/Asr_Situs.zip?raw=true",
     "attribution": "Madera County",

--- a/sources/us/ca/ventura.json
+++ b/sources/us/ca/ventura.json
@@ -21,9 +21,17 @@
     "type": "http",
     "compression": "zip",
     "conform": {
-        "split": "FULLSITUS",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "FULLSITUS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "FULLSITUS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile",
         "postcode": "zip"
     }

--- a/sources/us/ca/yolo.json
+++ b/sources/us/ca/yolo.json
@@ -20,9 +20,17 @@
     "conform": {
         "id": "APN",
         "type": "shapefile-polygon",
-        "split": "SITUS",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "SITUS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "SITUS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "postcode": "ZIP",
         "city": "CITY"
     }

--- a/sources/us/co/broomfield.json
+++ b/sources/us/co/broomfield.json
@@ -12,8 +12,12 @@
     "conform": {
         "type": "geojson",
         "number": "ADDRESS_NUMBER",
-        "split": "FULL_ADDRESS",
-        "street": "auto_street"
+        "street": {
+            "function": "regexp",
+            "field": "FULL_ADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     },
     "data": "http://gis.broomfield.org/ArcGIS/rest/services/Assessor/Subdivisions_Parcels_2D/MapServer/0",
     "type": "ESRI"

--- a/sources/us/co/jefferson.json
+++ b/sources/us/co/jefferson.json
@@ -13,9 +13,17 @@
     "data": "http://jeffco.us/ArcGIS/rest/services/address/MapServer/0",
     "type": "ESRI",
     "conform": {
-        "split": "ADDRESS",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "ADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "ADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "geojson",
         "postcode": "zip"
     }

--- a/sources/us/co/larimer.json
+++ b/sources/us/co/larimer.json
@@ -13,9 +13,13 @@
     "data": "http://maps.larimer.org/arcgis/rest/services/maps/selectableLayers/MapServer/3",
     "type": "ESRI",
     "conform": {
-        "split": "SITEADDR",
         "number": "addrnum",
-        "street": "auto_street",
+        "street": {
+            "function": "regexp",
+            "field": "SITEADDR",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "geojson",
         "postcode": "zipcode"
     }

--- a/sources/us/co/mesa.json
+++ b/sources/us/co/mesa.json
@@ -15,9 +15,17 @@
     "website": "http://emap.mesacounty.us/metadata/default.aspx?value=Administrative",
     "conform": {
         "type": "geojson",
-        "split": "LOCATION",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "LOCATION",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "LOCATION",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "city": "CITY",
         "region": "STATE",
         "postcode": "ZIP"

--- a/sources/us/co/montrose.json
+++ b/sources/us/co/montrose.json
@@ -11,9 +11,17 @@
     },
     "conform": {
         "type": "geojson",
-        "split": "FSA",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "FSA",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "FSA",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "postcode": "ZIPCODE",
         "city": "PCN"
     },

--- a/sources/us/ct/city_of_haddam.json
+++ b/sources/us/ct/city_of_haddam.json
@@ -9,9 +9,17 @@
     "website": "http://www.haddam.org/",
     "type": "ESRI",
     "conform": {
-        "split": "ParcelPolygon.StreetAddr",
-        "street": "auto_street",
-        "number": "auto_number",
+        "street": {
+            "function": "regexp",
+            "field": "ParcelPolygon.StreetAddr",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
+        "number": {
+            "function": "regexp",
+            "field": "ParcelPolygon.StreetAddr",
+            "pattern": "^([0-9]+)"
+        },
         "type": "geojson"
     }
 }

--- a/sources/us/ct/town_of_avon.json
+++ b/sources/us/ct/town_of_avon.json
@@ -9,9 +9,17 @@
     "website": "http://www.town.avon.ct.us/Public_Documents/index",
     "type": "ESRI",
     "conform": {
-        "split": "parcel_polygon.PropertyLoc",
-        "street": "auto_street",
-        "number": "auto_number",
+        "street": {
+            "function": "regexp",
+            "field": "parcel_polygon.PropertyLoc",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
+        "number": {
+            "function": "regexp",
+            "field": "parcel_polygon.PropertyLoc",
+            "pattern": "^([0-9]+)"
+        },
         "type": "geojson"
     }
 }

--- a/sources/us/ct/town_of_easton_monroe.json
+++ b/sources/us/ct/town_of_easton_monroe.json
@@ -9,9 +9,17 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "CombinedCAMA_CombinedCAMA_SiteAddress",
-        "street": "auto_street",
-        "number": "auto_number",
+        "street": {
+            "function": "regexp",
+            "field": "CombinedCAMA_CombinedCAMA_SiteAddress",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
+        "number": {
+            "function": "regexp",
+            "field": "CombinedCAMA_CombinedCAMA_SiteAddress",
+            "pattern": "^([0-9]+)"
+        },
         "city": "CombinedCAMA_CombinedCAMA_SiteCity",
         "postcode": "CombinedCAMA_CombinedCAMA_SiteZip",
         "region": "CombinedCAMA_CombinedCAMA_SiteState",

--- a/sources/us/ct/town_of_groton.json
+++ b/sources/us/ct/town_of_groton.json
@@ -13,9 +13,17 @@
     },
     "conform": {
         "type": "geojson",
-        "split": "LOGI_FULLNAM",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "LOGI_FULLNAM",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "LOGI_FULLNAM",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "postcode": "ZIP"
     },
     "attribution": "City of Groton",

--- a/sources/us/ct/town_on_trumbull.json
+++ b/sources/us/ct/town_on_trumbull.json
@@ -9,9 +9,13 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "Location",
         "number": "ST_NUM",
-        "street": "auto_street",
+        "street": {
+            "function": "regexp",
+            "field": "Location",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "id": "PAR_ID",
         "accuracy": 2
     }

--- a/sources/us/fl/manatee.json
+++ b/sources/us/fl/manatee.json
@@ -20,9 +20,17 @@
     "type": "http",
     "compression": "zip",
     "conform": {
-        "split": "primary_ad",
-        "street": "auto_street",
-        "number": "auto_number",
+        "street": {
+            "function": "regexp",
+            "field": "primary_ad",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
+        "number": {
+            "function": "regexp",
+            "field": "primary_ad",
+            "pattern": "^([0-9]+)"
+        },
         "type": "shapefile-polygon",
         "postcode": "prop_zip"
     }

--- a/sources/us/ia/benton.json
+++ b/sources/us/ia/benton.json
@@ -20,9 +20,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/boone.json
+++ b/sources/us/ia/boone.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/bremer.json
+++ b/sources/us/ia/bremer.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/buchanan.json
+++ b/sources/us/ia/buchanan.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/buena_vista.json
+++ b/sources/us/ia/buena_vista.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/calhoun.json
+++ b/sources/us/ia/calhoun.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/carroll.json
+++ b/sources/us/ia/carroll.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/cass.json
+++ b/sources/us/ia/cass.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/cherokee.json
+++ b/sources/us/ia/cherokee.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/clarke.json
+++ b/sources/us/ia/clarke.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/clarke_county.json
+++ b/sources/us/ia/clarke_county.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/crawford.json
+++ b/sources/us/ia/crawford.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/dallas.json
+++ b/sources/us/ia/dallas.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/decatur.json
+++ b/sources/us/ia/decatur.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/delaware.json
+++ b/sources/us/ia/delaware.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/dickinson.json
+++ b/sources/us/ia/dickinson.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/emmet.json
+++ b/sources/us/ia/emmet.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/franklin.json
+++ b/sources/us/ia/franklin.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/fremont.json
+++ b/sources/us/ia/fremont.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/greene.json
+++ b/sources/us/ia/greene.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/guthrie.json
+++ b/sources/us/ia/guthrie.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/hamilton.json
+++ b/sources/us/ia/hamilton.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/hardin.json
+++ b/sources/us/ia/hardin.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/harrison.json
+++ b/sources/us/ia/harrison.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/howard.json
+++ b/sources/us/ia/howard.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/humboldt.json
+++ b/sources/us/ia/humboldt.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/ida.json
+++ b/sources/us/ia/ida.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/jasper.json
+++ b/sources/us/ia/jasper.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/kossuth.json
+++ b/sources/us/ia/kossuth.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/lucas.json
+++ b/sources/us/ia/lucas.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/lyon.json
+++ b/sources/us/ia/lyon.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/madison.json
+++ b/sources/us/ia/madison.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/marion.json
+++ b/sources/us/ia/marion.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/marshall.json
+++ b/sources/us/ia/marshall.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/mills.json
+++ b/sources/us/ia/mills.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/monona.json
+++ b/sources/us/ia/monona.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/monroe.json
+++ b/sources/us/ia/monroe.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/montgomery.json
+++ b/sources/us/ia/montgomery.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/palo_alto.json
+++ b/sources/us/ia/palo_alto.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/pocahontas.json
+++ b/sources/us/ia/pocahontas.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/pottawattamie.json
+++ b/sources/us/ia/pottawattamie.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/sac.json
+++ b/sources/us/ia/sac.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/shelby.json
+++ b/sources/us/ia/shelby.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/sioux.json
+++ b/sources/us/ia/sioux.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/sioux_county.json
+++ b/sources/us/ia/sioux_county.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/webster.json
+++ b/sources/us/ia/webster.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/winnebago.json
+++ b/sources/us/ia/winnebago.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/winneshiek.json
+++ b/sources/us/ia/winneshiek.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/wright.json
+++ b/sources/us/ia/wright.json
@@ -19,9 +19,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/id/teton.json
+++ b/sources/us/id/teton.json
@@ -12,9 +12,13 @@
     "data": "http://www.co.teton.id.us/arcgis/rest/services/ADDRESS/MapServer/0",
     "type": "ESRI",
     "conform": {
-        "split": "labelname",
         "number": "housenumber",
-        "street": "auto_street",
+        "street": {
+            "function": "regexp",
+            "field": "labelname",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "geojson",
         "postcode": "zipcode"
     }

--- a/sources/us/il/adams.json
+++ b/sources/us/il/adams.json
@@ -13,9 +13,17 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "MASTERADD",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "MASTERADD",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "MASTERADD",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "city": "CITY",
         "postcode": "ZIP",
         "region": "STATE"

--- a/sources/us/il/christian.json
+++ b/sources/us/il/christian.json
@@ -11,9 +11,17 @@
     },
     "conform": {
         "type": "geojson",
-        "split": "SiteAddres",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "SiteAddres",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "SiteAddres",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     },
     "data": "http://services2.bhamaps.com/arcgis/rest/services/AGS_christian_co_il_taxmap/MapServer/0",
     "type": "ESRI",

--- a/sources/us/il/city_of_aurora.json
+++ b/sources/us/il/city_of_aurora.json
@@ -20,9 +20,17 @@
     "data": "http://gis.aurora-il.org/arcgis/rest/services/AddressPoints/AddressPoints/MapServer/0",
     "conform": {
         "type": "geojson",
-        "split": "ADDRESS",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "ADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "ADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "city": "CITY",
         "postcode": "ZIPCODE"
     }

--- a/sources/us/il/clark.json
+++ b/sources/us/il/clark.json
@@ -12,9 +12,17 @@
     "data": "http://services2.bhamaps.com/arcgis/rest/services/AGS_clark_co_il_taxmap/MapServer/0",
     "type": "ESRI",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "geojson"
     }
 }

--- a/sources/us/il/jackson.json
+++ b/sources/us/il/jackson.json
@@ -12,9 +12,17 @@
     "data": "http://services2.bhamaps.com/arcgis/rest/services/AGS_jackson_co_il_taxmap/MapServer/0",
     "type": "ESRI",
     "conform": {
-        "split": "address",
-        "street": "auto_street",
-        "number": "auto_number",
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
         "type": "geojson"
     }
 }

--- a/sources/us/il/jersey.json
+++ b/sources/us/il/jersey.json
@@ -12,9 +12,17 @@
     "data": "http://services2.bhamaps.com/arcgis/rest/services/AGS_jersey_co_il_taxmap/MapServer/0",
     "type": "ESRI",
     "conform": {
-        "split": "site_address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "site_address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "site_address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "geojson"
     }
 }

--- a/sources/us/il/massac.json
+++ b/sources/us/il/massac.json
@@ -12,9 +12,17 @@
     "data": "http://services2.bhamaps.com/arcgis/rest/services/AGS_massac_co_il_taxmap/MapServer/0",
     "type": "ESRI",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "geojson"
     }
 }

--- a/sources/us/il/mchenry.json
+++ b/sources/us/il/mchenry.json
@@ -11,9 +11,17 @@
     },
     "conform": {
         "type": "geojson",
-        "split": "SiteAddressStreet",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "SiteAddressStreet",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "SiteAddressStreet",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     },
     "data": "http://www.mchenrycountygis.org/arcgis/rest/services/parcelsfull/MapServer/0",
     "type": "ESRI"

--- a/sources/us/il/menard.json
+++ b/sources/us/il/menard.json
@@ -12,9 +12,17 @@
     "data": "http://services2.bhamaps.com/arcgis/rest/services/AGS_menard_co_il_taxmap/MapServer/0",
     "type": "ESRI",
     "conform": {
-        "split": "site_address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "site_address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "site_address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "geojson",
         "accuracy": 2
     }

--- a/sources/us/il/morgan.json
+++ b/sources/us/il/morgan.json
@@ -12,9 +12,17 @@
     "data": "http://services2.bhamaps.com/arcgis/rest/services/AGS_morgan_co_il_taxmap/MapServer/0",
     "type": "ESRI",
     "conform": {
-        "split": "site_address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "site_address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "site_address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "geojson"
     }
 }

--- a/sources/us/il/putnam.json
+++ b/sources/us/il/putnam.json
@@ -12,9 +12,17 @@
     "data": "http://services2.bhamaps.com/arcgis/rest/services/AGS_putnam_co_il_taxmap/MapServer/0",
     "type": "ESRI",
     "conform": {
-        "split": "site_address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "site_address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "site_address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "geojson",
         "accuracy": 2
     }

--- a/sources/us/il/schuyler.json
+++ b/sources/us/il/schuyler.json
@@ -12,9 +12,17 @@
     "data": "http://services2.bhamaps.com/arcgis/rest/services/AGS_schuyler_co_il_taxmap/MapServer/0",
     "type": "ESRI",
     "conform": {
-        "split": "site_address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "site_address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "site_address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "geojson"
     }
 }

--- a/sources/us/il/vermilion.json
+++ b/sources/us/il/vermilion.json
@@ -12,9 +12,17 @@
     "data": "http://services2.bhamaps.com/arcgis/rest/services/AGS_vermilion_co_il_taxmap/MapServer/0",
     "type": "ESRI",
     "conform": {
-        "split": "FullSiteAddress1",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "FullSiteAddress1",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "FullSiteAddress1",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "geojson"
     }
 }

--- a/sources/us/in/bartholomew.json
+++ b/sources/us/in/bartholomew.json
@@ -11,9 +11,17 @@
     },
     "conform": {
         "type": "geojson",
-        "split": "ADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "ADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "ADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     },
     "data": "http://egislb-1921188874.us-east-1.elb.amazonaws.com/arcgis/rest/services/eGISBartholomewINPublic/BartholomewINDynamic/MapServer/0",
     "type": "ESRI"

--- a/sources/us/in/st_joseph.json
+++ b/sources/us/in/st_joseph.json
@@ -21,9 +21,17 @@
     "year": "2014",
     "note": "Full parcel shapefile set (not points)",
     "conform": {
-        "split": "prop_addr",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "prop_addr",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "prop_addr",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/in/st_joseph.json
+++ b/sources/us/in/st_joseph.json
@@ -21,17 +21,9 @@
     "year": "2014",
     "note": "Full parcel shapefile set (not points)",
     "conform": {
-        "number": {
-            "function": "regexp",
-            "field": "prop_addr",
-            "pattern": "^([0-9]+)"
-        },
-        "street": {
-            "function": "regexp",
-            "field": "prop_addr",
-            "pattern": "^(?:[0-9]+ )(.*)",
-            "replace": "$1"
-        },
+        "split": "prop_addr",
+        "number": "auto_number",
+        "street": "auto_street",
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/ks/butler_county.json
+++ b/sources/us/ks/butler_county.json
@@ -12,8 +12,12 @@
     "conform": {
         "type": "geojson",
         "number": "HNO",
-        "split": "LABEL",
-        "street": "auto_street",
+        "street": {
+            "function": "regexp",
+            "field": "LABEL",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "postcode": ""
     },
     "data": "http://ww1.bucoks.com/arcgis/rest/services/BuCo_NGAddress_Points/MapServer/0",

--- a/sources/us/ks/dickinson_county.json
+++ b/sources/us/ks/dickinson_county.json
@@ -11,9 +11,17 @@
     },
     "conform": {
         "type": "geojson",
-        "split": "CRS.dbo.DKBasemap.PropertyAddress",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "CRS.dbo.DKBasemap.PropertyAddress",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "CRS.dbo.DKBasemap.PropertyAddress",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "postcode": ""
     },
     "data": "http://67.214.197.22/arcgis/rest/services/BasicMap2013/MapServer/7",

--- a/sources/us/ks/reno_county.json
+++ b/sources/us/ks/reno_county.json
@@ -11,9 +11,17 @@
     },
     "conform": {
         "type": "geojson",
-        "number": "auto_number",
-        "split": "Appraiser_Data_Export.PROPADD",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "Appraiser_Data_Export.PROPADD",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "Appraiser_Data_Export.PROPADD",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     },
     "data": "http://renogis3.renogov.org/arcgis/rest/services/Test/WebLayers/MapServer/7",
     "type": "ESRI"

--- a/sources/us/ky/boone.json
+++ b/sources/us/ky/boone.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "ADR_LABEL",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "ADR_LABEL",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "ADR_LABEL",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ky/boone.json
+++ b/sources/us/ky/boone.json
@@ -13,16 +13,8 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "number": {
-            "function": "regexp",
-            "field": "ADR_LABEL",
-            "pattern": "^([0-9]+)"
-        },
-        "street": {
-            "function": "regexp",
-            "field": "ADR_LABEL",
-            "pattern": "^(?:[0-9]+ )(.*)",
-            "replace": "$1"
-        }
+        "split": "ADR_LABEL",
+        "number": "auto_number",
+        "street": "auto_street"
     }
 }

--- a/sources/us/md/cecil.json
+++ b/sources/us/md/cecil.json
@@ -16,9 +16,17 @@
     "type": "http",
     "year": 2014,
     "conform": {
-        "split": "address",
-        "street": "auto_street",
-        "number": "auto_number",
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/us/mn/aitkin_alt.json
+++ b/sources/us/mn/aitkin_alt.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/mn/becker.json
+++ b/sources/us/mn/becker.json
@@ -15,9 +15,17 @@
     "type": "http",
     "compression": "zip",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile",
         "postcode": "zip"
     }

--- a/sources/us/mn/big_stone.json
+++ b/sources/us/mn/big_stone.json
@@ -20,9 +20,17 @@
     "website": "http://www.bigstonecounty.org/gis/gis.vbhtml",
     "conform": {
         "type": "shapefile-polygon",
-        "split": "PHYSADDR",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "PHYSADDR",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PHYSADDR",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "city": "TWPNAME"
     }
 }

--- a/sources/us/mn/cass.json
+++ b/sources/us/mn/cass.json
@@ -12,17 +12,8 @@
     "data": "http://cassweb3.co.cass.mn.us/arcgis/rest/services/Basic_Layers2/MapServer/1",
     "type": "ESRI",
     "conform": {
-        "number": {
-            "function": "regexp",
-            "field": "PHYSADDR",
-            "pattern": "^([0-9]+)"
-        },
-        "street": {
-            "function": "regexp",
-            "field": "PHYSADDR",
-            "pattern": "^(?:[0-9]+ )(.*)",
-            "replace": "$1"
-        },
+        "number": "BLDNUM1",
+        "street": "RD_NAME",
         "type": "geojson"
     }
 }

--- a/sources/us/mn/cass.json
+++ b/sources/us/mn/cass.json
@@ -12,9 +12,17 @@
     "data": "http://cassweb3.co.cass.mn.us/arcgis/rest/services/Basic_Layers2/MapServer/1",
     "type": "ESRI",
     "conform": {
-        "split": "PHYSADDR",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "PHYSADDR",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PHYSADDR",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "geojson"
     }
 }

--- a/sources/us/mn/chisago.json
+++ b/sources/us/mn/chisago.json
@@ -11,9 +11,17 @@
     },
     "conform": {
         "type": "geojson",
-        "split": "ADDRESS",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "ADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "ADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "city": "CITY",
         "postcode": "ZIP"
     },

--- a/sources/us/mn/crow_wing.json
+++ b/sources/us/mn/crow_wing.json
@@ -12,9 +12,17 @@
     "data": "http://gis.co.crow-wing.mn.us/arcgis/rest/services/CROWWINGPUBLIC/MapServer/4",
     "type": "ESRI",
     "conform": {
-        "split": "ADDRESS",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "ADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "ADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "geojson",
         "postcode": "ZIP"
     },

--- a/sources/us/mn/lake_of_the_woods.json
+++ b/sources/us/mn/lake_of_the_woods.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "ADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "ADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "ADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/mn/pope.json
+++ b/sources/us/mn/pope.json
@@ -13,9 +13,13 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "FULLADDR",
         "number": "ADDRNUM",
-        "street": "auto_street",
+        "street": {
+            "function": "regexp",
+            "field": "FULLADDR",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "postcode": "ZIP",
         "city": "MUNICIPALITY"
     }

--- a/sources/us/mn/ramsey.json
+++ b/sources/us/mn/ramsey.json
@@ -11,9 +11,17 @@
     },
     "conform": {
         "type": "geojson",
-        "split": "SiteAddress",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "SiteAddress",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "SiteAddress",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     },
     "license": {
         "text": "Indemnification",

--- a/sources/us/mn/roseau.json
+++ b/sources/us/mn/roseau.json
@@ -12,9 +12,17 @@
     "data": "http://gis.co.roseau.mn.us/arcgis/rest/services/Roseau_OperationalData/MapServer/0",
     "type": "ESRI",
     "conform": {
-        "split": "RoseauAS400.dbo.tblParcelJoin.PhysAddr",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "RoseauAS400.dbo.tblParcelJoin.PhysAddr",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "RoseauAS400.dbo.tblParcelJoin.PhysAddr",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "geojson",
         "city": "RoseauAS400.dbo.tblParcelJoin.PhysCity",
         "accuracy": 2

--- a/sources/us/mn/st_louis.json
+++ b/sources/us/mn/st_louis.json
@@ -13,9 +13,17 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PHYSADDR",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "PHYSADDR",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PHYSADDR",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "city": "PHYSCITY",
         "postcode": "PHYSZIP"
     }

--- a/sources/us/mn/wilkin.json
+++ b/sources/us/mn/wilkin.json
@@ -12,9 +12,17 @@
     "data": "http://gisweb.co.wilkin.mn.us/arcgis/rest/services/WilkinPublic/MapServer/16",
     "type": "ESRI",
     "conform": {
-        "split": "address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "geojson",
         "postcode": "zip"
     }

--- a/sources/us/mn/yellow_medicine.json
+++ b/sources/us/mn/yellow_medicine.json
@@ -13,9 +13,17 @@
     "type": "ESRI",
     "note": "polygon",
     "conform": {
-        "split": "YellowMedicineTaxData.dbo.tblParcelJoin.PROPERTY_ADDRESS",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "YellowMedicineTaxData.dbo.tblParcelJoin.PROPERTY_ADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "YellowMedicineTaxData.dbo.tblParcelJoin.PROPERTY_ADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "geojson"
     }
 }

--- a/sources/us/ms/copiah.json
+++ b/sources/us/ms/copiah.json
@@ -12,9 +12,17 @@
     "data": "http://gis.cmpdd.org/arcgis/rest/services/Viewers/Copiah/MapServer/2",
     "type": "ESRI",
     "conform": {
-        "split": "situs",
-        "street": "auto_street",
-        "number": "auto_number",
+        "street": {
+            "function": "regexp",
+            "field": "situs",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
+        "number": {
+            "function": "regexp",
+            "field": "situs",
+            "pattern": "^([0-9]+)"
+        },
         "type": "geojson",
         "postcode": "zip"
     }

--- a/sources/us/mt/beaverhead.json
+++ b/sources/us/mt/beaverhead.json
@@ -11,9 +11,17 @@
     },
     "conform": {
         "type": "shapefile-polygon",
-        "split": "AddressLin",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "AddressLin",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "AddressLin",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     },
     "data": "ftp://anonymous:anonymous@ftp.gis.mt.gov/CadastralFramework/Beaverhead/BeaverheadOwnerParcel_shp.zip",
     "type": "ftp",

--- a/sources/us/mt/big_horn.json
+++ b/sources/us/mt/big_horn.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/blaine.json
+++ b/sources/us/mt/blaine.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/broadwater.json
+++ b/sources/us/mt/broadwater.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/carbon.json
+++ b/sources/us/mt/carbon.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/carter.json
+++ b/sources/us/mt/carter.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/cascade.json
+++ b/sources/us/mt/cascade.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/chouteau.json
+++ b/sources/us/mt/chouteau.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/custer.json
+++ b/sources/us/mt/custer.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/daniels.json
+++ b/sources/us/mt/daniels.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/dawson.json
+++ b/sources/us/mt/dawson.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/deer_lodge.json
+++ b/sources/us/mt/deer_lodge.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/fallon.json
+++ b/sources/us/mt/fallon.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/fergus.json
+++ b/sources/us/mt/fergus.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/flathead.json
+++ b/sources/us/mt/flathead.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/gallatin.json
+++ b/sources/us/mt/gallatin.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/garfield.json
+++ b/sources/us/mt/garfield.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/glacier.json
+++ b/sources/us/mt/glacier.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "AddressLin",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "AddressLin",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "AddressLin",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon",
         "accuracy": 2
     }

--- a/sources/us/mt/golden_valley.json
+++ b/sources/us/mt/golden_valley.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/granite.json
+++ b/sources/us/mt/granite.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/hill.json
+++ b/sources/us/mt/hill.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/jefferson.json
+++ b/sources/us/mt/jefferson.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/judith_basin.json
+++ b/sources/us/mt/judith_basin.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/lake.json
+++ b/sources/us/mt/lake.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/lake_county.json
+++ b/sources/us/mt/lake_county.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/liberty.json
+++ b/sources/us/mt/liberty.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon",
         "postcode": "ownerzipco"
     }

--- a/sources/us/mt/lincoln.json
+++ b/sources/us/mt/lincoln.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/madison.json
+++ b/sources/us/mt/madison.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/mccone.json
+++ b/sources/us/mt/mccone.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/meagher.json
+++ b/sources/us/mt/meagher.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/mineral.json
+++ b/sources/us/mt/mineral.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/missoula.json
+++ b/sources/us/mt/missoula.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "AddressLin",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "AddressLin",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "AddressLin",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon",
         "accuracy": 2
     }

--- a/sources/us/mt/musselshell.json
+++ b/sources/us/mt/musselshell.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/petroleum.json
+++ b/sources/us/mt/petroleum.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/phillips.json
+++ b/sources/us/mt/phillips.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/pondera.json
+++ b/sources/us/mt/pondera.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "AddressLin",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "AddressLin",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "AddressLin",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon",
         "accuracy": 2
     }

--- a/sources/us/mt/powder_river.json
+++ b/sources/us/mt/powder_river.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/powell.json
+++ b/sources/us/mt/powell.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon",
         "postcode": "ownerzipco"
     }

--- a/sources/us/mt/prairie.json
+++ b/sources/us/mt/prairie.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/ravalli.json
+++ b/sources/us/mt/ravalli.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/richland.json
+++ b/sources/us/mt/richland.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/roosevelt.json
+++ b/sources/us/mt/roosevelt.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/rosebud.json
+++ b/sources/us/mt/rosebud.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/sanders.json
+++ b/sources/us/mt/sanders.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/sheridan.json
+++ b/sources/us/mt/sheridan.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/silverbow.json
+++ b/sources/us/mt/silverbow.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/stillwater.json
+++ b/sources/us/mt/stillwater.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/sweet_grass.json
+++ b/sources/us/mt/sweet_grass.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/teton.json
+++ b/sources/us/mt/teton.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/toole.json
+++ b/sources/us/mt/toole.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/treasure.json
+++ b/sources/us/mt/treasure.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/valley.json
+++ b/sources/us/mt/valley.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/wheatland.json
+++ b/sources/us/mt/wheatland.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/wibaux.json
+++ b/sources/us/mt/wibaux.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "OwnerAddre",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "OwnerAddre",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/mt/yellowstone.json
+++ b/sources/us/mt/yellowstone.json
@@ -13,9 +13,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "AddressLin",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "AddressLin",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "AddressLin",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon",
         "accuracy": 2
     }

--- a/sources/us/nc/alexander.json
+++ b/sources/us/nc/alexander.json
@@ -12,9 +12,17 @@
     "data": "http://maps.co.alexander.nc.us/arcgis/rest/services/Regional_Site/MapServer/0",
     "type": "ESRI",
     "conform": {
-        "split": "num_street",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "num_street",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "num_street",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "geojson"
     }
 }

--- a/sources/us/nc/blowing_rock.json
+++ b/sources/us/nc/blowing_rock.json
@@ -7,9 +7,17 @@
     "data": "http://arcgis.webgis.net/arcgis/rest/services/NC/BlowingRock/MapServer/6",
     "type": "ESRI",
     "conform": {
-        "split": "PropAddress",
-        "street": "auto_street",
-        "number": "auto_number",
+        "street": {
+            "function": "regexp",
+            "field": "PropAddress",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
+        "number": {
+            "function": "regexp",
+            "field": "PropAddress",
+            "pattern": "^([0-9]+)"
+        },
         "type": "geojson"
     }
 }

--- a/sources/us/nc/buncombe.json
+++ b/sources/us/nc/buncombe.json
@@ -14,9 +14,17 @@
     "compression": "zip",
     "website": "http://www.buncombecounty.org/Governing/Depts/GIS/DataDownload.aspx",
     "conform": {
-        "split": "full_civic",
-        "number": "auto_number",
-        "street": "auto_Street",
+        "number": {
+            "function": "regexp",
+            "field": "full_civic",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "full_civic",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile",
         "postcode": "postal_cod"
     }

--- a/sources/us/nc/city_of_king.json
+++ b/sources/us/nc/city_of_king.json
@@ -19,9 +19,17 @@
     "data": "http://arcgis.webgis.net/arcgis/rest/services/NC/CityOfKing/MapServer/6",
     "type": "ESRI",
     "conform": {
-        "split": "PropertyAddr",
-        "street": "auto_street",
-        "number": "auto_number",
+        "number": {
+            "function": "regexp",
+            "field": "PropertyAddr",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PropertyAddr",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "geojson",
         "postcode": "ownerzip"
     }

--- a/sources/us/nc/craven.json
+++ b/sources/us/nc/craven.json
@@ -11,9 +11,17 @@
     },
     "conform": {
         "type": "shapefile-polygon",
-        "split": "PROP_ADD",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROP_ADD",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROP_ADD",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     },
     "data": "http://gis.cravencountync.gov/Downloads/Shape_files/county_shape.zip",
     "type": "http",

--- a/sources/us/nc/madison.json
+++ b/sources/us/nc/madison.json
@@ -14,8 +14,12 @@
     "compression": "zip",
     "website": "http://madisoncountygis.com/nc/madison/downloads.php",
     "conform": {
-        "split": "address",
-        "street": "auto_street",
+        "street": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "number": "addnum",
         "type": "shapefile"
     }

--- a/sources/us/nd/cass.json
+++ b/sources/us/nd/cass.json
@@ -12,9 +12,13 @@
     "data": "http://gisweb.casscountynd.gov/arcgis/rest/services/PublicDynamic/MapServer/22",
     "type": "ESRI",
     "conform": {
-        "split": "property_addr",
         "number": "addr_num",
-        "street": "auto_street",
+        "street": {
+            "function": "regexp",
+            "field": "property_addr",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "geojson",
         "postcode": "zip_code"
     }

--- a/sources/us/nd/golden_valley_county.json
+++ b/sources/us/nd/golden_valley_county.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/nd/mckenzie_county.json
+++ b/sources/us/nd/mckenzie_county.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/nd/stark_county.json
+++ b/sources/us/nd/stark_county.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/antelope.json
+++ b/sources/us/ne/antelope.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/arthur.json
+++ b/sources/us/ne/arthur.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/banner.json
+++ b/sources/us/ne/banner.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/blaine.json
+++ b/sources/us/ne/blaine.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/boone.json
+++ b/sources/us/ne/boone.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/box_butte.json
+++ b/sources/us/ne/box_butte.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/brown.json
+++ b/sources/us/ne/brown.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/buffalo.json
+++ b/sources/us/ne/buffalo.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/burt.json
+++ b/sources/us/ne/burt.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/butler.json
+++ b/sources/us/ne/butler.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/cass.json
+++ b/sources/us/ne/cass.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/cedar.json
+++ b/sources/us/ne/cedar.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/chase.json
+++ b/sources/us/ne/chase.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/cherry.json
+++ b/sources/us/ne/cherry.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/cheyenne.json
+++ b/sources/us/ne/cheyenne.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/clay.json
+++ b/sources/us/ne/clay.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/cuming.json
+++ b/sources/us/ne/cuming.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/custer.json
+++ b/sources/us/ne/custer.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/dakota.json
+++ b/sources/us/ne/dakota.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/dawes.json
+++ b/sources/us/ne/dawes.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/dawson.json
+++ b/sources/us/ne/dawson.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/deuel.json
+++ b/sources/us/ne/deuel.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/fillmore.json
+++ b/sources/us/ne/fillmore.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/franklin.json
+++ b/sources/us/ne/franklin.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/frontier.json
+++ b/sources/us/ne/frontier.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/gage.json
+++ b/sources/us/ne/gage.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/garden.json
+++ b/sources/us/ne/garden.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/garfield.json
+++ b/sources/us/ne/garfield.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/gosper.json
+++ b/sources/us/ne/gosper.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/grant.json
+++ b/sources/us/ne/grant.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/greeley.json
+++ b/sources/us/ne/greeley.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/hamilton.json
+++ b/sources/us/ne/hamilton.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/harlan.json
+++ b/sources/us/ne/harlan.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/hayes.json
+++ b/sources/us/ne/hayes.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/hitchcock.json
+++ b/sources/us/ne/hitchcock.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/holt.json
+++ b/sources/us/ne/holt.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/hooker.json
+++ b/sources/us/ne/hooker.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/howard.json
+++ b/sources/us/ne/howard.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/johnson.json
+++ b/sources/us/ne/johnson.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/kearney.json
+++ b/sources/us/ne/kearney.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/keith.json
+++ b/sources/us/ne/keith.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/keya_paha.json
+++ b/sources/us/ne/keya_paha.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/kimball.json
+++ b/sources/us/ne/kimball.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/knox.json
+++ b/sources/us/ne/knox.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/lincoln.json
+++ b/sources/us/ne/lincoln.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/logan.json
+++ b/sources/us/ne/logan.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/madison.json
+++ b/sources/us/ne/madison.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/merrick.json
+++ b/sources/us/ne/merrick.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/morrill.json
+++ b/sources/us/ne/morrill.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/nance.json
+++ b/sources/us/ne/nance.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/nemaha.json
+++ b/sources/us/ne/nemaha.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/nuckolls.json
+++ b/sources/us/ne/nuckolls.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/otoe.json
+++ b/sources/us/ne/otoe.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/pawnee.json
+++ b/sources/us/ne/pawnee.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/perkins.json
+++ b/sources/us/ne/perkins.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/phelps.json
+++ b/sources/us/ne/phelps.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/pierce.json
+++ b/sources/us/ne/pierce.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/platte.json
+++ b/sources/us/ne/platte.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/polk.json
+++ b/sources/us/ne/polk.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/red_willow.json
+++ b/sources/us/ne/red_willow.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/richardson.json
+++ b/sources/us/ne/richardson.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/rock.json
+++ b/sources/us/ne/rock.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/saline.json
+++ b/sources/us/ne/saline.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/seward.json
+++ b/sources/us/ne/seward.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/sheridan.json
+++ b/sources/us/ne/sheridan.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/sherman.json
+++ b/sources/us/ne/sherman.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/sioux.json
+++ b/sources/us/ne/sioux.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/stanton.json
+++ b/sources/us/ne/stanton.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/thayer.json
+++ b/sources/us/ne/thayer.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/thomas.json
+++ b/sources/us/ne/thomas.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/thurston.json
+++ b/sources/us/ne/thurston.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/valley.json
+++ b/sources/us/ne/valley.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/webster.json
+++ b/sources/us/ne/webster.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/ne/york.json
+++ b/sources/us/ne/york.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "PROPADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PROPADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/nm/city_of_las_cruces.json
+++ b/sources/us/nm/city_of_las_cruces.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "FULLADDR",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "FULLADDR",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "FULLADDR",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/nv/henderson.json
+++ b/sources/us/nv/henderson.json
@@ -8,9 +8,17 @@
     "license": "http://www.cityofhenderson.com/gis/disclaimer.php",
     "type": "ESRI",
     "conform": {
-        "split": "ADDRESS1",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "ADDRESS1",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "ADDRESS1",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "geojson"
     }
 }

--- a/sources/us/nv/las_vegas.json
+++ b/sources/us/nv/las_vegas.json
@@ -7,9 +7,17 @@
     "data": "http://mapdata.lasvegasnevada.gov/clvgis/rest/services/AdministrativeBoundaries/Condo_Parcels/MapServer/0",
     "type": "ESRI",
     "conform": {
-        "split": "ADDRESS1",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "ADDRESS1",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "ADDRESS1",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "geojson"
     }
 }

--- a/sources/us/ok/acog-counties.json
+++ b/sources/us/ok/acog-counties.json
@@ -7,9 +7,17 @@
     },
     "conform": {
         "type": "geojson",
-        "split": "PARCEL_ADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+          "function": "regexp",
+          "field": "PARCEL_ADDRESS",
+          "pattern": "^([0-9]+)"
+        },
+        "street": {
+          "function": "regexp",
+          "field": "PARCEL_ADDRESS",
+          "pattern": "^(?:[0-9]+ )(.*)",
+          "replace": "$1"
+        }
     },
     "attribution": "Kern, Cleveland, Canadian, Logan Counties - Association of Central Oklahoma Governments",
     "data": "http://arcgis4.roktech.net/arcgis/rest/services/ACOG/acog_query/MapServer/16",

--- a/sources/us/or/oregon_city.json
+++ b/sources/us/or/oregon_city.json
@@ -8,8 +8,16 @@
     "data": "https://webmaps.orcity.org/arcgis/rest/services/AddressPts/MapServer/0",
     "conform":{
         "type":"geojson",
-        "split": "GoldStandard.dbo.ocMap_Address_Pts_Query_as_Table.Situs_Full_Address",
-        "street": "auto_street",
-        "number": "auto_number"
+        "number": {
+            "function": "regexp",
+            "field": "GoldStandard.dbo.ocMap_Address_Pts_Query_as_Table.Situs_Full_Address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "GoldStandard.dbo.ocMap_Address_Pts_Query_as_Table.Situs_Full_Address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/pa/butler.json
+++ b/sources/us/pa/butler.json
@@ -13,9 +13,17 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "LOCATION",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "LOCATION",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "LOCATION",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "city": "MCN"
     }
 }

--- a/sources/us/pa/cambria.json
+++ b/sources/us/pa/cambria.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "SITUS_DESC_1",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "SITUS_DESC_1",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "SITUS_DESC_1",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/sc/saluda.json
+++ b/sources/us/sc/saluda.json
@@ -13,8 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "FullAddress",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "FullAddress",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "FullAddress",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/sc/sumter.json
+++ b/sources/us/sc/sumter.json
@@ -13,9 +13,17 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "O_ADDRESS",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "O_ADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "O_ADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "city": "COMMUNITY",
         "region": "STATE",
         "postcode": "ZIPCODE"

--- a/sources/us/tn/chattanooga.json
+++ b/sources/us/tn/chattanooga.json
@@ -19,9 +19,18 @@
         "srs": "EPSG:4326",
         "lon": "LONGITUDE",
         "lat": "LATITUDE",
-        "split": "ADDRESS",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "ADDRESS",
+            "pattern": "^([0-9]+)( .*)",
+            "replace": "$1"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "ADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "city": "CITY",
         "type": "csv",
         "postcode": "ZIPCODE"

--- a/sources/us/tx/houston.json
+++ b/sources/us/tx/houston.json
@@ -18,9 +18,17 @@
     "note": "Something wrong with the zip 'invalid signature', works with `unzip` though.",
     "conform": {
         "type": "shapefile-polygon",
-        "split": "LocAddr",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "LocAddr",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "LocAddr",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "postcode": "zip"
     }
 }

--- a/sources/us/va/city_of_alexandria.json
+++ b/sources/us/va/city_of_alexandria.json
@@ -13,9 +13,17 @@
     "type": "ESRI",
     "website": "https://www.alexandriava.gov/gis/info/default.aspx?id=7654",
     "conform": {
-        "split": "FULL_ADDS",
-        "street": "auto_street",
-        "number": "auto_number",
+        "street": {
+            "function": "regexp",
+            "field": "FULL_ADDS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
+        "number": {
+            "function": "regexp",
+            "field": "FULL_ADDS",
+            "pattern": "^([0-9]+)"
+        },
         "type": "geojson"
     }
 }

--- a/sources/us/va/city_of_richmond.json
+++ b/sources/us/va/city_of_richmond.json
@@ -14,9 +14,17 @@
     "compression": "zip",
     "website": "http://www.richmondgov.com/content/GIS/index.aspx",
     "conform": {
-        "split": "AddressLab",
-        "street": "auto_street",
-        "number": "auto_number",
+        "street": {
+            "function": "regexp",
+            "field": "AddressLab",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
+        "number": {
+            "function": "regexp",
+            "field": "AddressLab",
+            "pattern": "^([0-9]+)"
+        },
         "type": "shapefile",
         "postcode": "zip5"
     }

--- a/sources/us/va/city_of_staunton.json
+++ b/sources/us/va/city_of_staunton.json
@@ -14,9 +14,17 @@
     "website": "http://gis.ci.staunton.va",
     "conform": {
         "type": "geojson",
-        "split": "P_ADDRESS",
-        "street": "auto_street",
-        "number": "auto_number",
+        "street": {
+            "function": "regexp",
+            "field": "P_ADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
+        "number": {
+            "function": "regexp",
+            "field": "P_ADDRESS",
+            "pattern": "^([0-9]+)"
+        },
         "accuracy": 2
     }
 }

--- a/sources/us/va/prince_william.json
+++ b/sources/us/va/prince_william.json
@@ -13,9 +13,17 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "ADDRESS",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "ADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "ADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "city": "CITY",
         "postcode": "ZIP"
     }

--- a/sources/us/va/stafford.json
+++ b/sources/us/va/stafford.json
@@ -14,9 +14,17 @@
     "compression": "zip",
     "website": "http://staffordcountyva.gov/index.aspx?nid=1318",
     "conform": {
-        "split": "fulladd",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "fulladd",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "fulladd",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile-polygon"
     }
 }

--- a/sources/us/va/town_of_blacksburg.json
+++ b/sources/us/va/town_of_blacksburg.json
@@ -15,8 +15,16 @@
     "website": "http://www.gis.lib.vt.edu/gis_data/Blacksburg/GISPage.html",
     "conform": {
         "type": "shapefile",
-        "split": "ADDR",
-        "street": "auto_street",
-        "number": "auto_number"
+        "street": {
+            "function": "regexp",
+            "field": "ADDR",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
+        "number": {
+            "function": "regexp",
+            "field": "ADDR",
+            "pattern": "^([0-9]+)"
+        }
     }
 }

--- a/sources/us/wa/pacific.json
+++ b/sources/us/wa/pacific.json
@@ -11,9 +11,17 @@
     },
     "conform": {
         "type": "shapefile-polygon",
-        "split": "SITUS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "SITUS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "SITUS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     },
     "license": "http://www.co.pacific.wa.us/gis/DesktopGIS/WEB/index.html",
     "type": "http",

--- a/sources/us/wa/san_juan.json
+++ b/sources/us/wa/san_juan.json
@@ -12,9 +12,17 @@
     "data": "http://sjcgis.org/arcgis/rest/services/Polaris/Buildings/MapServer/0",
     "type": "ESRI",
     "conform": {
-        "split": "FULLADDR",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "FULLADDR",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "FULLADDR",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "addrtype": "BLDGTYPE",
         "type": "geojson"
     }

--- a/sources/us/wa/snohomish_county.json
+++ b/sources/us/wa/snohomish_county.json
@@ -15,9 +15,17 @@
     "type": "ftp",
     "compression": "zip",
     "conform": {
-        "split": "SITUSLINE1",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "SITUSLINE1",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "SITUSLINE1",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "type": "shapefile",
         "postcode": "SITUSZIP"
     }

--- a/sources/us/wi/dane.json
+++ b/sources/us/wi/dane.json
@@ -13,9 +13,17 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "SITEADDRESS",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "SITEADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "SITEADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "accuracy": 2
     }
 }

--- a/sources/us/wi/dane.json
+++ b/sources/us/wi/dane.json
@@ -13,17 +13,9 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "number": {
-            "function": "regexp",
-            "field": "SITEADDRESS",
-            "pattern": "^([0-9]+)"
-        },
-        "street": {
-            "function": "regexp",
-            "field": "SITEADDRESS",
-            "pattern": "^(?:[0-9]+ )(.*)",
-            "replace": "$1"
-        },
+        "split": "SITEADDRESS",
+        "number": "auto_number",
+        "street": "auto_street",
         "accuracy": 2
     }
 }

--- a/sources/us/wi/iron.json
+++ b/sources/us/wi/iron.json
@@ -14,8 +14,16 @@
     "note": "Number contains letters",
     "conform": {
         "type": "geojson",
-        "split": "ADDRESS",
-        "number": "auto_number",
-        "street": "auto_street"
+        "number": {
+            "function": "regexp",
+            "field": "ADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "ADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        }
     }
 }

--- a/sources/us/wi/pierce.json
+++ b/sources/us/wi/pierce.json
@@ -13,9 +13,17 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "ADDRESS",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "ADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "ADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "postcode": "ZIPCODE"
     }
 }

--- a/sources/us/wi/walworth.json
+++ b/sources/us/wi/walworth.json
@@ -13,9 +13,17 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "ADDRESS",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "ADDRESS",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "ADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "city": "COMMUNITY",
         "accuracy": 1
     }

--- a/sources/us/wi/waukesha.json
+++ b/sources/us/wi/waukesha.json
@@ -13,9 +13,17 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "split": "Full_Address",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": {
+            "function": "regexp",
+            "field": "Full_Address",
+            "pattern": "^([0-9]+)"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "Full_Address",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "city": "Municipality",
         "postcode": "ZipCode",
         "accuracy": 1

--- a/sources/us/wy/natrona.json
+++ b/sources/us/wy/natrona.json
@@ -14,8 +14,12 @@
     "conform": {
         "type": "geojson",
         "number": "STREET_NUM",
-        "split": "ADDRESS",
-        "street": "auto_street",
+        "street": {
+            "function": "regexp",
+            "field": "ADDRESS",
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
+        },
         "region": "STATE",
         "postcode": "ZIPCODE"
     }


### PR DESCRIPTION
maintains 4 space indentations
changes limited to lines affected
maintains newline at EOF