### PR TITLE
adding house number formatting to NL countrywide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,6 +150,7 @@ Function | Note
 -------- | -----
 `regexp` | Allow regex find and/or replace on a given field. Useful to extract house number/street/city/region etc when the source has them in a single field
 `join`   | Allow multiple fields to be joined with a given delimiter.
+`format` | Allow multiple fields to be formatted into a single string.
 
 ##### Attribute Tag Examples
 
@@ -241,6 +242,28 @@ _Example_
     "function": "join",
     "fields": ["BLOCK_NUM", "BLOCK_GRP"],
     "separator": "-"
+}
+```
+
+###### format function
+
+The format function allows fields to be formatted into a single string. Each item in the fields list can be referenced with a numbered variable such as `$1`, `$2`, etc.
+
+_Format_
+```JSON
+"{Attribute Tag}": {
+    "function": "format",
+    "fields": ["{Field1}", "{Field2}", "etc..." ],
+    "format": "{Format String}"
+}
+```
+
+_Example_
+```JSON
+"number": {
+    "function": "format",
+    "fields": ["number", "letter", "supplement"],
+    "separator": "$1$2-$3"
 }
 ```
 

--- a/sources/nl/countrywide.json
+++ b/sources/nl/countrywide.json
@@ -13,7 +13,11 @@
 	"conform": {
 		"lon": "lon",
 		"lat": "lat",
-		"number": ["huisnummer", "huisletter", "huisnummertoevoeging"],
+		"number": {
+            "function": "format",
+            "fields": ["huisnummer", "huisletter", "huisnummertoevoeging"],
+            "format": "$1$2-$3"
+        },
 		"street": "openbareruimte",
 		"postcode": "postcode",
 		"city": "woonplaats",

--- a/sources/nl/countrywide.json
+++ b/sources/nl/countrywide.json
@@ -14,10 +14,10 @@
 		"lon": "lon",
 		"lat": "lat",
 		"number": {
-            "function": "format",
-            "fields": ["huisnummer", "huisletter", "huisnummertoevoeging"],
-            "format": "$1$2-$3"
-        },
+			"function": "format",
+			"fields": ["huisnummer", "huisletter", "huisnummertoevoeging"],
+			"format": "$1$2-$3"
+		},
 		"street": "openbareruimte",
 		"postcode": "postcode",
 		"city": "woonplaats",

--- a/test/sources.js
+++ b/test/sources.js
@@ -112,6 +112,9 @@ function checkSource(i){
                         } else if (data.conform[attrib].function === 'join') { 
                             t.ok(Array.isArray(data.conform[attrib].fields), attrib + ' join should reference fields');
                             t.ok(typeof data.conform[attrib].separator === 'string', attrib + ' join separator should be a string');
+                        } else if (data.conform[attrib].function === 'format') {
+                            t.ok(Array.isArray(data.conform[attrib].fields), attrib + ' format should reference fields');
+                            t.ok(typeof data.conform[attrib].format === 'string', attrib + ' format should be a string');
                         } else {
                             t.fail(data.conform[attrib].function + ' function should be valid');
                         }


### PR DESCRIPTION
Assuming the CI workers have the latest code from the machine repo implementing this, uses the new format function for house numbers in the Netherlands. No space between huisnummer and huisletter, whereas huisnummertoevoeging, when provided, is appended with a hyphen.

* [x] Add information about new "format" function to contribution guide.
* [x] Update unit tests with "format" function.
* [x] Update Netherlands data to use "format".

Closes #1928.