### PR TITLE
Update Moscow to include city types

### DIFF
--- a/sources/ru/mow/statewide.json
+++ b/sources/ru/mow/statewide.json
@@ -8,7 +8,7 @@
         "country": "ru",
         "state": "MOW"
     },
-    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/sergiyprotsiv/736ec4/ru-msk.csv.zip",
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/sergiyprotsiv/cfbc25/ru-msk.csv.zip",
     "website": "http://data.mos.ru/opendata/7705031674-adresniy-reestr-zdaniy-i-soorujeniy-v-gorode-moskve",
     "license": {
         "url": "https://apidata.mos.ru/Home/Terms",


### PR DESCRIPTION
This is the new run of the script where I did not strip the city type (i.e. it is now "г. Москва" instead of just "Москва")