### PR TITLE
Solothurn, Switzerland

### DIFF
--- a/sources/ch/solothurn.json
+++ b/sources/ch/solothurn.json
@@ -4,7 +4,7 @@
         "city": "Solothurn"
     },
     "website": "http://geoweb.so.ch/geodaten/index.php",
-    "data": "http://files.be.ch/bve/agi/geoportal/geo/zip/GEBADR.zip",
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/sergiyprotsiv/b1f209/ch-solothurn.csv.zip",
     "type": "http",
     "compression": "zip",
     "license": {

--- a/sources/ch/solothurn.json
+++ b/sources/ch/solothurn.json
@@ -1,0 +1,26 @@
+{
+    "coverage": {
+        "country": "ch",
+        "city": "Solothurn"
+    },
+    "website": "http://geoweb.so.ch/geodaten/index.php",
+    "data": "http://files.be.ch/bve/agi/geoportal/geo/zip/GEBADR.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "attribution": false,
+        "share-alike": false,
+        "url": "http://geoweb.so.ch/geodaten/index.php"
+    },
+    "conform": {
+        "type": "csv",
+        "file": "ch-solothurn.csv",
+        "encoding": "utf-8",
+        "number": "hausnummer",
+        "street": "strasse",
+        "city": "public_geo_gemeinden_name",
+        "postcode": "public_geo_gemeinden_plz",
+        "lat": "Y",
+        "lon": "X"
+    }
+}


### PR DESCRIPTION
Another Swiss canton. This time no registration was required (though one still needs to accept the terms, etc). The main shape file with addresses only contained the id of the district (gemeinde), not the name, so I used QGIS to join the address shape file with the gemeinden shape file.
The original address file is here: https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/sergiyprotsiv/2565b3/sogis_1483513972.zip
The original district file is here: https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/sergiyprotsiv/198a8f/sogis_1483514338.zip