### PR TITLE
Updating license information in Switzerland

### DIFF
--- a/sources/ch/basel-land.json
+++ b/sources/ch/basel-land.json
@@ -11,7 +11,7 @@
     "type": "http",
     "compression": "zip",
     "license": {
-        "attribution": true,
+        "attribution": "Geodaten des Kantons Basel-Landschaft",
         "share-alike": false,
         "url": "https://www.geo.bl.ch/servlet/redirector/standard/geoshop/BLGeoShop.igs?user=public&password=public"
     },

--- a/sources/ch/basel-land.json
+++ b/sources/ch/basel-land.json
@@ -11,7 +11,8 @@
     "type": "http",
     "compression": "zip",
     "license": {
-        "attribution": "Geodaten des Kantons Basel-Landschaft",
+        "attribution": true,
+        "attribution name": "Geodaten des Kantons Basel-Landschaft",
         "share-alike": false,
         "url": "https://www.geo.bl.ch/servlet/redirector/standard/geoshop/BLGeoShop.igs?user=public&password=public"
     },

--- a/sources/ch/basel-stadt.json
+++ b/sources/ch/basel-stadt.json
@@ -11,7 +11,8 @@
     "type": "http",
     "compression": "zip",
     "license": {
-        "attribution": "Geodaten Kanton Basel-Stadt",
+        "attribution": true,
+        "attribution name": "Geodaten Kanton Basel-Stadt",
         "share-alike": false,
         "url": "http://www.geo.bs.ch/geodaten/geodaten-shop/nutzungsbedingungen.html"
     },

--- a/sources/ch/basel-stadt.json
+++ b/sources/ch/basel-stadt.json
@@ -11,7 +11,7 @@
     "type": "http",
     "compression": "zip",
     "license": {
-        "attribution": true,
+        "attribution": "Geodaten Kanton Basel-Stadt",
         "share-alike": false,
         "url": "http://www.geo.bs.ch/geodaten/geodaten-shop/nutzungsbedingungen.html"
     },

--- a/sources/ch/glarus.json
+++ b/sources/ch/glarus.json
@@ -6,7 +6,7 @@
             "alpha2": "CH-GL"
         }
     },
-    "website": "https://www.geodienste.ch/services",
+    "website": "https://geodienste.ch/",
     "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/sergiyprotsiv/8b7516/ch-gl.csv.zip",
     "type": "http",
     "compression": "zip",

--- a/sources/ch/grisons.json
+++ b/sources/ch/grisons.json
@@ -11,7 +11,8 @@
     "type": "http",
     "compression": "zip",
     "license": {
-        "attribution": "Amtliche Vermessung (AV), Kanton Graubuenden, 05.01.2017",
+        "attribution": true,
+        "attribution name": "Amtliche Vermessung (AV), Kanton Graubuenden, 05.01.2017",
         "share-alike": false
     },
     "conform": {

--- a/sources/ch/grisons.json
+++ b/sources/ch/grisons.json
@@ -11,7 +11,7 @@
     "type": "http",
     "compression": "zip",
     "license": {
-        "attribution": false,
+        "attribution": "Amtliche Vermessung (AV), Kanton Graubünden, 05.01.2017",
         "share-alike": false
     },
     "conform": {

--- a/sources/ch/grisons.json
+++ b/sources/ch/grisons.json
@@ -11,7 +11,7 @@
     "type": "http",
     "compression": "zip",
     "license": {
-        "attribution": "Amtliche Vermessung (AV), Kanton Graubünden, 05.01.2017",
+        "attribution": "Amtliche Vermessung (AV), Kanton Graubuenden, 05.01.2017",
         "share-alike": false
     },
     "conform": {

--- a/sources/ch/schwyz.json
+++ b/sources/ch/schwyz.json
@@ -9,6 +9,7 @@
     "website": "http://geoshop.sz.ch/client5/index_sz.html?user=sz_public&password=public",
     "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/sergiyprotsiv/559828/ch-sz.csv.zip",
     "type": "http",
+    "skip": true,
     "compression": "zip",
     "license": {
         "attribution": false,

--- a/sources/ch/uri.json
+++ b/sources/ch/uri.json
@@ -10,10 +10,6 @@
     "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/sergiyprotsiv/a24c45/ch-ur.csv.zip",
     "type": "http",
     "compression": "zip",
-    "license": {
-        "attribution": false,
-        "share-alike": false
-    },
     "conform": {
         "type": "csv",
         "file": "ch-ur.csv",


### PR DESCRIPTION
After a review of the licenses using suggestions by @simonpoole, here are some of the changes to the cantons that I have contributed:
- Removed canton of Schwyz since the license poses restriction on use without prior confirmation with the source (if someone want to contact the source, please go ahead)
- Fixed the attribution in some cantons to be more specific
- Removed the license data to not imply CC0 in Uri
- This leaves Uri, Luzern and Aargau without the licenses since currency we are using the public ERSI/WMS servers and the copyright information in them is not readily present.

The status of Grisons is to be determined depending on whether I have interpreted the license correctly: https://github.com/openaddresses/openaddresses/commit/17e4e29fac52b032fc68d6fcdf1827df98a4a554