### PR TITLE
city field for Bern, Switzerland

### DIFF
--- a/sources/ch/bern.json
+++ b/sources/ch/bern.json
@@ -23,7 +23,7 @@
         "city": {
             "function": "regexp",
             "field": "ORT",
-            "pattern": "(.*)(?: BE)?"
+            "pattern": "(^.*?)(?: BE)?$"
         },
         "postcode": "PLZ",
         "addrtype": "NUTZUNG"

--- a/sources/ch/bern.json
+++ b/sources/ch/bern.json
@@ -20,7 +20,11 @@
         "id": "BE_GID",
         "number": "GEBNR",
         "street": "LOKALISAT",
-        "city": "ORT",
+        "city": {
+            "function": "regexp",
+            "field": "ORT",
+            "pattern": "(.*)(?: BE)?"
+        },
         "postcode": "PLZ",
         "addrtype": "NUTZUNG"
     }

--- a/sources/ch/bern.json
+++ b/sources/ch/bern.json
@@ -20,6 +20,7 @@
         "id": "BE_GID",
         "number": "GEBNR",
         "street": "LOKALISAT",
+        "city": "ORT",
         "postcode": "PLZ",
         "addrtype": "NUTZUNG"
     }


### PR DESCRIPTION
The field "ORT" ([Ortschaft](https://de.wikipedia.org/wiki/Ortschaft)?) in this data set appears to be a city. Top 10:

```
[(u'Bern', 22207),
 (u'Thun', 10281),
 (u'Biel/Bienne', 10257),
 (u'Steffisburg', 5802),
 (u'Langenthal', 5002),
 (u'Burgdorf', 4991),
 (u'Grindelwald', 4374),
 (u'Lyss', 3525),
 (u'Münsingen', 3502),
 (u'Spiez', 3443)]
```