### PR TITLE
Forsyth county had two more-or-less identical fields appended to street name

### DIFF
--- a/sources/us/nc/forsyth.json
+++ b/sources/us/nc/forsyth.json
@@ -25,7 +25,6 @@
         "street": [
             "STDIR",
             "STNAME",
-            "STTYPE",
             "STTYPEPO"
         ],
         "postcode": "ZIPCODE"


### PR DESCRIPTION
The resulting addresses look like this:

```
-80.3742528,35.9841966,4830,BENT RIDGE LN LN,,,,,27012,,de141b70f9b55386
-80.0738147,36.0936321,1301,WHITWORTH CT CT,,,,,27284,,c9e1a10b3dda1327
-80.3550192,36.0937036,1116,ROCKDALE DR DR,,,,,27104,,1a55e71d6f47e88c
-80.1670648,36.0760055,3955,THORNABY CR CIR,,,,,27107,,439e67ab2452b9d6
-80.1988279,36.0380146,4006,HARTSOE RD RD,,,,,27107,,cf38f42a8c7447c1
-80.1888324,36.153153,4365,WAKEMAN DR DR,,,,,27105,,6061600bd7571223
-80.3289822,36.0643463,2851,HONDO DR DR,,,,,27103,,8a7590b163132ec1
```

Looks like STTYPE is a two-letter code for thoroughfare type and STTYPEPO is the USPS abbreviation. Using only the latter.