### PR TITLE
Schwyz, Switzerland

### DIFF
--- a/sources/ch/schwyz.json
+++ b/sources/ch/schwyz.json
@@ -4,7 +4,7 @@
         "city": "Schwyz"
     },
     "website": "http://geoshop.sz.ch/client5/index_sz.html?user=sz_public&password=public",
-    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/sergiyprotsiv/9cee67/ch-sz.csv.zip",
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/sergiyprotsiv/559828/ch-sz.csv.zip",
     "type": "http",
     "compression": "zip",
     "license": {

--- a/sources/ch/schwyz.json
+++ b/sources/ch/schwyz.json
@@ -1,0 +1,26 @@
+{
+    "coverage": {
+        "country": "ch",
+        "city": "Schwyz"
+    },
+    "website": "http://geoshop.sz.ch/client5/index_sz.html?user=sz_public&password=public",
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/sergiyprotsiv/9cee67/ch-sz.csv.zip",
+    "type": "http",
+    "compression": "zip",
+    "license": {
+        "attribution": false,
+        "share-alike": false
+    },
+    "conform": {
+        "type": "csv",
+        "file": "ch-sz.csv",
+        "encoding": "utf-8",
+        "id": "GWR_EGID",
+        "number": "Hausnummer",
+        "street": "Lokalisati",
+        "city": "Ortschafts",
+        "postcode": "PLZ",
+        "lat": "Y",
+        "lon": "X"
+    }
+}


### PR DESCRIPTION
Canton of Schwyz, Switzerland. 
This one came via a "geoshop" as well (http://geoshop.sz.ch/client5/index_sz.html?user=sz_public&password=public), but the query mechanism did not allow to select the whole canton at once. So, this is stitched from five separate query results and deduplicated within QGIS.