### PR TITLE
fixing house numbers in Volgograd oblast

### DIFF
--- a/sources/ru/vgg/statewide.json
+++ b/sources/ru/vgg/statewide.json
@@ -12,7 +12,11 @@
     "type": "ESRI",
     "language": "ru",
     "conform": {
-        "number": ["consturct", "letter"],
+        "number": {
+            "function": "format",
+            "fields": ["construct", "letter"],
+            "format": "$1$2"
+        },
         "street": ["street_type_text","street"],
         "city": "raion",
         "district": "raion_name",


### PR DESCRIPTION
Number + letter should be concatenated. Also there was a spelling error for the field "construct" (the building number, more commonly used than letter) so wasn't getting picked up.