### PR TITLE
Liechtenstein countrywide

### DIFF
--- a/sources/li/countrywide.json
+++ b/sources/li/countrywide.json
@@ -6,7 +6,7 @@
         },
         "country": "li"
     },
-    "data": "https://www.dropbox.com/s/t77mtmevrdddd4q/li_countrywide.zip?dl=1",
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/sergiyprotsiv/3b8bdb/li_countrywide.zip",
     "website": "http://geodaten.llv.li/geoportal/gebaeudeidentifikator.html",
     "type": "http",
     "compression": "zip",
@@ -17,6 +17,7 @@
         "city": "ortschaft",
         "postcode": "plz",
         "type": "shapefile",
-        "accuracy": 1
+        "accuracy": 1,
+        "srs":"EPSG:2056"
     }
 }

--- a/sources/li/countrywide.json
+++ b/sources/li/countrywide.json
@@ -1,0 +1,22 @@
+{
+    "coverage": {
+        "ISO 3166": {
+            "alpha2": "LI",
+            "country": "Liechtenstein"
+        },
+        "country": "li"
+    },
+    "data": "https://www.dropbox.com/s/t77mtmevrdddd4q/li_countrywide.zip?dl=1",
+    "website": "http://geodaten.llv.li/geoportal/gebaeudeidentifikator.html",
+    "type": "http",
+    "compression": "zip",
+    "language": "de",
+    "conform": {
+        "number": "hausnummer",
+        "street": "strassenna",
+        "city": "ortschaft",
+        "postcode": "plz",
+        "type": "shapefile",
+        "accuracy": 1
+    }
+}


### PR DESCRIPTION
Another full-country coverage:) Again in Dropbox. Please add me to the Openaddresses organization, will upload all the sources to S3.

This one comes from the official website: http://www.llv.li/#/11694/internet-kartendienstgeowebservices However, the Addresses layer there strangely contains only geometry and no attributes. So I am getting the data from another WFS server of theirs, the GDAL command is:

`ogr2ogr -f "ESRI Shapefile" -sql 'select * from "ms:HADR"' li_countrywide.shp WFS:"http://geodaten.llv.li//mapserver/geoportal"`

Was unable to find the license, but this is all freely accessible.