### PR TITLE
added `POST_TYPE` for `STREET`, `LANE`, etc

### DIFF
--- a/sources/us/ma/statewide.json
+++ b/sources/us/ma/statewide.json
@@ -23,6 +23,7 @@
             "PRE_MOD",
             "PRE_DIR",
             "BASE",
+            "POST_TYPE",
             "POST_MOD",
             "POST_DIR"
         ],


### PR DESCRIPTION
This was missed in the transition from parcels zip file to ESRI