### PR TITLE
Generate a proper unique id for Finnish metadata entries 

### DIFF
--- a/sources/fi/ahvenanmaa-fi.json
+++ b/sources/fi/ahvenanmaa-fi.json
@@ -29,7 +29,11 @@
         "number": "COLUMN10",
         "lat": "COLUMN5",
         "lon": "COLUMN6",
-        "id": "COLUMN1",
+        "id": {
+            "function": "join",
+            "fields": ["COLUMN1","COLUMN7"],
+            "separator": "-"
+        },
         "postcode": "COLUMN11",
         "type": "csv",
         "accuracy": 1

--- a/sources/fi/ahvenanmaa-sv.json
+++ b/sources/fi/ahvenanmaa-sv.json
@@ -29,7 +29,11 @@
         "number": "COLUMN10",
         "lat": "COLUMN5",
         "lon": "COLUMN6",
-        "id": "COLUMN1",
+        "id": {
+            "function": "join",
+            "fields": ["COLUMN1","COLUMN7"],
+            "separator": "-"
+        },
         "postcode": "COLUMN11",
         "type": "csv",
         "accuracy": 1

--- a/sources/fi/etelä-karjala-fi.json
+++ b/sources/fi/etelä-karjala-fi.json
@@ -28,7 +28,11 @@
         "number": "COLUMN10",
         "lat": "COLUMN5",
         "lon": "COLUMN6",
-        "id": "COLUMN1",
+        "id": {
+            "function": "join",
+            "fields": ["COLUMN1","COLUMN7"],
+            "separator": "-"
+        },
         "postcode": "COLUMN11",
         "type": "csv",
         "accuracy": 1

--- a/sources/fi/etelä-karjala-sv.json
+++ b/sources/fi/etelä-karjala-sv.json
@@ -28,7 +28,11 @@
         "number": "COLUMN10",
         "lat": "COLUMN5",
         "lon": "COLUMN6",
-        "id": "COLUMN1",
+        "id": {
+            "function": "join",
+            "fields": ["COLUMN1","COLUMN7"],
+            "separator": "-"
+        },
         "postcode": "COLUMN11",
         "type": "csv",
         "accuracy": 1

--- a/sources/fi/etelä-pohjanmaa-fi.json
+++ b/sources/fi/etelä-pohjanmaa-fi.json
@@ -28,7 +28,11 @@
         "number": "COLUMN10",
         "lat": "COLUMN5",
         "lon": "COLUMN6",
-        "id": "COLUMN1",
+        "id": {
+            "function": "join",
+            "fields": ["COLUMN1","COLUMN7"],
+            "separator": "-"
+        },
         "postcode": "COLUMN11",
         "type": "csv",
         "accuracy": 1

--- a/sources/fi/etelä-pohjanmaa-sv.json
+++ b/sources/fi/etelä-pohjanmaa-sv.json
@@ -28,7 +28,11 @@
         "number": "COLUMN10",
         "lat": "COLUMN5",
         "lon": "COLUMN6",
-        "id": "COLUMN1",
+        "id": {
+            "function": "join",
+            "fields": ["COLUMN1","COLUMN7"],
+            "separator": "-"
+        },
         "postcode": "COLUMN11",
         "type": "csv",
         "accuracy": 1

--- a/sources/fi/etelä-savo-fi.json
+++ b/sources/fi/etelä-savo-fi.json
@@ -28,7 +28,11 @@
         "number": "COLUMN10",
         "lat": "COLUMN5",
         "lon": "COLUMN6",
-        "id": "COLUMN1",
+        "id": {
+            "function": "join",
+            "fields": ["COLUMN1","COLUMN7"],
+            "separator": "-"
+        },
         "postcode": "COLUMN11",
         "type": "csv",
         "accuracy": 1

--- a/sources/fi/etelä-savo-sv.json
+++ b/sources/fi/etelä-savo-sv.json
@@ -28,7 +28,11 @@
         "number": "COLUMN10",
         "lat": "COLUMN5",
         "lon": "COLUMN6",
