### PR TITLE
Update washington.json

### DIFF
--- a/sources/us/mn/washington.json
+++ b/sources/us/mn/washington.json
@@ -21,7 +21,7 @@
             "STREETTYPE",
             "SUFFIX_DIR"
         ],
-        "city": "CITY",
+        "city": "CITY_USPS",
         "postcode": "ZIP"
     }
 }


### PR DESCRIPTION
While the "USPS city" might not always be the actual situs city, in this service it is a better choice, because the "City" field says things like "City of Woodbury". Which is how nobody refers to it. 106K records are not null in that field.