### PR TITLE
fixed regexes for `number` and `street`

### DIFF
--- a/sources/us/pa/berks.json
+++ b/sources/us/pa/berks.json
@@ -13,17 +13,16 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "number":  {
+        "number": {
             "function": "regexp",
             "field": "FULLSITEADDRESS",
-            "pattern": "([0-9]+)(.*)",
-            "replace": "$1"
+            "pattern": "^([0-9]+)"
         },
-        "street":  {
+        "street": {
             "function": "regexp",
             "field": "FULLSITEADDRESS",
-            "pattern": "([0-9]+)(.*)",
-            "replace": "$2"
+            "pattern": "^(?:[0-9]+ )(.*)",
+            "replace": "$1"
         },
         "city": "MUNICIPALNAME"
     }


### PR DESCRIPTION
the bad regex was causing entries like:

`-75.8727528,40.6626665,QUAKER CITY RD,Quaker City Road,,ALBANY,,,,,`

where the `number` field is all text and no number