### PR TITLE
correcting house number and street name fields for Honolulu

### DIFF
--- a/sources/us/hi/honolulu.json
+++ b/sources/us/hi/honolulu.json
@@ -19,9 +19,13 @@
     "note": "Includes full parcel shapefile of the island of Oahu. SRS is EPSG: 2784",
     "conform": {
         "type": "shapefile-polygon",
-        "number": "housenumbr",
-        "street": "streename",
-        "unit": "housesuffx",
-        "city": "city"
+        "number": {
+            "function": "join",
+            "fields": ["HOUSEPRFX", "HOUSENUMBR"],
+            "separator": "-"
+        },
+        "street": "STREETNAME",
+        "unit": "HOUSESUFFX",
+        "city": "CITY"
     }
 }


### PR DESCRIPTION
Noticed there were no street names in the Honolulu file because of a typo in the field name.

Also, it appears that when the field HOUSEPRFX is non-NULL, the prefix is prepended to the house number separated by a hyphen. Here are a few examples:
- [86-78 Hoaha St](https://www.google.com/maps/place/86-78+Hoaha+St,+Wai%CA%BBanae,+HI+96792/@21.438733,-158.1846891,17z/data=!3m1!4b1!4m5!3m4!1s0x7c008a3657180b87:0x9f33cd0abccfe132!8m2!3d21.438728!4d-158.182495)
- [62-103 Anahulu Pl](https://www.google.com/maps/place/62-103+Anahulu+Pl,+Haleiwa,+HI+96712/@21.591828,-158.1050031,17z/data=!3m1!4b1!4m5!3m4!1s0x7c0058d39894bb33:0xeae11f326f97d70c!8m2!3d21.591823!4d-158.102809)
- [41-162 Iuiu St](https://www.google.com/maps/place/47-162+Iuiu+St,+Kaneohe,+HI+96744/@21.451303,-157.8224581,17z/data=!3m1!4b1!4m5!3m4!1s0x7c006a7a65abc5c1:0x6ece581b14bb41db!8m2!3d21.451298!4d-157.820264)