### PR TITLE
updated Manatee County, FL, USA to use addresses over parcels

### DIFF
--- a/sources/us/fl/manatee.json
+++ b/sources/us/fl/manatee.json
@@ -10,7 +10,7 @@
         "county": "Manatee"
     },
     "attribution": "Manatee County",
-    "data": "http://www.mymanatee.org/gisapps/data/shape/parcels.zip",
+    "data": "http://www.mymanatee.org/gisapps/data/shape/ADDRESS.zip",
     "website": "http://www.mymanatee.org/home/government/departments/information-technology/gis-home/gis-datadownload.html",
     "license": {
         "text": "Public Domain",
@@ -20,16 +20,18 @@
     "type": "http",
     "compression": "zip",
     "conform": {
-        "number": "PROP_HN",
-        "street": [
-          "PROP_SN",
-          "PROP_ST1",
-          "PROP_ST2",
-          "PROP_DIR"
-        ],
-        "unit": "UNIT",
-        "city": "PROP_CITYN",
         "type": "shapefile-polygon",
-        "postcode": "prop_zip"
+        "number": "ST_NUM",
+        "street": [
+          "SDIRPRE",
+          "SFEANME",
+          "SFEATYP",
+          "SDIRSUF"
+        ],
+        "unit": "LV_APT",
+        "city": "POSTAL_COM",
+        "district": "COUNTY_NAM",
+        "region": "STATE",
+        "postcode": "ZIP"
     }
 }


### PR DESCRIPTION
Fixed #1618 

While the old parcels.zip file has more rows, it contains a lot of blank and `0` house numbers:

```
admins-MacBook-Pro-8% awk -F ',' '{ if ($3 == "" || $3 == "0") print $0 }' manatee.csv | wc -l
17166
```

whereas the new ADDRESS.zip only has 1 blank or `0` house number.  Instead of 226738-17166=209572 valid entries from parcels, there are 217742-1=217741 valid entries from addresses.  