### PR TITLE
Almaty, Kazakhstan

### DIFF
--- a/sources/kz/ala-statewide.json
+++ b/sources/kz/ala-statewide.json
@@ -1,0 +1,17 @@
+{
+    "coverage": {
+        "country": "kz",
+        "ISO 3166": {
+          "alpha2": "KZ-ALA", 
+          "country": "Kazakhstan",
+          "subdivision": "Almaty"}
+    },
+    "data": "http://infopublic.pravstat.kz:8399/arcgis/rest/services/Kazakhstan/MapServer/20",
+    "attribution": "Комитет по правовой статистике и специальным учетам Генеральной прокуратуры Республики Казахстан",
+    "type": "ESRI",
+    "conform": {
+        "city": "Алматы",
+        "number": "NUMBER_1",
+        "street": "STREET_NAM"
+    }
+}

--- a/sources/kz/ala-statewide.json
+++ b/sources/kz/ala-statewide.json
@@ -9,6 +9,7 @@
     "data": "http://infopublic.pravstat.kz:8399/arcgis/rest/services/Kazakhstan/MapServer/20",
     "attribution": "Комитет по правовой статистике и специальным учетам Генеральной прокуратуры Республики Казахстан",
     "type": "ESRI",
+    "language": "ru",
     "conform": {
         "city": "Алматы",
         "number": "NUMBER_1",

--- a/sources/kz/ala-statewide.json
+++ b/sources/kz/ala-statewide.json
@@ -11,6 +11,7 @@
     "type": "ESRI",
     "language": "ru",
     "conform": {
+        "type": "geojson",
         "city": "Алматы",
         "number": "NUMBER_1",
         "street": "STREET_NAM"


### PR DESCRIPTION
Here is a layer for Almaty, the largest city in Kazakhstan. This is sourced from the public map of the Attorney General GIS website infopublic.pravstat.kz (which they use to display crime rates, traffic collisions, etc).

I do not think there is any license attached, but it is in public access from a governmental website specifically created for public purpose. If you think it's fine, I'll format the rest of the country.