### PR TITLE
Fix North Glengarry house numbers

### DIFF
--- a/sources/ca/on/north_glengarry.json
+++ b/sources/ca/on/north_glengarry.json
@@ -12,8 +12,7 @@
         "number": {
             "function": "regexp",
             "field": "LOCATION",
-            "pattern": "^([0-9]+)( .*)",
-            "replace": "$1"
+            "pattern": "^([0-9]+(?:\-[0-9]+)?)(?: .*)"
         },
         "street": "STREETNAME",
         "type": "shapefile"

--- a/sources/ca/on/north_glengarry.json
+++ b/sources/ca/on/north_glengarry.json
@@ -4,7 +4,7 @@
         "state": "on",
         "county": "North Glengarry"
     },
-    "type": "HTTP",
+    "type": "http",
     "compression": "zip",
     "data": "http://data.openaddresses.io/cache/ca-on-north_glengarry.zip",
     "note": "Obtained via FOI Request June 2016 by nicholas ingalls <nicholas.ingalls@gmail.com>",


### PR DESCRIPTION
Regex didn't account for hyphenated numbers.

Also using "replace": "$1" will insert the full string if the field doesn't match the regex. One way to ensure that records match the regex is to remove the "replace" directive and only use one capture group as the default behavior in that case is to whitespace-join all captured groups as a string.

There's also probably a larger discussion to be had about the desired behavior of "replace", but this method will work in the meantime.