### PR TITLE
switched to more reliable fields

### DIFF
--- a/sources/us/fl/city_of_lakeland.json
+++ b/sources/us/fl/city_of_lakeland.json
@@ -13,14 +13,14 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "number": "HOUSENUMBER",
-        "unit": "UNIT",
+        "number": "COL_HOUSENUM",
         "street": [
-            "PREFIX",
-            "STREETNAME",
-            "TYPE",
-            "SUFFIX"
+            "COL_PREFIX",
+            "COL_STREETNAME",
+            "COL_TYPE",
+            "COL_SUFFIX"
         ],
+        "unit": "COL_APT",
         "postcode": "ZIP"
     }
 }


### PR DESCRIPTION
The `PREFIX` field doesn't contain any data and the directional in the `SUFFIX` field could be the prefix, so addresses with a prefix directional were being formatted incorrectly.  This swaps out for more reliable fields prefixed with `COL_`.