### PR TITLE
Saint Petersburg, Russia

### DIFF
--- a/sources/ru/spe/statewide.json
+++ b/sources/ru/spe/statewide.json
@@ -1,0 +1,33 @@
+{
+    "coverage": {
+        "ISO 3166": {
+            "alpha2": "RU-SPE",
+            "country": "Russian Federation",
+            "subdivision": "Saint Petersburg"
+        },
+        "country": "ru",
+        "state": "SPE"
+    },
+    "data": "http://gis.iac.spb.ru/arcgis/rest/services/EAS_SERVICE/EAS_SERVICE_WGS84/MapServer/3",
+    "type": "ESRI",
+    "language": "ru",
+    "conform": {
+        "number": {
+            "function": "format",
+            "fields": ["HOUSE", "LITER", "КОРПУС"],
+            "format": "$1$2 корпус $3"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "PADDRESS",
+            "pattern": "^(?:.*?),(.*),(?:.*?)$" 
+        },
+        "city": {
+            "function": "regexp",
+            "field": "PADDRESS",
+            "pattern": "^(.*?),(?:.*?)$" 
+        },
+        "id": "ID_BUILDING_EAS",
+        "type": "geojson"
+    }
+}


### PR DESCRIPTION
The data comes from the official city information portal. 

I have tried the regex, but please correct if something is odd. For the house number, the most traditional way to write is "72А к2" or "д. 72А к. 2" instead of "дом 72 корпус 2 литера А". The "литера А" part first of all refers to the house number, not to "korpus", and secondly it is ridiculous to spell it out as "литера А" (a US analogue would be to write "California street direction North" for "N California St")