### PR TITLE
Zurich encoding and regexes

### DIFF
--- a/sources/ch/zurich.json
+++ b/sources/ch/zurich.json
@@ -16,13 +16,13 @@
         "number": {
             "function": "regexp",
             "field": "Adresse",
-            "pattern": "(.* )([0-9]+)",
+            "pattern": "(.* )([0-9]+[^\\s]*)[\\s]*$",
             "replace": "$2"
         },
         "street": {
             "function": "regexp",
             "field": "Adresse",
-            "pattern": "(.*)( [0-9]+)",
+            "pattern": "(.*)( [0-9]+[^\\s]*)[\\s]*$",
             "replace": "$1"
         },
         "postcode": "PLZ",

--- a/sources/ch/zurich.json
+++ b/sources/ch/zurich.json
@@ -12,6 +12,7 @@
     },
     "type": "http",
     "conform": {
+        "encoding": "utf-8",
         "number": {
             "function": "regexp",
             "field": "Adresse",


### PR DESCRIPTION
Setting encoding to UTF-8 and using regexes that allow for alphanumeric house numbers like "102a". The way it was written previously would concatenate the "a" onto the end of the street name (does an re.findall and strings all the group 1's together).