### PR TITLE
Update Bucks County, PA

### DIFF
--- a/sources/us/pa/bucks.json
+++ b/sources/us/pa/bucks.json
@@ -9,8 +9,9 @@
         "state": "pa",
         "county": "Bucks"
     },
-    "data": "https://gisweb.co.bucks.pa.us/arcgis/rest/services/Assessment/PropertyRecords/MapServer/7?token=CtaGPNgtI048o4b5TrovNnbU-sJLzj6XEPlor4giGTIh8JKWUaxHBVrydlHW29L_",
-    "type": "ESRI",
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/iandees/ed482f/bucks.geojson.zip",
+    "type": "http",
+    "compression": "zip",
     "conform": {
         "type": "geojson",
         "number": "SITUS_ADDR_NUM",


### PR DESCRIPTION
Fixes #2054

The source data was pulled down using:

```bash
esri2geojson \
   -p "token=0Q3AaiYYQMQ75_5fUAXUJRt7uTYTPliscnTIIqXaYnTruHeHeeq2umFSz1_19MVW" \
   https://gisweb.co.bucks.pa.us/arcgis/rest/services/Assessment/PropertyRecords/MapServer/7 \
   ~/Downloads/bucks.geojson
```

... zipping the resulting GeoJSON, and uploading it via https://results.openaddresses.io/upload-cache.