### PR TITLE
Curaçao countrywide

### DIFF
--- a/sources/cw/countrywide.json
+++ b/sources/cw/countrywide.json
@@ -7,6 +7,7 @@
     "website": "http://basiskaart.gobiernu.cw/",
     "type": "ESRI",
     "conform": {
+        "type": "geojson",
         "region": "Curaçao",
         "number": "Huisnummer",
         "street": "Straatnaam"

--- a/sources/cw/countrywide.json
+++ b/sources/cw/countrywide.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "cw",
+        "ISO 3166": {"alpha2": "CW", "country": "Curaçao"}
+    },
+    "data": "http://basiskaart.gobiernu.cw/arcgis/rest/services/GeoWeb/BasiskaartCuracaov3/MapServer/57",
+    "website": "http://basiskaart.gobiernu.cw/",
+    "type": "ESRI",
+    "conform": {
+        "region": "Curaçao",
+        "number": "Huisnummer",
+        "street": "Straatnaam"
+    }
+}


### PR DESCRIPTION
This layer is rather patchy in terms of having house numbers and does not contain the city, but more than 90% of the country lives in the capital, so that should not be an issue.