### PR TITLE
Grisons/Graubünden, Switzerland

### DIFF
--- a/sources/ch/grisons.json
+++ b/sources/ch/grisons.json
@@ -4,7 +4,7 @@
         "city": "Grisons"
     },
     "website": "http://geogr.mapserver.ch/shop/?q=de/prod_av",
-    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/sergiyprotsiv/ecee94/ch-gr.csv.zip",
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/sergiyprotsiv/8d3c1a/ch-gr.csv.zip",
     "type": "http",
     "compression": "zip",
     "license": {

--- a/sources/ch/grisons.json
+++ b/sources/ch/grisons.json
@@ -9,7 +9,7 @@
     "compression": "zip",
     "license": {
         "attribution": false,
-        "share-alike": false,
+        "share-alike": false
     },
     "conform": {
         "type": "csv",

--- a/sources/ch/grisons.json
+++ b/sources/ch/grisons.json
@@ -1,0 +1,26 @@
+{
+    "coverage": {
+        "country": "ch",
+        "city": "Grisons"
+    },
+    "website": "http://geogr.mapserver.ch/shop/?q=de/prod_av",
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/sergiyprotsiv/ecee94/ch-gr.csv.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "attribution": false,
+        "share-alike": false,
+    },
+    "conform": {
+        "type": "csv",
+        "file": "ch-gr.csv",
+        "encoding": "utf-8",
+        "id": "regbl_egid",
+        "number": "house_number",
+        "street": "street_name",
+        "city": "city",
+        "postcode": "postalcode",
+        "lat": "Y",
+        "lon": "X"
+    }
+}


### PR DESCRIPTION
Canton of Grisons/Graubünden. 

They have a WMS server (http://geogr.mapserver.ch/shop/?q=de/prod_av, see WMS), but you need to register to get the password to use it. The license file prohibits the distribution of the password, but regarding the data it only says that when the data is published it has no legal value (I assume this largely refer to parcels, ownership, etc).

This is a common theme across the Swiss datasets: they often require registration and acceptance of the terms, but the main issue they bring up in the terms is that the data they supply cannot be used in court, etc. I am assuming this is fine with OA, but maybe someone with better knowledge of German and legal issues can take a look.

In any case, the file I uploaded is the straight dump of the HADR layer of the WFS (which is the common name for house number layers across most cantons who have WFS).