### PR TITLE
Moscow, Russia

### DIFF
--- a/scripts/ru/msk_parse.py
+++ b/scripts/ru/msk_parse.py
@@ -1,0 +1,122 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+import re
+import sys
+import requests
+import json
+from shapely.geometry import Polygon, Point
+
+
+base_url = "http://api.data.mos.ru/v1/datasets/1927/"
+dump_filename = "/users/seriozha/Downloads/ru-msk.csv"
+
+s = requests.Session()
+outfile = open(dump_filename,'w')
+
+count = int(s.get(base_url + "count").content)
+
+print "Processing " + str(count) + " rows..."
+
+step = 500
+
+outfile.write("GUID,Address,Raion,Housenumber,Unit,Building,CityParsed,StreetParsed,lon,lat\n")
+
+
+for i in range(25000/step, count / step + 1):
+	step_url = base_url + "rows?$top=" + str(step) + "&$orderby=global_id&$skip=" + str(i * step)
+	print step_url
+	
+	for item in json.loads(s.get(step_url).content):
+		cells = item["Cells"]
+		
+		export_string = str(cells["global_id"]) + ","
+		
+		full_address = cells["ADRES"]
+		admArea = cells["AdmArea"]
+		house = cells["DMT"]
+		korp = cells["KRT"]
+		bldg = cells["STRT"]
+		
+		
+		if full_address is not None and len(full_address) >0 :
+			export_string += '"'+(full_address.replace("\"", "\"\"").encode('utf-8'))+'",'
+		else:
+			export_string += '"",'
+			
+		if admArea is not None and len(admArea) >0 :
+			export_string += '"'+str(admArea[0].encode('utf-8'))+'",'
+		else:
+			export_string += '"",'
+			
+		if house is not None and len(house) >0 :
+			export_string += '"'+str(house.encode('utf-8'))+'",'
+		else:
+			export_string += '"",'
+			
+		if korp is not None and len(korp) >0 :
+			export_string += '"'+str(korp.encode('utf-8'))+'",'
+		else:
+			export_string += '"",'
+		
+		if bldg is not None and len(bldg) >0 :
+			export_string += '"'+str(bldg.encode('utf-8'))+'",'
+		else:
+			export_string += '"",'
+			
+			
+		elems = full_address.split(",")
+
+		if bldg is not None and len(bldg) > 0:
+			elems.pop()
+			
+		if korp is not None and len(korp) > 0:
+			elems.pop()
+			
+		if house is not None and len(house) > 0:
+			elems.pop()
+		
+		if len(elems) > 0:
+			matchstring = elems[0]
+			m = re.search(u'(^(г. )|(г .)|(город )|(деревня )|(посёлок ))(.*)', matchstring)
+
+			# Check if the first field contains 
+			if m is not None:
+				city = matchstring[len(m.group(1)):len(matchstring)]
+				elems.pop(0)
+			else:
+				city = u"Москва"
+			
+			export_string += '"'+city.strip().encode('utf-8')+'",'
+		
+			if len(elems) > 0:
+				export_string += '"'+elems.pop().strip().encode('utf-8')+'",'
+			else:
+				export_string += ','
+		else:
+			export_string += ',,'
+			
+		if "geoData" in cells:
+			flat_coords = cells["geoData"]["coordinates"]
+			while not isinstance(flat_coords[0], float):
+			 	flat_coords = [item for sublist in flat_coords for item in sublist]
+			
+			if flat_coords is not None:
+				if len(flat_coords) > 4:
+					coords = []
+					for i in xrange(len(flat_coords) / 2):
+						coords.append([flat_coords[i*2], flat_coords[i*2+1]])
+					geom = Polygon(coords)
+					export_string += str(geom.centroid.x)+','+str(geom.centroid.y)+"\n"
+				elif len(flat_coords) > 0:
+					export_string += str(flat_coords[0])+','+str(gflat_coords[1])+"\n"
+				else:
+					export_string += '","\n'
+			else:
+				export_string += ',\n'
+		else:
+			export_string += ',\n'
+		
+		outfile.write(export_string)
+
+outfile.close()

