### PR TITLE
Chechen Republic, Russia 

### DIFF
--- a/sources/ru/ce/argun.json
+++ b/sources/ru/ce/argun.json
@@ -3,7 +3,7 @@
         "country": "ru",
         "city": "Argun"
     },
-    "data": "http://geoportal95.ru:6080/arcgis/rest/services/%D0%90%D0%B4%D1%80%D0%B5%D1%81%D0%BD%D1%8B%D0%B9_%D0%BF%D0%BB%D0%B0%D0%BD_zd/MapServer/5",
+    "data": "http://geoportal95.ru:6080/arcgis/rest/services/%D0%90%D0%B4%D1%80%D0%B5%D1%81%D0%BD%D1%8B%D0%B9_%D0%BF%D0%BB%D0%B0%D0%BD_zd/MapServer/9",
     "type": "ESRI",
     "language": "ru",
     "conform": {

--- a/sources/ru/ce/argun.json
+++ b/sources/ru/ce/argun.json
@@ -1,0 +1,17 @@
+{
+    "coverage": {
+        "country": "ru",
+        "city": "Argun"
+    },
+    "data": "http://geoportal95.ru:6080/arcgis/rest/services/%D0%90%D0%B4%D1%80%D0%B5%D1%81%D0%BD%D1%8B%D0%B9_%D0%BF%D0%BB%D0%B0%D0%BD_zd/MapServer/5",
+    "type": "ESRI",
+    "language": "ru",
+    "conform": {
+        "number": "Nomer_doma",
+        "street": "Name_UL",
+        "city": "Toponim",
+        "district": "Raion",
+        "postcode": "P_Indeks",
+        "type": "geojson"
+    }
+}

--- a/sources/ru/ce/gikalo.json
+++ b/sources/ru/ce/gikalo.json
@@ -1,0 +1,17 @@
+{
+    "coverage": {
+        "country": "ru",
+        "city": "Gikalo"
+    },
+    "data": "http://geoportal95.ru:6080/arcgis/rest/services/%D0%90%D0%B4%D1%80%D0%B5%D1%81%D0%BD%D1%8B%D0%B9_%D0%BF%D0%BB%D0%B0%D0%BD_zd/MapServer/5",
+    "type": "ESRI",
+    "language": "ru",
+    "conform": {
+        "number": "Nomer_doma",
+        "street": "Name_UL",
+        "city": "Toponim",
+        "district": "Raion",
+        "postcode": "P_Indeks",
+        "type": "geojson"
+    }
+}

--- a/sources/ru/ce/grozny.json
+++ b/sources/ru/ce/grozny.json
@@ -1,0 +1,21 @@
+{
+    "coverage": {
+        "country": "ru",
+        "city": "Grozny"
+    },
+    "data": "http://geoportal95.ru:6080/arcgis/rest/services/%D0%90%D0%B4%D1%80%D0%B5%D1%81%D0%BD%D1%8B%D0%B9_%D0%BF%D0%BB%D0%B0%D0%BD_zd/MapServer/1",
+    "type": "ESRI",
+    "language": "ru",
+    "conform": {
+        "number": "Nomer_doma",
+        "street": "Name_UL",
+        "city": {
+            "function": "regexp",
+            "field": "Adres",
+            "pattern": "^(?:.*)?,(?:.*)?,(.*),(?:.*)?$"
+        }
+        "district": "Raion",
+        "postcode": "P_Indeks",
+        "type": "geojson"
+    }
+}

--- a/sources/ru/ce/grozny.json
+++ b/sources/ru/ce/grozny.json
@@ -3,7 +3,7 @@
         "country": "ru",
         "city": "Grozny"
     },
-    "data": "http://geoportal95.ru:6080/arcgis/rest/services/%D0%90%D0%B4%D1%80%D0%B5%D1%81%D0%BD%D1%8B%D0%B9_%D0%BF%D0%BB%D0%B0%D0%BD_zd/MapServer/1",
+    "data": "http://geoportal95.ru:6080/arcgis/rest/services/%D0%90%D0%B4%D1%80%D0%B5%D1%81%D0%BD%D1%8B%D0%B9_%D0%BF%D0%BB%D0%B0%D0%BD_zd/MapServer/7",
     "type": "ESRI",
     "language": "ru",
     "conform": {

--- a/sources/ru/ce/grozny.json
+++ b/sources/ru/ce/grozny.json
@@ -13,7 +13,7 @@
             "function": "regexp",
             "field": "Adres",
             "pattern": "^(?:.*)?,(?:.*)?,(.*),(?:.*)?$"
-        }
+        },
         "district": "Raion",
         "postcode": "P_Indeks",
         "type": "geojson"

--- a/sources/ru/ce/grozny.json
+++ b/sources/ru/ce/grozny.json
@@ -9,11 +9,7 @@
     "conform": {
         "number": "Nomer_doma",
         "street": "Name_UL",
-        "city": {
-            "function": "regexp",
-            "field": "Adres",
-            "pattern": "^(?:.*)?,(?:.*)?,(.*),(?:.*)?$"
-        },
+        "city": "г. Грозный",
         "district": "Raion",
         "postcode": "P_Indeks",
         "type": "geojson"

--- a/sources/ru/ce/gudermes.json
+++ b/sources/ru/ce/gudermes.json
@@ -1,7 +1,7 @@
 {
     "coverage": {
         "country": "ru",
-        "city": "Kurchaloy"
+        "city": "Gudermes"
     },
     "data": "http://geoportal95.ru:6080/arcgis/rest/services/%D0%90%D0%B4%D1%80%D0%B5%D1%81%D0%BD%D1%8B%D0%B9_%D0%BF%D0%BB%D0%B0%D0%BD_zd/MapServer/3",
     "type": "ESRI",

--- a/sources/ru/ce/gudermes.json
+++ b/sources/ru/ce/gudermes.json
@@ -1,0 +1,17 @@
+{
+    "coverage": {
+        "country": "ru",
+        "city": "Kurchaloy"
+    },
+    "data": "http://geoportal95.ru:6080/arcgis/rest/services/%D0%90%D0%B4%D1%80%D0%B5%D1%81%D0%BD%D1%8B%D0%B9_%D0%BF%D0%BB%D0%B0%D0%BD_zd/MapServer/3",
+    "type": "ESRI",
+    "language": "ru",
+    "conform": {
+        "number": "Nomer_doma",
+        "street": "Name_UL",
+        "city": "Toponim",
+        "district": "Raion",
+        "postcode": "P_Indeks",
+        "type": "geojson"
+    }
+}

--- a/sources/ru/ce/kurchaloy.json
+++ b/sources/ru/ce/kurchaloy.json
@@ -1,0 +1,17 @@
+{
+    "coverage": {
+        "country": "ru",
+        "city": "Kurchaloy"
+    },
+    "data": "http://geoportal95.ru:6080/arcgis/rest/services/%D0%90%D0%B4%D1%80%D0%B5%D1%81%D0%BD%D1%8B%D0%B9_%D0%BF%D0%BB%D0%B0%D0%BD_zd/MapServer/1",
+    "type": "ESRI",
+    "language": "ru",
+    "conform": {
+        "number": "Nomer_doma",
+        "street": "Name_UL",
+        "city": "Toponim",
+        "district": "Raion",
+        "postcode": "P_Indeks",
+        "type": "geojson"
+    }
+}


### PR DESCRIPTION
This covers the majority of Chechen Republic (though not completely). From their official GIS site.
Contains five nearly identical source files for separate cities (Grozny has a regex for city since in that file if the address was in the main city the field was left blank). 