### PR TITLE
Netherlands house numbers - letter should come after number

### DIFF
--- a/sources/nl/countrywide.json
+++ b/sources/nl/countrywide.json
@@ -13,7 +13,7 @@
 	"conform": {
 		"lon": "lon",
 		"lat": "lat",
-		"number": ["huisletter", "huisnummer","huisnummertoevoeging"],
+		"number": ["huisnummer", "huisletter", "huisnummertoevoeging"],
 		"street": "openbareruimte",
 		"postcode": "postcode",
 		"city": "woonplaats",


### PR DESCRIPTION
Was looking at Dutch house numbers in OSM and they usually take form "number + letter". The OpenAddresses config was using the inverse.

Format-wise, it didn't seem from [conform.py](https://github.com/openaddresses/machine/blob/master/openaddr/conform.py) that there was a way to do a string join with more than one separator, but it might be worth considering that for the conform spec. In the Netherlands, as far as I can tell, when there's a "huisletter", it would usually be concatenated onto the number with no space e.g. "112B", whereas the "huisnummertoevoeging" ("house number addition", usually also numeric) is joined using a hyphen e.g. "112-11". If all three fields exist, it's "112B-11".