### PR TITLE
Make field names all-caps in us/dc/statewide.json

### DIFF
--- a/sources/us/dc/statewide.json
+++ b/sources/us/dc/statewide.json
@@ -13,14 +13,14 @@
     "license": "http://data.dc.gov/TermsOfUse.aspx",
     "type": "ESRI",
     "conform": {
-        "number": ["addrnum","addrnumsuffix"],
+        "number": ["ADDRNUM","ADDRNUMSUFFIX"],
         "street": [
-            "stname",
-            "street_type",
-            "quadrant"
+            "STNAME",
+            "STREET_TYPE",
+            "QUADRANT"
         ],
         "type": "geojson",
-        "city": "city",
-        "postcode": "zipcode"
+        "city": "CITY",
+        "postcode": "ZIPCODE"
     }
 }


### PR DESCRIPTION
Fields other than geo-coordinates were not present in OA dataset for us/dc/statewide. It appears this issue was due to lowercasing of the field names. Made upper-case as per the field dictionary at http://maps2.dcgis.dc.gov/dcgis/rest/services/DCGIS_DATA/Location_WebMercator/MapServer/0

Fixes #1615