### PR TITLE
Change source for us-la-lafayette

### DIFF
--- a/sources/us/la/lafayette.json
+++ b/sources/us/la/lafayette.json
@@ -10,16 +10,14 @@
         "county": "Lafayette"
     },
     "type": "ESRI",
-    "data": "http://lcgmaps.lafayettela.gov/arcgis/rest/services/ParcelPublicAccess/MapServer/2",
+    "data": "http://lcgmaps.lafayettela.gov/arcgis/rest/services/BaseLayerServices/LCG_Address_Points/MapServer/0",
     "note": "Lafayette consolidted government represents city of Lafayette and other unincorporated ares of Lafayette Parish",
     "conform": {
         "type": "geojson",
-        "number": "ADDRNUM",
-        "street": "FULLNAME",
-        "unit": [
-            "UNITTYPE",
-            "UNITID"
-        ],
-        "city": "MUNICIPALITY"
+        "number": "ADDR_NUM",
+        "street": "FULL_STR_NAME",
+        "unit": "UNIT",
+        "city": "CITY",
+        "postcode": "ZIP"
     }
 }


### PR DESCRIPTION
This source has 102,341 features while the previous source had 49,672. 

A possible problem is the `CITY` field uses `LAF PARISH` which looks like shortened "Lafayette Parish".

Related #2030.