### PR TITLE
Israel countrywide

### DIFF
--- a/sources/il/countrywide-hebrew.json
+++ b/sources/il/countrywide-hebrew.json
@@ -5,6 +5,7 @@
     },
     "data": "http://www.sol-israel.co.il/arcgis/rest/services/Amidar_Vector/MapServer/9",
     "type": "ESRI",
+    "skip": true,
     "language": "HE",
     "conform": {
         "type": "geojson",

--- a/sources/il/countrywide-hebrew.json
+++ b/sources/il/countrywide-hebrew.json
@@ -7,6 +7,7 @@
     "type": "ESRI",
     "language": "IW",
     "conform": {
+        "type": "geojson",
         "city": "SETL_NAME",
         "number": "HOUSE_NUM",
         "unit": "ENTRY_LETR",

--- a/sources/il/countrywide-hebrew.json
+++ b/sources/il/countrywide-hebrew.json
@@ -5,12 +5,17 @@
     },
     "data": "http://www.sol-israel.co.il/arcgis/rest/services/Amidar_Vector/MapServer/9",
     "type": "ESRI",
-    "language": "IW",
+    "language": "HE",
+    "skip": true,
     "conform": {
         "type": "geojson",
         "city": "SETL_NAME",
-        "number": "HOUSE_NUM",
+        "number": {
+            "function": "format",
+            "fields": ["HOUSE_NUM", "ENTRY_LETR"],
+            "format": "$1$2"
+        },
         "unit": "ENTRY_LETR",
-        "street": "STR_FLNM"
+        "street": "STR_FULNAM"
     }
 }

--- a/sources/il/countrywide-hebrew.json
+++ b/sources/il/countrywide-hebrew.json
@@ -6,7 +6,6 @@
     "data": "http://www.sol-israel.co.il/arcgis/rest/services/Amidar_Vector/MapServer/9",
     "type": "ESRI",
     "language": "HE",
-    "skip": true,
     "conform": {
         "type": "geojson",
         "city": "SETL_NAME",

--- a/sources/il/countrywide-hebrew.json
+++ b/sources/il/countrywide-hebrew.json
@@ -1,0 +1,15 @@
+{
+    "coverage": {
+        "country": "il",
+        "ISO 3166": {"alpha2": "IL", "country": "Israel"}
+    },
+    "data": "http://www.sol-israel.co.il/arcgis/rest/services/Amidar_Vector/MapServer/9",
+    "type": "ESRI",
+    "language": "IW",
+    "conform": {
+        "city": "SETL_NAME",
+        "number": "HOUSE_NUM",
+        "unit": "ENTRY_LETR",
+        "street": "STR_FLNM"
+    }
+}

--- a/sources/il/countrywide-latin.json
+++ b/sources/il/countrywide-latin.json
@@ -6,6 +6,7 @@
     "data": "http://www.sol-israel.co.il/arcgis/rest/services/Amidar_Vector/MapServer/9",
     "type": "ESRI",
     "conform": {
+        "type": "geojson",
         "city": "SETL_NAME_LTN",
         "number": "HOUSE_NUM",
         "unit": "ENTRY_LETR",

--- a/sources/il/countrywide-latin.json
+++ b/sources/il/countrywide-latin.json
@@ -5,7 +5,6 @@
     },
     "data": "http://www.sol-israel.co.il/arcgis/rest/services/Amidar_Vector/MapServer/9",
     "type": "ESRI",
-    "skip": true,
     "conform": {
         "type": "geojson",
         "city": "SETL_NAME_LTN",

--- a/sources/il/countrywide-latin.json
+++ b/sources/il/countrywide-latin.json
@@ -5,6 +5,7 @@
     },
     "data": "http://www.sol-israel.co.il/arcgis/rest/services/Amidar_Vector/MapServer/9",
     "type": "ESRI",
+    "skip": true,
     "conform": {
         "type": "geojson",
         "city": "SETL_NAME_LTN",

--- a/sources/il/countrywide-latin.json
+++ b/sources/il/countrywide-latin.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "il",
+        "ISO 3166": {"alpha2": "IL", "country": "Israel"}
+    },
+    "data": "http://www.sol-israel.co.il/arcgis/rest/services/Amidar_Vector/MapServer/9",
+    "type": "ESRI",
+    "conform": {
+        "city": "SETL_NAME_LTN",
+        "number": "HOUSE_NUM",
+        "unit": "ENTRY_LETR",
+        "street": "STR_FLNM_LTN"
+    }
+}

--- a/sources/il/countrywide-latin.json
+++ b/sources/il/countrywide-latin.json
@@ -5,10 +5,15 @@
     },
     "data": "http://www.sol-israel.co.il/arcgis/rest/services/Amidar_Vector/MapServer/9",
     "type": "ESRI",
+    "skip": true,
     "conform": {
         "type": "geojson",
         "city": "SETL_NAME_LTN",
-        "number": "HOUSE_NUM",
+        "number": {
+            "function": "format",
+            "fields": ["HOUSE_NUM", "ENTRY_LETR"],
+            "format": "$1$2"
+        },
         "unit": "ENTRY_LETR",
         "street": "STR_FLNM_LTN"
     }


### PR DESCRIPTION
Here is a great quality source for Israel. It is available in the open, however I cannot fully determine its provenance.

Has both Latin and Hebrew versions of addresses (as separate files). Many building include "entrances", which I coded as "unit". This is usually a numeral in Hebrew, but I kept it in the Latin source too.

The geometry is oddly a linestring, hopefully the machine handles those too.