### PR TITLE
Added source us-or-marion. Fixes #1952.

### DIFF
--- a/sources/us/or/marion.json
+++ b/sources/us/or/marion.json
@@ -1,0 +1,26 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "41047",
+            "state": "Oregon",
+            "name": "Marion County"
+        },
+        "country": "us",
+        "state": "or",
+        "county": "Marion"
+    },
+    "website": "http://gis.co.marion.or.us/GISDownload/gisdownload.aspx",
+    "data": "http://gis.co.marion.or.us/gisdownload/download/assessors/taxlot.zip",
+    "type": "http",
+    "compression": "zip",
+    "conform": {
+        "type": "shapefile-polygon",
+        "number": "XSTNO",
+        "street": [
+            "SDIRPX",
+            "STNAM",
+            "STYP",
+            "SDIRSX"
+        ]
+    }
+}


### PR DESCRIPTION
A few of the parcels seem to have address ranges. The `conform` uses the start address number now. Is there a better way to handle ranges?