### PR TITLE
adding Brussels postcodes

### DIFF
--- a/sources/be/wa/brussels-fr.json
+++ b/sources/be/wa/brussels-fr.json
@@ -15,6 +15,7 @@
         "number": "ADRN",
         "type": "shapefile",
         "city":  "MU_NAME_FR",
-        "street": "PW_NAME_FR"
+        "street": "PW_NAME_FR",
+        "postcode": "PZNC"
     }
 }

--- a/sources/be/wa/brussels-nl.json
+++ b/sources/be/wa/brussels-nl.json
@@ -15,6 +15,7 @@
         "number": "ADRN",
         "type": "shapefile",
         "city":  "MU_NAME_DU",
-        "street": "PW_NAME_DU"
+        "street": "PW_NAME_DU",
+        "postcode": "PZNC"
     }
 }


### PR DESCRIPTION
Postcodes are available in the PZNC field for Brussels.