### PR TITLE
Update ramsey.json

### DIFF
--- a/sources/us/mn/ramsey.json
+++ b/sources/us/mn/ramsey.json
@@ -14,7 +14,7 @@
         "number": "ANUMBER",
         "street": ["StreetPreModifier", "StreetPrefixDirectional", "StreetPreType","ST_NAME","StreetPostType","StreetPostDirectional","StreetPostModifier"],
         "unit": ["SubType1","SubNumber1"],
-        "city": "CityCode",
+        "city": "PostalCity",
         "postcode": "ZIP",
         "notes": "Comments"
     },

--- a/sources/us/mn/ramsey.json
+++ b/sources/us/mn/ramsey.json
@@ -16,6 +16,7 @@
         "unit": ["SubType1","SubNumber1"],
         "city": "PostalCity",
         "postcode": "ZIP",
+        "district": "CO_NAME",
         "notes": "Comments"
     },
     "license": {


### PR DESCRIPTION
PostalCity, while not a "situs address city" but more like a "mailing address city", seems a better choice for this service, because the CityCode makes use of a coded value domain. In other words, a human-readable city doesn't come across, instead a numeric code. This change resolves that, although the "city" listed will often be for bulk-mailing purposes, not the actual city.