-        "id": "COLUMN1",
+        "id": {
+            "function": "join",
+            "fields": ["COLUMN1","COLUMN7"],
+            "separator": "-"
+        },
         "postcode": "COLUMN11",
         "type": "csv",
         "accuracy": 1

--- a/sources/fi/kainuu-fi.json
+++ b/sources/fi/kainuu-fi.json
@@ -28,7 +28,11 @@
         "number": "COLUMN10",
         "lat": "COLUMN5",
         "lon": "COLUMN6",
-        "id": "COLUMN1",
+        "id": {
+            "function": "join",
+            "fields": ["COLUMN1","COLUMN7"],
+            "separator": "-"
+        },
         "postcode": "COLUMN11",
         "type": "csv",
         "accuracy": 1

--- a/sources/fi/kainuu-sv.json
+++ b/sources/fi/kainuu-sv.json
@@ -28,7 +28,11 @@
         "number": "COLUMN10",
         "lat": "COLUMN5",
         "lon": "COLUMN6",
-        "id": "COLUMN1",
+        "id": {
+            "function": "join",
+            "fields": ["COLUMN1","COLUMN7"],
+            "separator": "-"
+        },
         "postcode": "COLUMN11",
         "type": "csv",
         "accuracy": 1

--- a/sources/fi/kanta-häme-fi.json
+++ b/sources/fi/kanta-häme-fi.json
@@ -28,7 +28,11 @@
         "number": "COLUMN10",
         "lat": "COLUMN5",
         "lon": "COLUMN6",
-        "id": "COLUMN1",
+        "id": {
+            "function": "join",
+            "fields": ["COLUMN1","COLUMN7"],
+            "separator": "-"
+        },
         "postcode": "COLUMN11",
         "type": "csv",
         "accuracy": 1

--- a/sources/fi/kanta-häme-sv.json
+++ b/sources/fi/kanta-häme-sv.json
@@ -28,7 +28,11 @@
         "number": "COLUMN10",
         "lat": "COLUMN5",
         "lon": "COLUMN6",
-        "id": "COLUMN1",
+        "id": {
+            "function": "join",
+            "fields": ["COLUMN1","COLUMN7"],
+            "separator": "-"
+        },
         "postcode": "COLUMN11",
         "type": "csv",
         "accuracy": 1

--- a/sources/fi/keski-pohjanmaa-fi.json
+++ b/sources/fi/keski-pohjanmaa-fi.json
@@ -28,7 +28,11 @@
         "number": "COLUMN10",
         "lat": "COLUMN5",
         "lon": "COLUMN6",
-        "id": "COLUMN1",
+        "id": {
+            "function": "join",
+            "fields": ["COLUMN1","COLUMN7"],
+            "separator": "-"
+        },
         "postcode": "COLUMN11",
         "type": "csv",
         "accuracy": 1

--- a/sources/fi/keski-pohjanmaa-sv.json
+++ b/sources/fi/keski-pohjanmaa-sv.json
@@ -28,7 +28,11 @@
         "number": "COLUMN10",
         "lat": "COLUMN5",
         "lon": "COLUMN6",
-        "id": "COLUMN1",
+        "id": {
+            "function": "join",
+            "fields": ["COLUMN1","COLUMN7"],
+            "separator": "-"
+        },
         "postcode": "COLUMN11",
         "type": "csv",
         "accuracy": 1

--- a/sources/fi/keski-suomi-fi.json
+++ b/sources/fi/keski-suomi-fi.json
@@ -28,7 +28,11 @@
         "number": "COLUMN10",
         "lat": "COLUMN5",
         "lon": "COLUMN6",
-        "id": "COLUMN1",
+        "id": {
+            "function": "join",
+            "fields": ["COLUMN1","COLUMN7"],
+            "separator": "-"
+        },
         "postcode": "COLUMN11",
         "type": "csv",
         "accuracy": 1

--- a/sources/fi/keski-suomi-sv.json
+++ b/sources/fi/keski-suomi-sv.json
@@ -28,7 +28,11 @@
         "number": "COLUMN10",
         "lat": "COLUMN5",
         "lon": "COLUMN6",
