### PR TITLE
Update ny-statewide to remove zipcode

### DIFF
--- a/sources/us/ny/statewide.json
+++ b/sources/us/ny/statewide.json
@@ -14,7 +14,6 @@
     "conform": {
         "type": "geojson",
         "street": "CompleteStreetName",
-        "number": "AddressNumber",
-        "postcode": "ZipCode"
+        "number": "AddressNumber"
     }
 }


### PR DESCRIPTION
Updated us/ny/statewide.json to reflect the fact that the ZipCode attribute is restricted separately from the rest.

Ref: https://github.com/openaddresses/openaddresses/issues/1473