### PR TITLE
Support for several language versions of addresses

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -279,7 +279,7 @@ Additional metadata helps future proof the project!
 `note`        | A String containing a human readable note.
 `attribution` | **Deprecated:** Where the license requires attribution, add it here. example `CC-BY United Federation of Planets`
 `email`       | This email is used to send automated emails to the data provider if a user changes their data. Do not set unless the data provider wants to receive updates.
-`language`    | ISO 639-1 code for the language of the data. For example, `en`, `fr` or `de`.
+`language`    | ISO 639-1 code for the language of the data. For example: `en`, `fr` or `de`.
 
 #### Example
 
@@ -294,6 +294,7 @@ Additional metadata helps future proof the project!
     "license": {"url": "http://geonb.snb.ca/downloads/documents/geonb_license_e.pdf"},
     "type": "http",
     "compression": "zip",
+    "language": "en",
     "conform": {
         "number": "civic_num",
         "street": "street_nam",
@@ -303,15 +304,16 @@ Additional metadata helps future proof the project!
 }
 ```
 
-### Language:
+### Language
 
 Names of places, cities, addresses etc. are often translated to various languages. For example: Munich, Bavaria, Germany
 vs. München, Bayern, Deutschland. The optional `language` tag defines, which language is in use in the metadata entry.
 A data source usually includes addresses in a single language (e.g. Montreal in Canada contains only French names).
 Some data sources can define several translations of address components under appropriate csv column labels. For example,
 Brussels in Belgium has both Dutch and French names. Such a bilingual data source can be linked to OpenAddresses
-with two separate metadata entries, one for reading the French addresses and one for reading the Dutch addresses. An application,
-which uses OpenAddresses and wishes to generate multilingual address entries, can access the data via both metadata entries
+with two separate metadata entries, one for reading the [French addresses](https://github.com/openaddresses/openaddresses/blob/master/sources/be/wa/brussels-fr.json)
+and one for reading the [Dutch addresses](https://github.com/openaddresses/openaddresses/blob/master/sources/be/wa/brussels-nl.json).
+An application,which uses OpenAddresses and wishes to generate multilingual address entries, can access the data via both metadata entries
 and merge the language versions by identifying the address items by their `id` unique identifier tag.
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -279,6 +279,7 @@ Additional metadata helps future proof the project!
 `note`        | A String containing a human readable note.
 `attribution` | **Deprecated:** Where the license requires attribution, add it here. example `CC-BY United Federation of Planets`
 `email`       | This email is used to send automated emails to the data provider if a user changes their data. Do not set unless the data provider wants to receive updates.
+`language`    | ISO 639-1 code for the language of the data. For example, `en`, `fr` or `de`.
 
 #### Example
 
@@ -302,6 +303,18 @@ Additional metadata helps future proof the project!
 }
 ```
 
+### Language:
+
+Names of places, cities, addresses etc. are often translated to various languages. For example: Munich, Bavaria, Germany
+vs. München, Bayern, Deutschland. The optional `language` tag defines, which language is in use in the metadata entry.
+A data source usually includes addresses in a single language (e.g. Montreal in Canada contains only French names).
+Some data sources can define several translations of address components under appropriate csv column labels. For example,
+Brussels in Belgium has both Dutch and French names. Such a bilingual data source can be linked to OpenAddresses
+with two separate metadata entries, one for reading the French addresses and one for reading the Dutch addresses. An application,
+which uses OpenAddresses and wishes to generate multilingual address entries, can access the data via both metadata entries
+and merge the language versions by identifying the address items by their `id` unique identifier tag.
+
+
 ### Formatting:
 
 A few notes on formatting:
@@ -313,3 +326,4 @@ A few notes on formatting:
 
 Although these are read by a machine, they are maintained by us mortals.
 Following the formatting guidelines keeps the rest of us sane!
+

--- a/sources/be/wa/brussels-fr.json
+++ b/sources/be/wa/brussels-fr.json
@@ -3,6 +3,7 @@
     "data": "http://data.openaddresses.io/cache/be-wa-brussels-4326.zip",
     "website": "http://bric.brussels/",
     "compression": "zip",
+    "language": "fr",
     "coverage": {
         "country": "be",
         "state": "Wallonia",
@@ -12,6 +13,7 @@
     "conform": {
         "number": "ADRN",
         "type": "shapefile",
+        "city":  "MU_NAME_FR",
         "street": "PW_NAME_FR"
     }
 }

--- a/sources/be/wa/brussels-nl.json
+++ b/sources/be/wa/brussels-nl.json
@@ -3,6 +3,7 @@
     "data": "http://data.openaddresses.io/cache/be-wa-brussels-4326.zip",
     "website": "http://bric.brussels/",
     "compression": "zip",
+    "language": "nl",
     "coverage": {
         "country": "be",
         "state": "Wallonia",
@@ -12,6 +13,7 @@
     "conform": {
         "number": "ADRN",
         "type": "shapefile",
+        "city":  "MU_NAME_DU",
         "street": "PW_NAME_DU"
     }
 }

--- a/sources/fi/18/helsinki-sv.json
+++ b/sources/fi/18/helsinki-sv.json
@@ -4,7 +4,7 @@
     "website": "http://ptp.hel.fi/avoindata/",
     "type": "http",
     "data": "http://ptp.hel.fi/avoindata/aineistot/Paakaupunkiseudun_osoiteluettelo.zip",
-    "language": "fi",
+    "language": "sv",
     "coverage": {
         "state": "FI-18",
         "country": "fi",
@@ -29,8 +29,8 @@
             "fields": ["osoitenumero", "kiinteiston_jakokirjain"],
             "separator": ""
         },
-        "street": "katunimi",
-        "city": "kaupunki",
+        "street": "gatan",
+        "city": "staden",
         "type": "csv",
         "accuracy": 1
     }

--- a/test/sources.js
+++ b/test/sources.js
@@ -50,7 +50,7 @@ function checkSource(i){
                 'data', 'type', 'coverage', 'coverage', 'conform', 'compression',
                 
                 // https://github.com/openaddresses/openaddresses/blob/master/CONTRIBUTING.md#optional-tags
-                'website', 'license', 'note', 'attribution', 'email',
+                'website', 'license', 'note', 'attribution', 'email', 'language',
                 
                 // Not documented, but works
                 'year', 'skip'


### PR DESCRIPTION
Added the guidelines how to handle address translations to several languages. Two example cases, Brussels  and Helsinki, updated to demonstrate how to use the new language tag.