-        "id": "COLUMN1",
+        "id": {
+            "function": "join",
+            "fields": ["COLUMN1","COLUMN7"],
+            "separator": "-"
+        },
         "postcode": "COLUMN11",
         "type": "csv",
         "accuracy": 1

--- a/sources/fi/kymeenlaakso-fi.json
+++ b/sources/fi/kymeenlaakso-fi.json
@@ -28,7 +28,11 @@
         "number": "COLUMN10",
         "lat": "COLUMN5",
         "lon": "COLUMN6",
-        "id": "COLUMN1",
+        "id": {
+            "function": "join",
+            "fields": ["COLUMN1","COLUMN7"],
+            "separator": "-"
+        },
         "postcode": "COLUMN11",
         "type": "csv",
         "accuracy": 1

--- a/sources/fi/kymeenlaakso-sv.json
+++ b/sources/fi/kymeenlaakso-sv.json
@@ -28,7 +28,11 @@
         "number": "COLUMN10",
         "lat": "COLUMN5",
         "lon": "COLUMN6",
-        "id": "COLUMN1",
+        "id": {
+            "function": "join",
+            "fields": ["COLUMN1","COLUMN7"],
+            "separator": "-"
+        },
         "postcode": "COLUMN11",
         "type": "csv",
         "accuracy": 1

--- a/sources/fi/lappi-fi.json
+++ b/sources/fi/lappi-fi.json
@@ -28,7 +28,11 @@
         "number": "COLUMN10",
         "lat": "COLUMN5",
         "lon": "COLUMN6",
-        "id": "COLUMN1",
+        "id": {
+            "function": "join",
+            "fields": ["COLUMN1","COLUMN7"],
+            "separator": "-"
+        },
         "postcode": "COLUMN11",
         "type": "csv",
         "accuracy": 1

--- a/sources/fi/lappi-sv.json
+++ b/sources/fi/lappi-sv.json
@@ -28,7 +28,11 @@
         "number": "COLUMN10",
         "lat": "COLUMN5",
         "lon": "COLUMN6",
-        "id": "COLUMN1",
+        "id": {
+            "function": "join",
+            "fields": ["COLUMN1","COLUMN7"],
+            "separator": "-"
+        },
         "postcode": "COLUMN11",
         "type": "csv",
         "accuracy": 1

--- a/sources/fi/pirkanmaa-fi.json
+++ b/sources/fi/pirkanmaa-fi.json
@@ -28,7 +28,11 @@
         "number": "COLUMN10",
         "lat": "COLUMN5",
         "lon": "COLUMN6",
-        "id": "COLUMN1",
+        "id": {
+            "function": "join",
+            "fields": ["COLUMN1","COLUMN7"],
+            "separator": "-"
+        },
         "postcode": "COLUMN11",
         "type": "csv",
         "accuracy": 1

--- a/sources/fi/pirkanmaa-sv.json
+++ b/sources/fi/pirkanmaa-sv.json
@@ -28,7 +28,11 @@
         "number": "COLUMN10",
         "lat": "COLUMN5",
         "lon": "COLUMN6",
-        "id": "COLUMN1",
+        "id": {
+            "function": "join",
+            "fields": ["COLUMN1","COLUMN7"],
+            "separator": "-"
+        },
         "postcode": "COLUMN11",
         "type": "csv",
         "accuracy": 1

--- a/sources/fi/pohjanmaa-fi.json
+++ b/sources/fi/pohjanmaa-fi.json
@@ -28,7 +28,11 @@
         "number": "COLUMN10",
         "lat": "COLUMN5",
         "lon": "COLUMN6",
-        "id": "COLUMN1",
+        "id": {
+            "function": "join",
+            "fields": ["COLUMN1","COLUMN7"],
+            "separator": "-"
+        },
         "postcode": "COLUMN11",
         "type": "csv",
         "accuracy": 1

