### PR TITLE
Glarus, Switzerland

### DIFF
--- a/sources/ch/glarus.json
+++ b/sources/ch/glarus.json
@@ -3,7 +3,7 @@
         "country": "ch",
         "city": "Glarus"
     },
-    "website": "http://geogr.mapserver.ch/shop/?q=de/prod_av",
+    "website": "https://www.geodienste.ch/services",
     "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/sergiyprotsiv/8b7516/ch-gl.csv.zip",
     "type": "http",
     "compression": "zip",

--- a/sources/ch/glarus.json
+++ b/sources/ch/glarus.json
@@ -13,7 +13,7 @@
     },
     "conform": {
         "type": "csv",
-        "file": "ch-gr.csv",
+        "file": "ch-gl.csv",
         "encoding": "utf-8",
         "id": "RegBL_EGID",
         "number": "Numero_maison",

--- a/sources/ch/glarus.json
+++ b/sources/ch/glarus.json
@@ -1,0 +1,26 @@
+{
+    "coverage": {
+        "country": "ch",
+        "city": "Glarus"
+    },
+    "website": "http://geogr.mapserver.ch/shop/?q=de/prod_av",
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/sergiyprotsiv/8b7516/ch-gl.csv.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "attribution": false,
+        "share-alike": false
+    },
+    "conform": {
+        "type": "csv",
+        "file": "ch-gr.csv",
+        "encoding": "utf-8",
+        "id": "RegBL_EGID",
+        "number": "Numero_maison",
+        "street": "Nom_de_rue",
+        "city": "Ortschaft",
+        "postcode": "PLZ",
+        "lat": "Y",
+        "lon": "X"
+    }
+}


### PR DESCRIPTION
Canton of Glarus, Switzerland.

The main data is sourced from the nationwide website with open geodata (https://www.geodienste.ch/services). So far they only have three open datasets of addresses (two I have covered yesterday from respective cantons), but hopefully they will add more in the future.

The data did not have municipality or postcode, so I did a spatial join with the layer of postal code areas (PLZ-Gebiete) from the official Canton of Glarus WFS: https://wfs.geo.gl.ch/Public?VERSION=1.1.0. 