### PR TITLE
Removing TYPE in the Beaumont source (appears to be redundant)

### DIFF
--- a/sources/us/tx/city_of_beaumont.json
+++ b/sources/us/tx/city_of_beaumont.json
@@ -26,7 +26,6 @@
             "PREFIX_TYPE",
             "STREET_NAME",
             "SUFFIX_TYPE",
-            "SUFFIX_DIR",
             "TYPE"
         ],
         "postcode": "ZIP"

--- a/sources/us/tx/city_of_beaumont.json
+++ b/sources/us/tx/city_of_beaumont.json
@@ -26,7 +26,7 @@
             "PREFIX_TYPE",
             "STREET_NAME",
             "SUFFIX_TYPE",
-            "TYPE"
+            "SUFFIX_DIR"
         ],
         "postcode": "ZIP"
     }


### PR DESCRIPTION
Saw a few more addresses like this:

```
-94.1875947,30.1105266,3590,GRAYSON LN  LN,,,,,77706,,4a3456df4665b937
-94.187594,30.1107091,3594,GRAYSON LN  LN,,,,,77706,,932093aa64862396
-94.1876003,30.1109091,3598,GRAYSON LN  LN,,,,,77706,,50948493555658e9
-94.1875482,30.1090818,3510,GRAYSON LN  LN,,,,,77706,,60c7487ff621e817
-94.1875869,30.1112771,3610,GRAYSON LN  LN,,,,,77706,,72799aaa2f3de618
-94.1875848,30.1114871,3620,GRAYSON LN  LN,,,,,77706,,29bd3225ae4008e2
```

SUFFIX_DIR is a directional (seldom used), whereas TYPE is just a repeat of the thoroughfare type.