### PR TITLE
Fixing street name regex in Juno, AK

### DIFF
--- a/sources/us/ak/city_of_juneau.json
+++ b/sources/us/ak/city_of_juneau.json
@@ -29,7 +29,7 @@
         "street": {
             "function": "regexp",
             "field": "site_addrs",
-            "pattern": "^(?:[0-9]+ )(.*)",
+            "pattern": "^(?:[0-9]+ )(.*?)(?: (?:[Aa][Pp][Tt]|[Uu][Nn][Ii][Tt]) .*?)?(?:;|$)",
             "replace": "$1"
         }
     }


### PR DESCRIPTION
May have multiple semicolon-separated addresses or unit info appended e.g.

```
-134.4305189,58.3032895,1417,Harbor Way;  1421 Harbor Way;  1425 Harbor Way;  1427 Harbor Way,,,,,,,407fd46bb87d8c7a
-134.4171561,58.3031473,330,W Ninth St Apt A;  330 W Ninth St Apt B;  330 W Ninth St Apt C;  907 Capital Ave;  911 Capital Ave,,,,,,,9f704d80c7150359
```