### PR TITLE
Update anoka.json with all caps field names

### DIFF
--- a/sources/us/mn/anoka.json
+++ b/sources/us/mn/anoka.json
@@ -12,17 +12,17 @@
     "data": "http://gisservices.co.anoka.mn.us/anoka_gis/rest/services/Address_Pts/MapServer/0",
     "type": "ESRI",
     "conform": {
-        "number": "loc_numb",
+        "number": "LOC_NUMB",
         "street": [
             "LOC_PREFIX",
-            "loc_name",
-            "loc_type",
+            "LOC_NAME",
+            "LOC_TYPE",
             "LOC_SUFFIX"
         ],
         "unit": "LOC_UNIT",
         "city": "LOC_CITY",
         "region": "LOC_STATE",
         "type": "geojson",
-        "postcode": "loc_zip"
+        "postcode": "LOC_ZIP"
     }
 }


### PR DESCRIPTION
Looking at this REST endpoint and the resulting download here in OA, it looks to me like the REST query is case sensitive for the column names. The download appears successful for the column names where all caps was used, so I'm suggesting using all caps in all the column names.