--- a/scripts/ru/msk_parse.py
+++ b/scripts/ru/msk_parse.py
@@ -82,10 +82,10 @@ for i in range(25000/step, count / step + 1):
 
 			# Check if the first field contains 
 			if m is not None:
-				city = matchstring[len(m.group(1)):len(matchstring)]
+				city = matchstring
 				elems.pop(0)
 			else:
-				city = u"Москва"
+				city = u"г. Москва"
 			
 			export_string += '"'+city.strip().encode('utf-8')+'",'
 		

--- a/sources/ru/mow/statewide.json
+++ b/sources/ru/mow/statewide.json
@@ -19,10 +19,15 @@
     "compression": "zip",
     "language": "ru",
     "conform": {
-        "number": ["Housenumber","Unit","Building"],
+        "number": {
+            "function": "format",
+            "fields": ["Housenumber", "Building"],
+            "format": "дом $1, строение $2"
+        },
         "street": "StreetParsed",
         "city": "CityParsed",
         "district": "raion",
+        "unit": "Unit",
         "id": "GUID",
         "type": "csv",
         "lat": "lat",

--- a/sources/ru/mow/statewide.json
+++ b/sources/ru/mow/statewide.json
@@ -9,6 +9,12 @@
         "state": "MOW"
     },
     "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/sergiyprotsiv/736ec4/ru-msk.csv.zip",
+    "website": "http://data.mos.ru/opendata/7705031674-adresniy-reestr-zdaniy-i-soorujeniy-v-gorode-moskve",
+    "license": {
+        "url": "https://apidata.mos.ru/Home/Terms",
+        "attribution": true,
+        "share-alike": false
+        },
     "type": "http",
     "language": "ru",
     "conform": {

--- a/sources/ru/mow/statewide.json
+++ b/sources/ru/mow/statewide.json
@@ -16,6 +16,7 @@
         "share-alike": false
         },
     "type": "http",
+    "compression": "zip",
     "language": "ru",
     "conform": {
         "number": ["Housenumber","Unit","Building"],

--- a/sources/ru/mow/statewide.json
+++ b/sources/ru/mow/statewide.json
@@ -21,13 +21,12 @@
     "conform": {
         "number": {
             "function": "format",
-            "fields": ["Housenumber", "Building"],
-            "format": "дом $1, строение $2"
+            "fields": ["Housenumber", "Unit", "Building"],
+            "format": "дом $1, корпус $2, строение $3"
         },
         "street": "StreetParsed",
         "city": "CityParsed",
         "district": "raion",
-        "unit": "Unit",
         "id": "GUID",
         "type": "csv",
         "lat": "lat",

--- a/sources/ru/msk/statewide.json
+++ b/sources/ru/msk/statewide.json
@@ -1,0 +1,24 @@
+{
+    "coverage": {
+        "ISO 3166": {
+            "alpha2": "RU-MOW",
+            "country": "Russian Federation",
+            "subdivision": "Moscow"
+        },
+        "country": "ru",
+        "state": "MOW"
+    },
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/sergiyprotsiv/736ec4/ru-msk.csv.zip",
+    "type": "http",
+    "language": "ru",
+    "conform": {
+        "number": ["Housenumber","Unit","Building"],
+        "street": "StreetParsed",
+        "city": "CityParsed",
+        "district": "raion",
+        "id": "GUID",
+        "type": "csv",
+        "lat": "lat",
+        "lon": "lon"
+    }
+}


### PR DESCRIPTION
This is an official dataset for Moscow. There are plenty of more convenient ESRI servers with data for Moscow, but this one is actually published by the city of Moscow as an official open data resource, so I think it is most in line with the priorities of OA.

I am attaching the script to get the data from their APIs (where they use a custom JSON format). Most addresses refer to Moscow, but some are for nearby towns, in which case the city name is prepended to the address. The original address line also contains the house number, the unit ("korpus") and the building number, which are all used to identify a specific building and thus I concatenated them as a the "number" property. It might be better to put them in a specific format: "д. 5а к. 10 с. 2" or something like that. Note that none of the three sub-parts are required (though "house" is usually there).  

Parsing the street and city names are down in clumsy Python, but can probably be just as well accomplished using regex (after I've seen what can be done in Belarus). Would be good to ensure that the default value for "city" is "Москва" though.