### PR TITLE
Fix conform for us/ca/mono

### DIFF
--- a/sources/us/ca/mono.json
+++ b/sources/us/ca/mono.json
@@ -13,9 +13,9 @@
         "type": "shapefile",
         "number": "Address",
         "street": [
-            "ST_Prefix",
+            "StreetPref",
             "Street",
-            "ST_Suffix"
+            "StreetSuff"
         ],
         "unit": "Unit",
         "city": "Community",


### PR DESCRIPTION
Fixed the conform for Mono County from this [error](https://s3.amazonaws.com/data.openaddresses.io/runs/128160/output.txt).

`ST_Prefix` → `StreetPref`
`ST_Suffix` → `StreetSuff`