--- a/sources/fi/pohjanmaa-sv.json
+++ b/sources/fi/pohjanmaa-sv.json
@@ -28,7 +28,11 @@
         "number": "COLUMN10",
         "lat": "COLUMN5",
         "lon": "COLUMN6",
-        "id": "COLUMN1",
+        "id": {
+            "function": "join",
+            "fields": ["COLUMN1","COLUMN7"],
+            "separator": "-"
+        },
         "postcode": "COLUMN11",
         "type": "csv",
         "accuracy": 1

--- a/sources/fi/pohjois-karjala-fi.json
+++ b/sources/fi/pohjois-karjala-fi.json
@@ -28,7 +28,11 @@
         "number": "COLUMN10",
         "lat": "COLUMN5",
         "lon": "COLUMN6",
-        "id": "COLUMN1",
+        "id": {
+            "function": "join",
+            "fields": ["COLUMN1","COLUMN7"],
+            "separator": "-"
+        },
         "postcode": "COLUMN11",
         "type": "csv",
         "accuracy": 1

--- a/sources/fi/pohjois-karjala-sv.json
+++ b/sources/fi/pohjois-karjala-sv.json
@@ -28,7 +28,11 @@
         "number": "COLUMN10",
         "lat": "COLUMN5",
         "lon": "COLUMN6",
-        "id": "COLUMN1",
+        "id": {
+            "function": "join",
+            "fields": ["COLUMN1","COLUMN7"],
+            "separator": "-"
+        },
         "postcode": "COLUMN11",
         "type": "csv",
         "accuracy": 1

--- a/sources/fi/pohjois-pohjanmaa-fi.json
+++ b/sources/fi/pohjois-pohjanmaa-fi.json
@@ -28,7 +28,11 @@
         "number": "COLUMN10",
         "lat": "COLUMN5",
         "lon": "COLUMN6",
-        "id": "COLUMN1",
+        "id": {
+            "function": "join",
+            "fields": ["COLUMN1","COLUMN7"],
+            "separator": "-"
+        },
         "postcode": "COLUMN11",
         "type": "csv",
         "accuracy": 1

--- a/sources/fi/pohjois-pohjanmaa-sv.json
+++ b/sources/fi/pohjois-pohjanmaa-sv.json
@@ -28,7 +28,11 @@
         "number": "COLUMN10",
         "lat": "COLUMN5",
         "lon": "COLUMN6",
-        "id": "COLUMN1",
+        "id": {
+            "function": "join",
+            "fields": ["COLUMN1","COLUMN7"],
+            "separator": "-"
+        },
         "postcode": "COLUMN11",
         "type": "csv",
         "accuracy": 1

--- a/sources/fi/pohjois-savo-fi.json
+++ b/sources/fi/pohjois-savo-fi.json
@@ -28,7 +28,11 @@
         "number": "COLUMN10",
         "lat": "COLUMN5",
         "lon": "COLUMN6",
-        "id": "COLUMN1",
+        "id": {
+            "function": "join",
+            "fields": ["COLUMN1","COLUMN7"],
+            "separator": "-"
+        },
         "postcode": "COLUMN11",
         "type": "csv",
         "accuracy": 1

--- a/sources/fi/pohjois-savo-sv.json
+++ b/sources/fi/pohjois-savo-sv.json
@@ -28,7 +28,11 @@
         "number": "COLUMN10",
         "lat": "COLUMN5",
         "lon": "COLUMN6",
-        "id": "COLUMN1",
+        "id": {
+            "function": "join",
+            "fields": ["COLUMN1","COLUMN7"],
+            "separator": "-"
+        },
         "postcode": "COLUMN11",
         "type": "csv",
         "accuracy": 1

--- a/sources/fi/päijät-häme-fi.json
+++ b/sources/fi/päijät-häme-fi.json
@@ -28,7 +28,11 @@
         "number": "COLUMN10",
         "lat": "COLUMN5",
         "lon": "COLUMN6",
-        "id": "COLUMN1",
+        "id": {
+            "function": "join",
+            "fields": ["COLUMN1","COLUMN7"],
+            "separator": "-"
+        },
         "postcode": "COLUMN11",
         "type": "csv",
         "accuracy": 1

