### PR TITLE
Use regexp to remove commas from Virginia postalcodes

### DIFF
--- a/sources/us/va/statewide.json
+++ b/sources/us/va/statewide.json
@@ -30,7 +30,7 @@
         "postcode": {
           "function": "regexp",
           "field": "ZIP_5",
-          "pattern": "(\d+),(\d+)",
+          "pattern": "([0-9]{2}),([0-9]{3})",
           "replace": "$1$2"
         }
     }

--- a/sources/us/va/statewide.json
+++ b/sources/us/va/statewide.json
@@ -27,6 +27,11 @@
         "city": "PO_NAME",
         "district": "MUNICIPALITY",
         "region": "STATE",
-        "postcode": "ZIP_5"
+        "postcode": {
+          "function": "regexp",
+          "field": "ZIP_5",
+          "pattern": "(\d+),(\d+)",
+          "replace": "$1$2"
+        }
     }
 }


### PR DESCRIPTION
The dataset for statewide addresses in Virginia has commas in the
postalcodes:

    julian@julian-mapzen ~/data $ head VA_SiteAddress.txt
    SITEADDID,ADDPTKEY,PREADDRNUM,ADDRNUM,ADDRNUMSUF,UNITTYPE,UNITID,STREET_PREMOD,STREET_PREFIX,STREET_PRE_TYPE,STREET_NAME,STREET_TYPE,STREET_SUFFIX,FULLNAME,FULLADDR,PLACENAME,FIPS,MUNICIPALITY,ESN,PSAP,MSAG_COMMUNITY,USNGCOORD,LAT,LONG,ADDRCLASS,POINTTYPE,CAPTUREMETH,STATUS,LASTUPDATE,PO_NAME,STATE,ZIP_5
    "3,465,572.000000000000000",1067259433883520,,393,,,,,,,POPLAR,LN,,POPLAR LN,393 POPLAR LN,,51077,Grayson County,834,7215,INDEPENDENCE,17SMA7669750099,36.596097285069824,-81.260533627271982,0,,,CURRENT,3/10/2015 0:00:00,INDEPENDENCE,VA,"24,348"
    "3,465,573.000000000000000",1066979633883330,,925,,,,,,,ORCHID,LN,,ORCHID LN,925 ORCHID LN,,51077,Grayson County,834,7215,INDEPENDENCE,17SMA7584550071,36.595820020122453,-81.270059262886406,0,,,CURRENT,3/10/2015 0:00:00,INDEPENDENCE,VA,"24,348"
    "3,465,662.000000000000000",1066913933881390,,1032,,,,,,,ORCHID,LN,,ORCHID LN,1032 ORCHID LN,,51077,Grayson County,834,7215,INDEPENDENCE,17SMA7564650006,36.595234439288944,-81.272277116445053,0,,,CURRENT,3/10/2015 0:00:00,INDEPENDENCE,VA,"24,348"
    "3,465,663.000000000000000",1067290733881350,,327,,,,,,,POPLAR,LN,,POPLAR LN,327 POPLAR LN,,51077,Grayson County,834,7215,INDEPENDENCE,17SMA7679450036,36.595526683766820,-81.259445310649781,0,,,CURRENT,3/10/2015 0:00:00,INDEPENDENCE,VA,"24,348"
    "3,465,974.000000000000000",1067814233891600,,1712,,,,,,,BRIDLE CREEK,RD,,BRIDLE CREEK RD,1712 BRIDLE CREEK RD,,51077,Grayson County,834,7215,INDEPENDENCE,17SMA7838050390,36.598759593400729,-81.241724126493779,0,,,CURRENT,3/10/2015 0:00:00,INDEPENDENCE,VA,"24,348"
    "3,465,977.000000000000000",1067337533890290,,98,,,,,,,POPLAR,LN,,POPLAR LN,98 POPLAR LN,,51077,Grayson County,834,7215,INDEPENDENCE,17SMA7692950312,36.598018616243870,-81.257942201985429,0,,,CURRENT,3/10/2015 0:00:00,INDEPENDENCE,VA,"24,348"
    "3,465,986.000000000000000",1067304333886780,,214,,,,,,,POPLAR,LN,,POPLAR LN,214 POPLAR LN,,51077,Grayson County,834,7215,INDEPENDENCE,17SMA7683150202,36.597028363878259,-81.259036313231931,0,,,CURRENT,3/10/2015 0:00:00,INDEPENDENCE,VA,"24,348"
    "3,465,990.000000000000000",1066996933885990,,865,,,,,,,ORCHID,LN,,ORCHID LN,865 ORCHID LN,,51077,Grayson County,834,7215,INDEPENDENCE,17SMA7589550153,36.596564238985451,-81.269496818095377,0,,,CURRENT,3/10/2015 0:00:00,INDEPENDENCE,VA,"24,348"
    "3,465,992.000000000000000",1066982433882610,,935,,,,,,,ORCHID,LN,,ORCHID LN,935 ORCHID LN,,51077,Grayson County,834,7215,INDEPENDENCE,17SMA7585450049,36.595624582517097,-81.269957755830291,0,,,CURRENT,3/10/2015 0:00:00,INDEPENDENCE,VA,"24,348"

This is a bit hacky, but using a regexp to match digits before and after
the comma allows us to remove them.