### PR TITLE
Swap out "better" city field.

### DIFF
--- a/sources/us/mn/ramsey.json
+++ b/sources/us/mn/ramsey.json
@@ -14,7 +14,7 @@
         "number": "ANUMBER",
         "street": ["StreetPreModifier", "StreetPrefixDirectional", "StreetPreType","ST_NAME","StreetPostType","StreetPostDirectional","StreetPostModifier"],
         "unit": ["SubType1","SubNumber1"],
-        "city": "CityCode",
+        "city": "PostalCity",
         "postcode": "ZIP",
         "notes": "Comments"
     },


### PR DESCRIPTION
Actual "situs" city is delivered in "city": "CityCode", field with a coded value domain. Those domain values are available via https://maps.co.ramsey.mn.us/arcgis/rest/services/AddressEditor/AddressPointsAll/MapServer/0?f=pjson - just parse the result for fields[15].domain.codedValues. But I don't know how to wire that up here, so I'm swapping out Postal City, which is better than a coded value which means almost nothing to the human eye.