### PR TITLE
Added Sicily

### DIFF
--- a/sources/it/82/statewide.json
+++ b/sources/it/82/statewide.json
@@ -8,24 +8,21 @@
         "country": "it",
         "state": "82"
     },
-    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/iandees/6dae2f/sicily20160804.csv.zip",
+    "data": "http://map.sitr.regione.sicilia.it/ArcGIS/rest/services/CART_2000/StradeEdifici_2000/MapServer/0/",
     "website": "http://www.sitr.regione.sicilia.it/geoportale/it/metadata/details/633",
     "license": {
         "url": "https://creativecommons.org/licenses/by-sa/3.0/",
         "attribution": true,
         "share-alike": true
         },
-    "type": "http",
-    "compression": "zip",
+    "type": "ESRI",
     "language": "it",
     "conform": {
         "number": ["CIVICO","ESPONENTE"],
-        "street": "TOPONIMO_S",
+        "street": "TOPONIMO_VIA",
         "city": "COMUNE",
-        "region": "Sicilia",
-        "type": "csv",
-        "accuracy": 3,
-        "lat":"Y",
-        "lon":"X"
+        "type": "geojson",
+        "addrtype": "TIPO_CIVICO",
+        "accuracy": 3
     }
 }

--- a/sources/it/82/statewide.json
+++ b/sources/it/82/statewide.json
@@ -8,7 +8,7 @@
         "country": "it",
         "state": "82"
     },
-    "data": "https://www.dropbox.com/s/ha70cel2091j8r2/sicily20160804.csv.zip?dl=1",
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/iandees/6dae2f/sicily20160804.csv.zip",
     "website": "http://www.sitr.regione.sicilia.it/geoportale/it/metadata/details/633",
     "license": {
         "url": "https://creativecommons.org/licenses/by-sa/3.0/",

--- a/sources/it/82/statewide.json
+++ b/sources/it/82/statewide.json
@@ -18,7 +18,11 @@
     "type": "ESRI",
     "language": "it",
     "conform": {
-        "number": ["CIVICO","ESPONENTE"],
+        "number": {
+            "function": "format",
+            "fields": ["CIVICO", "ESPONENTE"],
+            "format": "$1/$2"
+        },
         "street": "TOPONIMO_VIA",
         "city": "COMUNE",
         "type": "geojson",

--- a/sources/it/82/statewide.json
+++ b/sources/it/82/statewide.json
@@ -1,0 +1,29 @@
+{
+    "coverage": {
+        "ISO 3166": {
+            "alpha2": "IT-82",
+            "country": "Italy",
+            "subdivision": "Sicilia"
+        },
+        "country": "it",
+        "state": "82"
+    },
+    "data": "https://www.dropbox.com/s/67h7d588ab25ne0/sicily20160804.zip?dl=1",
+    "website": "http://www.sitr.regione.sicilia.it/geoportale/it/metadata/details/633",
+    "license": {
+        "url": "https://creativecommons.org/licenses/by-sa/3.0/",
+        "attribution": true,
+        "share-alike": true
+        },
+    "type": "http",
+    "compression": "zip",
+    "language": "it",
+    "conform": {
+        "number": ["CIVICO","ESPONENTE"],
+        "street": "TOPONIMO_S",
+        "city": "COMUNE",
+        "region": "Sicilia",
+        "type": "shapefile",
+        "accuracy": 3
+    }
+}

--- a/sources/it/82/statewide.json
+++ b/sources/it/82/statewide.json
@@ -8,7 +8,7 @@
         "country": "it",
         "state": "82"
     },
-    "data": "https://www.dropbox.com/s/67h7d588ab25ne0/sicily20160804.zip?dl=1",
+    "data": "https://www.dropbox.com/s/ha70cel2091j8r2/sicily20160804.csv.zip?dl=1",
     "website": "http://www.sitr.regione.sicilia.it/geoportale/it/metadata/details/633",
     "license": {
         "url": "https://creativecommons.org/licenses/by-sa/3.0/",
@@ -23,7 +23,9 @@
         "street": "TOPONIMO_S",
         "city": "COMUNE",
         "region": "Sicilia",
-        "type": "shapefile",
-        "accuracy": 3
+        "type": "csv",
+        "accuracy": 3,
+        "lat":"Y",
+        "lon":"X"
     }
 }


### PR DESCRIPTION
Added the dataset for Sicily, some 2M addresses. The quality is average as a large fraction of addresses are missing the house number or the street name. Positional accuracy appears to be the driveway since most points are on the street.

Created by downloading the data from the WFS server at http://map.sitr.regione.sicilia.it/ArcGIS/services/CART_2000/Numeri_Civici/GeoDataServer/WFSServer and converting to the Shapefile.

Share-Alike license.
