### PR TITLE
Switzerland: adding postcode in Zurich / removing redundant street abbreviation in Geneva

### DIFF
--- a/sources/ch/geneva.json
+++ b/sources/ch/geneva.json
@@ -19,7 +19,6 @@
         "number": "NO_ADRESSE",
         "street": [
             "TYVOIE",
-            "TYPABR",
             "LIANT",
             "NOMVOI"
         ],

--- a/sources/ch/zurich.json
+++ b/sources/ch/zurich.json
@@ -24,6 +24,7 @@
             "pattern": "(.*)( [0-9]+)",
             "replace": "$1"
         },
+        "postcode": "PLZ",
         "type": "geojson"
     }
 }


### PR DESCRIPTION
Hey all - now that https://github.com/openaddresses/machine/pull/281 is implemented, I'm looking at incorporating OpenAddresses as a source of training data for libpostal's address parser. Primary use cases are to improve modeling of street names that aren't in OSM (or contain different variations) and to get a more complete view of valid contexts for postcodes to help disambiguate them from regular house numbers, etc.

As such, wanted to make a few PRs to add postcodes to some of the data sets and fix a few other issues I've been seeing.

Noticing in Zurich there is a postcode available in the PLZ field (which [appears to be the name for postal codes in Switzerland](https://en.wikipedia.org/wiki/Postal_codes_in_Switzerland_and_Liechtenstein#Format_of_postal_codes_.28PLZ.29), at least the German-speaking parts).

For Geneva, the street name includes both the unabbreviated form of the thoroughfare type and its abbreviated form, so there are many names like "Chemin ch. des Corbillettes". This makes it simply "Chemin des Corbillettes".