--- a/sources/fi/päijät-häme-sv.json
+++ b/sources/fi/päijät-häme-sv.json
@@ -28,7 +28,11 @@
         "number": "COLUMN10",
         "lat": "COLUMN5",
         "lon": "COLUMN6",
-        "id": "COLUMN1",
+        "id": {
+            "function": "join",
+            "fields": ["COLUMN1","COLUMN7"],
+            "separator": "-"
+        },
         "postcode": "COLUMN11",
         "type": "csv",
         "accuracy": 1

--- a/sources/fi/satakunta-fi.json
+++ b/sources/fi/satakunta-fi.json
@@ -28,7 +28,11 @@
         "number": "COLUMN10",
         "lat": "COLUMN5",
         "lon": "COLUMN6",
-        "id": "COLUMN1",
+        "id": {
+            "function": "join",
+            "fields": ["COLUMN1","COLUMN7"],
+            "separator": "-"
+        },
         "postcode": "COLUMN11",
         "type": "csv",
         "accuracy": 1

--- a/sources/fi/satakunta-sv.json
+++ b/sources/fi/satakunta-sv.json
@@ -28,7 +28,11 @@
         "number": "COLUMN10",
         "lat": "COLUMN5",
         "lon": "COLUMN6",
-        "id": "COLUMN1",
+        "id": {
+            "function": "join",
+            "fields": ["COLUMN1","COLUMN7"],
+            "separator": "-"
+        },
         "postcode": "COLUMN11",
         "type": "csv",
         "accuracy": 1

--- a/sources/fi/uusimaa-fi.json
+++ b/sources/fi/uusimaa-fi.json
@@ -28,7 +28,11 @@
         "number": "COLUMN10",
         "lat": "COLUMN5",
         "lon": "COLUMN6",
-        "id": "COLUMN1",
+        "id": {
+            "function": "join",
+            "fields": ["COLUMN1","COLUMN7"],
+            "separator": "-"
+        },
         "postcode": "COLUMN11",
         "type": "csv",
         "accuracy": 1

--- a/sources/fi/uusimaa-sv.json
+++ b/sources/fi/uusimaa-sv.json
@@ -28,7 +28,11 @@
         "number": "COLUMN10",
         "lat": "COLUMN5",
         "lon": "COLUMN6",
-        "id": "COLUMN1",
+        "id": {
+            "function": "join",
+            "fields": ["COLUMN1","COLUMN7"],
+            "separator": "-"
+        },
         "postcode": "COLUMN11",
         "type": "csv",
         "accuracy": 1

--- a/sources/fi/varsinais-suomi-fi.json
+++ b/sources/fi/varsinais-suomi-fi.json
@@ -28,7 +28,11 @@
         "number": "COLUMN10",
         "lat": "COLUMN5",
         "lon": "COLUMN6",
-        "id": "COLUMN1",
+        "id": {
+            "function": "join",
+            "fields": ["COLUMN1","COLUMN7"],
+            "separator": "-"
+        },
         "postcode": "COLUMN11",
         "type": "csv",
         "accuracy": 1

--- a/sources/fi/varsinais-suomi-sv.json
+++ b/sources/fi/varsinais-suomi-sv.json
@@ -28,7 +28,11 @@
         "number": "COLUMN10",
         "lat": "COLUMN5",
         "lon": "COLUMN6",
-        "id": "COLUMN1",
+        "id": {
+            "function": "join",
+            "fields": ["COLUMN1","COLUMN7"],
+            "separator": "-"
+        },
         "postcode": "COLUMN11",
         "type": "csv",
         "accuracy": 1


### PR DESCRIPTION
Conform objects's id field for all Finnish source entries used a building identifier of the original data source. A large building can open to many streets, so the id was not unique. Now the source combines the building id with the index of each address assigned to it. The combined id should be truly unique.

A side note: 'npm test' complains about use of join function for id. However, looking at the specs for contributing, it should be OK. I 'm a bit confused about this contradiction.
    