### PR TITLE
Adding Grand Forks County, ND

### DIFF
--- a/sources/us/nd/grand_forks.json
+++ b/sources/us/nd/grand_forks.json
@@ -1,0 +1,29 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "38035",
+            "name": "Grand Forks County",
+            "state": "North Dakota"
+        },
+        "country": "us",
+        "state": "nd",
+        "county": "Grand Forks"
+    },
+    "data": "http://www.gfgis.com/arcgis/rest/services/Public_Layers/AddressPoints/MapServer/0",
+    "type": "ESRI",
+    "conform": {
+        "type": "geojson",
+        "number": {
+            "function": "remove_postfix",
+            "field": "addrnum",
+            "field_to_remove": "unitid"
+        },
+        "street": {
+            "function": "remove_prefix",
+            "field": "fulladdr",
+            "field_to_remove": "addrnum"
+        },
+        "unit": "unitid",
+        "city": "municipality"
+    }
+}


### PR DESCRIPTION
Fixes #2181 

Works with openaddresses/machine#498

The data is fine except for records with units.  Here's an example:

```
{
  "addrnum": "400 S14",
  "unitid": "S14",
  "fulladdr": "400 S14 EMERY AVE E"
}
```

Except for `unit`, both `number` and `street` fields are difficult to extract due to the complexity of unit formats and ambiguity introduced by deciding whether an "E" is a unit or part of the street address.  Ideally, a function would exist that returns a value after another field value has been removed as a prefix.  
