### PR TITLE
fixing elisions, longer house numers in Gatineau, QC

### DIFF
--- a/sources/ca/qc/gatineau.json
+++ b/sources/ca/qc/gatineau.json
@@ -10,12 +10,18 @@
     "type": "http",
     "compression": "zip",
     "conform": {
-        "number": "NUMERO_CIV",
-        "street": [
-            "GENERIQUE",
-            "LIAISON",
-            "SPECIFIQUE"
-        ],
+        "number": {
+            "function": "regexp",
+            "field": "ADR_COMPLE",
+            "pattern": "([0-9]+(?:\(.*?\))?)( .*)",
+            "replace": "$1"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "ADR_COMPLE",
+            "pattern": "([0-9]+(?:\(.*?\))? )(.*)",
+            "replace": "$2"
+        },
         "type": "shapefile"
     }
 }

--- a/sources/ca/qc/gatineau.json
+++ b/sources/ca/qc/gatineau.json
@@ -13,13 +13,13 @@
         "number": {
             "function": "regexp",
             "field": "ADR_COMPLE",
-            "pattern": "([0-9]+(?:\(.*?\))?)( .*)",
+            "pattern": "([0-9]+(?:\\(.*?\\))?)( .*)",
             "replace": "$1"
         },
         "street": {
             "function": "regexp",
             "field": "ADR_COMPLE",
-            "pattern": "([0-9]+(?:\(.*?\))? )(.*)",
+            "pattern": "([0-9]+(?:\\(.*?\\))? )(.*)",
             "replace": "$2"
         },
         "type": "shapefile"


### PR DESCRIPTION
Although there are separate fields for the individual components, it's probably better to parse the "ADR_COMPLE" field because of elisions and some complex house numbers.

Elision example:

```json
{
    "geometry": {
        "type": "Point", 
        "coordinates": [
            -75.658203, 
            45.504793
        ]
    }, 
    "type": "Feature", 
    "id": "48", 
    "properties": {
        "CODEID": 120.0, 
        "MUNID": 81017, 
        "NUMERO_CIV": "112", 
        "GENERIQUE": "Rue", 
        "LIAISON": "de l'", 
        "SPECIFIQUE": "Or\u00e9e-des-Bois", 
        "DIRECTION": null, 
        "ADR_COMPLE": "112 Rue de l'Or\u00e9e-des-Bois", 
        "RUESID": 1644, 
        "ENTITEID": "{A60029F6-33B9-4F6D-8D17-2C12A41A60F6}"
    }
}
```

The basic conform will concatenate GENERIQUE, LIAISON, and SPECIFIQUE using spaces, forming "Rue de l' Orée-des-Bois".

There are also cases like the following where the 

```json
{
    "geometry": {
        "type": "Point", 
        "coordinates": [
            -75.706776, 
            45.474168
        ]
    }, 
    "type": "Feature", 
    "id": "2246", 
    "properties": {
        "CODEID": 78099.0, 
        "MUNID": 81017, 
        "NUMERO_CIV": "25(100", 
        "GENERIQUE": "Chemin", 
        "LIAISON": "de la", 
        "SPECIFIQUE": "Savane", 
        "DIRECTION": null, 
        "ADR_COMPLE": "25(100) Chemin de la Savane", 
        "RUESID": 1466, 
        "ENTITEID": "{E56C7E47-B149-436D-9C24-9B1D27F2CEFC}"
    }
}
```

Here the NUMERO_CIV field cuts off numbers that are longer than 6 characters, which can be erroneous.