### PR TITLE
reverted to regexps for number+street

### DIFF
--- a/sources/ca/qc/gatineau.json
+++ b/sources/ca/qc/gatineau.json
@@ -25,11 +25,6 @@
             "field": "ADR_COMPLE",
             "pattern": "^(?:\\d+(?:\\(.*?\\))?\\s+)(.*)$"
         },
-        "unit": {
-            "function": "regexp",
-            "field": "ADR_COMPLE",
-            "pattern": "^(?:\\d+)(\\(?:|.*?\\))?(?:.*)$"
-        },
         "type": "shapefile"
     }
 }

--- a/sources/ca/qc/gatineau.json
+++ b/sources/ca/qc/gatineau.json
@@ -5,7 +5,7 @@
         "city": "Gatineau",
         "geometry": {
             "type": "Point",
-            "coordinates": [-75.767, 45.485] 
+            "coordinates": [-75.767, 45.485]
         }
     },
     "data": "http://gatineau.ca/upload/donneesouvertes/ADRESSE.zip",
@@ -17,18 +17,18 @@
     "conform": {
         "number": {
             "function": "regexp",
-            "field": "NUMERO_CIV",
-            "pattern": "^(\\d+)"
+            "field": "ADR_COMPLE",
+            "pattern": "^(\\d+)(?:.*)$"
         },
         "street": {
             "function": "regexp",
             "field": "ADR_COMPLE",
-            "pattern": "(?:\\d+(?:\\(?:.*?\\))?\\s+)(.*)"
+            "pattern": "^(?:\\d+(?:\\(.*?\\))?\\s+)(.*)$"
         },
         "unit": {
             "function": "regexp",
             "field": "ADR_COMPLE",
-            "pattern": "(?:\\d+)(\\(?:|.*?\\))?"
+            "pattern": "^(?:\\d+)(\\(?:|.*?\\))?(?:.*)$"
         },
         "type": "shapefile"
     }

--- a/sources/ca/qc/gatineau.json
+++ b/sources/ca/qc/gatineau.json
@@ -11,25 +11,27 @@
     "data": "http://gatineau.ca/upload/donneesouvertes/ADRESSE.zip",
     "website": "http://gatineau.ca/donneesouvertes/fiche_metadonnees_en.aspx?id=1393013950",
     "license": "http://gatineau.ca/donneesouvertes/licence_en.aspx",
+    "note": "don't use component fields, see https://github.com/openaddresses/openaddresses/pull/2266",
     "type": "http",
     "compression": "zip",
     "conform": {
         "number": {
             "function": "regexp",
             "field": "NUMERO_CIV",
-            "pattern": "^([0-9]+)"
+            "pattern": "([0-9]+(?:\\(.*?\\))?)( .*)",
+            "replace": "$1"
         },
-        "street": [
-            "GENERIQUE",
-            "LIAISON",
-            "SPECIFIQUE",
-            "DIRECTION"
-        ],
+        "street": {
+            "function": "regexp",
+            "field": "ADR_COMPLE",
+            "pattern": "([0-9]+(?:\\(.*?\\))? )(.*)",
+            "replace": "$2"
+        },
         "unit": {
             "function": "regexp",
-            "field": "NUMERO_CIV",
-            "pattern": "^(?:[0-9]+)(.*)",
-            "replace": "$1"
+            "field": "ADR_COMPLE",
+            "pattern": "([0-9]+(\\(.*?\\))? )",
+            "replace": "$2"
         },
         "type": "shapefile"
     }

--- a/sources/ca/qc/gatineau.json
+++ b/sources/ca/qc/gatineau.json
@@ -18,12 +18,17 @@
         "number": {
             "function": "regexp",
             "field": "ADR_COMPLE",
-            "pattern": "^(\\d+)(?:.*)$"
+            "pattern": "^(\\d+)"
         },
         "street": {
             "function": "regexp",
             "field": "ADR_COMPLE",
-            "pattern": "^(?:\\d+(?:\\(.*?\\))?\\s+)(.*)$"
+            "pattern": "^(?:\\d+(?:\\(.*?\\))?\\s+)(.*)"
+        },
+        "unit": {
+            "function": "regexp",
+            "field": "ADR_COMPLE",
+            "pattern": "(?:\\((.*?)\\))"
         },
         "type": "shapefile"
     }

--- a/sources/ca/qc/gatineau.json
+++ b/sources/ca/qc/gatineau.json
@@ -30,7 +30,7 @@
         "unit": {
             "function": "regexp",
             "field": "ADR_COMPLE",
-            "pattern": "([0-9]+(\\(.*?\\))? )",
+            "pattern": "(?:[0-9]+)(\\(|.*?\\))? ",
             "replace": "$2"
         },
         "type": "shapefile"

--- a/sources/ca/qc/gatineau.json
+++ b/sources/ca/qc/gatineau.json
@@ -18,20 +18,17 @@
         "number": {
             "function": "regexp",
             "field": "NUMERO_CIV",
-            "pattern": "([0-9]+(?:\\(.*?\\))?)( .*)",
-            "replace": "$1"
+            "pattern": "^(\\d+)"
         },
         "street": {
             "function": "regexp",
             "field": "ADR_COMPLE",
-            "pattern": "([0-9]+(?:\\(.*?\\))? )(.*)",
-            "replace": "$2"
+            "pattern": "(?:\\d+(?:\\(?:.*?\\))?\\s+)(.*)"
         },
         "unit": {
             "function": "regexp",
             "field": "ADR_COMPLE",
-            "pattern": "(?:[0-9]+)(\\(|.*?\\))? ",
-            "replace": "$2"
+            "pattern": "(?:\\d+)(\\(?:|.*?\\))?"
         },
         "type": "shapefile"
     }


### PR DESCRIPTION
Pull `unit` from single value field, added note warning others about switching to component fields.  