### PR TITLE
Basel-Stadt, Switzerland

### DIFF
--- a/sources/ch/basel-stadt.json
+++ b/sources/ch/basel-stadt.json
@@ -14,7 +14,7 @@
     },
     "conform": {
         "type": "shapefile",
-        "encoding": "latin1",
+        "encoding": "ISO-8859-1",
         "file": "DM_Datenmarkt/DatenmarktAdressen.shp",
         "number": "NAUSNR",
         "street": "STR_NAME",

--- a/sources/ch/basel-stadt.json
+++ b/sources/ch/basel-stadt.json
@@ -15,7 +15,6 @@
     "conform": {
         "type": "shapefile",
         "file": "DM_Datenmarkt/DatenmarktAdressen.shp",
-        "encoding": "utf-8",
         "number": "NAUSNR",
         "street": "STR_NAME",
         "city": "ORT",

--- a/sources/ch/basel-stadt.json
+++ b/sources/ch/basel-stadt.json
@@ -1,0 +1,24 @@
+{
+    "coverage": {
+        "country": "ch",
+        "city": "Basel"
+    },
+    "website": "http://shop.geo.bs.ch/geoshop_app/geoshop/",
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/sergiyprotsiv/17f880/GeodatenBS_20170103_0859.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "attribution": true,
+        "share-alike": false,
+        "url": "http://www.geo.bs.ch/geodaten/geodaten-shop/nutzungsbedingungen.html"
+    },
+    "conform": {
+        "type": "shapefile",
+        "file": "DM_Datenmarkt/DatenmarktAdressen.shp",
+        "encoding": "utf-8",
+        "number": "NAUSNR",
+        "street": "STR_NAME",
+        "city": "ORT",
+        "postcode": "PLZ"
+    }
+}

--- a/sources/ch/basel-stadt.json
+++ b/sources/ch/basel-stadt.json
@@ -19,6 +19,7 @@
         "number": "NAUSNR",
         "street": "STR_NAME",
         "city": "ORT",
-        "postcode": "PLZ"
+        "postcode": "PLZ",
+        "srs": "EPSG:2056"
     }
 }

--- a/sources/ch/basel-stadt.json
+++ b/sources/ch/basel-stadt.json
@@ -16,7 +16,7 @@
         "type": "shapefile",
         "encoding": "ISO-8859-1",
         "file": "DM_Datenmarkt/DatenmarktAdressen.shp",
-        "number": "NAUSNR",
+        "number": "HAUSNR",
         "street": "STR_NAME",
         "city": "ORT",
         "postcode": "PLZ",

--- a/sources/ch/basel-stadt.json
+++ b/sources/ch/basel-stadt.json
@@ -14,6 +14,7 @@
     },
     "conform": {
         "type": "shapefile",
+        "encoding": "latin1",
         "file": "DM_Datenmarkt/DatenmarktAdressen.shp",
         "number": "NAUSNR",
         "street": "STR_NAME",


### PR DESCRIPTION
Here are the addresses in the Swiss canton of Basel-Stadt. As with many sources in Switzerland, the canton has a "geoshop" where one can order the data. It then comes to the mailbox as a link to download the file (which I then upload to S3).