### PR TITLE
Added us/ca/tehama

### DIFF
--- a/sources/us/ca/tehama.json
+++ b/sources/us/ca/tehama.json
@@ -1,0 +1,20 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "06103",
+            "name": "Tehama County",
+            "state": "California"
+        },
+        "country": "us",
+        "state": "pa",
+        "county": "Tahema"
+    },
+    "data": "http://www.tehamacountypublicworks.ca.gov/arcgis/rest/services/LandRecords/TaxParcel/MapServer/0",
+    "type": "ESRI",
+    "conform": {
+        "type": "geojson",  
+        "number": "SITSTNO",
+        "street": "SITSTNM",
+        "postcode": "SITZIP"
+    }
+}


### PR DESCRIPTION
This source has a lot of inconsistent data. Parcels are missing some  or all of the fields. I left out the `SITCITST` field because sometimes it contains city information or city + state or some other information like Granny Unit.