### PR TITLE
add au/countrywide accuracy field

### DIFF
--- a/scripts/au/gnaf.sh
+++ b/scripts/au/gnaf.sh
@@ -61,7 +61,21 @@ SELECT
     latitude AS lat,
     locality_name AS city,
     locality_postcode AS postcode,
-    state AS region
+    state AS region,
+
+    (
+        CASE geocode_type WHEN 'BUILDING CENTROID' THEN 1 -- rooftop
+                          WHEN 'FRONTAGE CENTRE SETBACK' THEN 2 -- interpolation
+                          WHEN 'GAP GEOCODE' THEN 4 -- interpolation
+                          WHEN 'LOCALITY' THEN 4 -- interpolation
+                          WHEN 'PROPERTY ACCESS POINT SETBACK' THEN 3 -- driveway
+                          WHEN 'PROPERTY CENTROID' THEN 2 -- parcel
+                          WHEN 'PROPERTY CENTROID MANUAL' THEN 2 -- parcel
+                          WHEN 'STREET LOCALITY' THEN 4 -- interpolation
+                          ELSE 5 -- unknown
+        END
+    )
+    AS accuracy
 
 FROM gnaf.addresses adr;
 " | psql postgres://gnafun:gnafpw@localhost/gnafdb


### PR DESCRIPTION
GNAF provides a few fields measuring geocode:

- `reliability` a measure of how accurate the geometry of the geocode is, did the geometry come from the site boundary, road, locality?
- `confidence` metric based on how many different address databases it appears in
and type.
- `geocode_type` what is this address/geometry representing. eg. is it the building centroid or the front door to the building? or is it the property parcel centroid, or does it come from offsetting from the road centerline at a distance along the road? etc.

OA only provides [*`accuracy`*](https://github.com/openaddresses/openaddresses/blob/master/CONTRIBUTING.md#accuracy).

Looking through which fields accually appear in the GNAF data and comparing the field definitions to the OA `accuracy` field, this is my suggested mapping. Comments welcome.