### PR TITLE
Volgograd Oblast, Russia

### DIFF
--- a/sources/ru/vgg/statewide.json
+++ b/sources/ru/vgg/statewide.json
@@ -9,7 +9,7 @@
         "state": "VGG"
     },
     "data": "http://gis-vo.volganet.ru/arcgis/rest/services/OpenData/AdressPlanVOAtlas/MapServer/0",
-    "type": "http",
+    "type": "ESRI",
     "language": "ru",
     "conform": {
         "number": ["consturct", "letter"],

--- a/sources/ru/vgg/statewide.json
+++ b/sources/ru/vgg/statewide.json
@@ -1,0 +1,23 @@
+{
+    "coverage": {
+        "ISO 3166": {
+            "alpha2": "RU-VGG",
+            "country": "Russian Federation",
+            "subdivision": "Volgograd Oblast"
+        },
+        "country": "ru",
+        "state": "VGG"
+    },
+    "data": "http://gis-vo.volganet.ru/arcgis/rest/services/OpenData/AdressPlanVOAtlas/MapServer/0",
+    "type": "http",
+    "language": "ru",
+    "conform": {
+        "number": ["consturct", "letter"],
+        "street": ["street_type_text","street"],
+        "city": "raion",
+        "district": "raion_name",
+        "region": "Volgograd Oblast",
+        "id": "CAD_NUM",
+        "type": "geojson"
+    }
+}


### PR DESCRIPTION
A good open data address dataset for Volgograd Oblast in Russia (population 2.6 million). Will post a few more sources from the area eventually.
There are quite a few effectively blank lines, but they simply correspond to buildings that do not have a separate address. Not sure if filtering these out is handled automatically (i.e. if there is no street and no number, it can hardly be called an address point).