### PR TITLE
attempt to fix regexes

### DIFF
--- a/sources/us/wa/pierce.json
+++ b/sources/us/wa/pierce.json
@@ -16,20 +16,18 @@
     "number": {
       "function": "regexp",
       "field": "Site_Address",
-      "pattern": "^([0-9]+-?[A-Z]?) ",
+      "pattern": "^([0-9]+-?[a-z]?\\b)"
+    },
+    "street": {
+      "function": "regexp",
+      "field": "Site_Address",
+      "pattern": "^(?:(?:[0-9]+-?[A-Z]?|XXX)\\b)?(.*?)\\b(?:(?:UNIT|APT|BLDG|LOT|#).*|$)\\b",
       "replace": "$1"
     },
     "unit": {
       "function": "regexp",
       "field": "Site_Address",
-      "pattern": " ((?:UNIT|APT|BLDG|LOT|#).*)$",
-      "replace": "$1"
-    },
-    "street": {
-      "function": "regexp",
-      "field": "Site_Address",
-      "pattern": "^(?:[0-9]+-?[A-Z]? )(.*?)((UNIT|APT|BLDG|LOT|#).*|$)",
-      "replace": "$1"
+      "pattern": "\\b((?:UNIT|APT|BLDG|LOT|#).*)\\b$"
     }
   }
 }


### PR DESCRIPTION
Regexes are tricky for this source.  When there's no house number, the source prepends `XXX` to the street.  

Fixes #2174 