### PR TITLE
fixed a number of us/ia sources to include:

### DIFF
--- a/sources/us/ia/benton.json
+++ b/sources/us/ia/benton.json
@@ -28,9 +28,19 @@
         "street": {
             "function": "regexp",
             "field": "address",
-            "pattern": "^(?:[0-9]+ )(.*)",
+            "pattern": "^(?:[0-9]+ )(.*)( (Unit|Apt) [0-9A-Za-z])?$",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/boone.json
+++ b/sources/us/ia/boone.json
@@ -27,9 +27,19 @@
         "street": {
             "function": "regexp",
             "field": "address",
-            "pattern": "^(?:[0-9]+ )(.*)",
+            "pattern": "^(?:[0-9]+ )(.*)( (Unit|Apt) [0-9])?$",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/bremer.json
+++ b/sources/us/ia/bremer.json
@@ -27,9 +27,19 @@
         "street": {
             "function": "regexp",
             "field": "address",
-            "pattern": "^(?:[0-9]+ )(.*)",
+            "pattern": "^(?:[0-9]+ )(.*)( (Unit|Apt) [0-9A-Za-z])?$",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/buchanan.json
+++ b/sources/us/ia/buchanan.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/buena_vista.json
+++ b/sources/us/ia/buena_vista.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/calhoun.json
+++ b/sources/us/ia/calhoun.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/carroll.json
+++ b/sources/us/ia/carroll.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/cass.json
+++ b/sources/us/ia/cass.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/cherokee.json
+++ b/sources/us/ia/cherokee.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/clarke.json
+++ b/sources/us/ia/clarke.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/clarke_county.json
+++ b/sources/us/ia/clarke_county.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/clay.json
+++ b/sources/us/ia/clay.json
@@ -30,6 +30,12 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
         "city": " POSTAL_COM",
         "district": "COUNTY",
         "region": "STATE",

--- a/sources/us/ia/crawford.json
+++ b/sources/us/ia/crawford.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/dallas.json
+++ b/sources/us/ia/dallas.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/decatur.json
+++ b/sources/us/ia/decatur.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/delaware.json
+++ b/sources/us/ia/delaware.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/dickinson.json
+++ b/sources/us/ia/dickinson.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/emmet.json
+++ b/sources/us/ia/emmet.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/franklin.json
+++ b/sources/us/ia/franklin.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/fremont.json
+++ b/sources/us/ia/fremont.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/greene.json
+++ b/sources/us/ia/greene.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/guthrie.json
+++ b/sources/us/ia/guthrie.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/hamilton.json
+++ b/sources/us/ia/hamilton.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/hardin.json
+++ b/sources/us/ia/hardin.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/harrison.json
+++ b/sources/us/ia/harrison.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/howard.json
+++ b/sources/us/ia/howard.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/humboldt.json
+++ b/sources/us/ia/humboldt.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/ida.json
+++ b/sources/us/ia/ida.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/jasper.json
+++ b/sources/us/ia/jasper.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/kossuth.json
+++ b/sources/us/ia/kossuth.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/linn.json
+++ b/sources/us/ia/linn.json
@@ -23,6 +23,10 @@
             "SUFTYPE",
             "SUFDIR"
         ],
+        "unit": [
+            "UNITTYPE",
+            "UNITNO"
+        ],
         "postcode": "ZIP",
         "city": "CITY"
     }

--- a/sources/us/ia/linn_alt.json
+++ b/sources/us/ia/linn_alt.json
@@ -24,6 +24,7 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": "UnitNo",
         "city": "city",
         "id": "GPN"
     },

--- a/sources/us/ia/lucas.json
+++ b/sources/us/ia/lucas.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/lyon.json
+++ b/sources/us/ia/lyon.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/madison.json
+++ b/sources/us/ia/madison.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/marion.json
+++ b/sources/us/ia/marion.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/marshall.json
+++ b/sources/us/ia/marshall.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/mills.json
+++ b/sources/us/ia/mills.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/monona.json
+++ b/sources/us/ia/monona.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/monroe.json
+++ b/sources/us/ia/monroe.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/montgomery.json
+++ b/sources/us/ia/montgomery.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/palo_alto.json
+++ b/sources/us/ia/palo_alto.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/pocahontas.json
+++ b/sources/us/ia/pocahontas.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/pottawattamie.json
+++ b/sources/us/ia/pottawattamie.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/sac.json
+++ b/sources/us/ia/sac.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/shelby.json
+++ b/sources/us/ia/shelby.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/sioux.json
+++ b/sources/us/ia/sioux.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/sioux_county.json
+++ b/sources/us/ia/sioux_county.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/story.json
+++ b/sources/us/ia/story.json
@@ -30,6 +30,12 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
         "city": " POSTAL_COM",
         "district": "COUNTY",
         "region": "STATE",

--- a/sources/us/ia/webster.json
+++ b/sources/us/ia/webster.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/winnebago.json
+++ b/sources/us/ia/winnebago.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/winneshiek.json
+++ b/sources/us/ia/winneshiek.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }

--- a/sources/us/ia/wright.json
+++ b/sources/us/ia/wright.json
@@ -30,6 +30,16 @@
             "pattern": "^(?:[0-9]+ )(.*)",
             "replace": "$1"
         },
+        "unit": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
+            "replace": "$1"
+        },
+        "city": "POSTAL_COM",
+        "district": "COUNTY",
+        "region": "STATE",
+        "postcode": "ZIP_CODE",
         "type": "shapefile"
     }
 }


### PR DESCRIPTION
- unit types/ids
- correct street fields
- city/state/postcodes, where available

All FTP-hosted data sources appear to be the same format so this was a copy/paste job after the first few.

Unit is not identified as a unique field so I used some regexes to pull out the unit type/id.