### PR TITLE
using number and street fields for Windsor, Ontario

### DIFF
--- a/sources/ca/on/city_of_windsor.json
+++ b/sources/ca/on/city_of_windsor.json
@@ -11,9 +11,12 @@
     "type": "http",
     "compression": "zip",
     "conform": {
-        "split": "ADD_RANGE",
-        "number": "auto_number",
-        "street": "auto_street",
+        "number": "ADD_NUMBER",
+        "street": [
+            "STREET",
+            "SUFFIX",
+            "DIRECTION"
+        ],
         "type": "shapefile-polygon"
     }
 }


### PR DESCRIPTION
Was seeing some weird street names in the city_of_windsor file. 

Looks like it's splitting the full address field, using the first numeric token as the house number and the rest of the field as the street. Some of the addresses in this data set look like "239, 251 DROUILLARD RD", which splits into "239" and ", 251 DROUILLARD RD" as the street name. However, it looks like the source already contains separate number and street fields, so using those instead.