### PR TITLE
Updated US/AR with new column names

### DIFF
--- a/sources/us/ar/statewide.json
+++ b/sources/us/ar/statewide.json
@@ -16,16 +16,16 @@
         "type": "shapefile",
         "number": [
           "ADR_NUM",
-          "ADR_NUMSUF"
+          "ADR_NUM_SU"
         ],
         "street": "PSTR_FULNA",
         "unit": [
-          "ADR_UNITTY",
-          "ADR_UNITID"
+          "ADR_UNIT_T",
+          "ADR_UNIT_I"
         ],
         "city": "ADR_CITY",
         "district": "CNTY_NAME",
         "region": "ADR_STATE",
-        "postcode": "adr_zip5"
+        "postcode": "ADR_ZIP5"
     }
 }


### PR DESCRIPTION
“PSTR_FULNA ” is actually okay, but [the log](http://s3.amazonaws.com/data.openaddresses.io/runs/87439/output.txt) shows some other column name errors. Closes https://github.com/openaddresses/openaddresses/issues/1726.