### PR TITLE
Thüringen, Germany

### DIFF
--- a/scripts/de/th/process.py
+++ b/scripts/de/th/process.py
@@ -1,0 +1,21 @@
+# coding: utf-8
+
+# Download the file from http://geoportal.geoportal-th.de/hausko_umr/HK-TH.zip
+# Unzip and run from within the unzipped folder
+
+import csv
+import six
+reader = csv.reader(open('schluessel-TH.txt'), delimiter=';')
+cities = {}
+for line in reader:
+    if line[0] == 'G':
+        cities[tuple(line[1:5])] = line[5]
+
+reader = csv.reader(open('adressen-TH.txt'), delimiter=';')
+writer = csv.writer(open('thuringen.txt', 'w'), delimiter=';')
+for line in reader:
+    city_id = line[3:7]
+    city = cities.get(tuple(city_id), '')
+    line.append(city)
+    writer.writerow(line)
+    

--- a/sources/de/th/statewide.json
+++ b/sources/de/th/statewide.json
@@ -1,0 +1,20 @@
+{
+	"coverage": {
+        "country": "de",
+        "state": "th",
+	      "ISO 3166": { "alpha2": "DE-TH" }
+    },
+	"data": "http://geoportal.geoportal-th.de/hausko_umr/HK-TH.zip",
+	"website": "https://onlineshop.thueringen.de/th9/tlvermgeo/geoshop/flure/hauskoordinaten/",
+	"type": "http",
+	"compression": "zip",
+	"conform": {
+		"type": "csv",
+    "file": "HK-TH/adressen-TH.txt",
+    "srs": "EPSG:25832",
+		"street": "field_14",
+		"number": ["field_10","field_11"],
+		"lat": "field_13",
+		"lon": "field_12"
+	}
+}

--- a/sources/de/th/statewide.json
+++ b/sources/de/th/statewide.json
@@ -12,7 +12,7 @@
 		"type": "csv",
 		"csvsplit": ";",
 		"headers":-1,
-    		"file": "HK-TH/adressen-TH.txt",
+    		"file": "adressen-TH.txt",
     		"srs": "EPSG:25832",
 		"street": "COLUMN14",
 		"number": ["COLUMN10","COLUMN11"],

--- a/sources/de/th/statewide.json
+++ b/sources/de/th/statewide.json
@@ -13,7 +13,7 @@
 		"csvsplit": ";",
 		"headers":-1,
     		"file": "adressen-TH.txt",
-    		"srs": "EPSG:25832",
+    		"srs": "EPSG:4647",
 		"street": "COLUMN14",
 		"number": ["COLUMN10","COLUMN11"],
 		"lat": "COLUMN13",

--- a/sources/de/th/statewide.json
+++ b/sources/de/th/statewide.json
@@ -1,20 +1,22 @@
 {
 	"coverage": {
-        "country": "de",
-        "state": "th",
-	      "ISO 3166": { "alpha2": "DE-TH" }
-    },
+        	"country": "de",
+        	"state": "th",
+	      	"ISO 3166": { "alpha2": "DE-TH" }
+	},
 	"data": "http://geoportal.geoportal-th.de/hausko_umr/HK-TH.zip",
 	"website": "https://onlineshop.thueringen.de/th9/tlvermgeo/geoshop/flure/hauskoordinaten/",
 	"type": "http",
 	"compression": "zip",
 	"conform": {
 		"type": "csv",
-    "file": "HK-TH/adressen-TH.txt",
-    "srs": "EPSG:25832",
-		"street": "field_14",
-		"number": ["field_10","field_11"],
-		"lat": "field_13",
-		"lon": "field_12"
+		"csvsplit": ";",
+		"headers":-1,
+    		"file": "HK-TH/adressen-TH.txt",
+    		"srs": "EPSG:25832",
+		"street": "COLUMN14",
+		"number": ["COLUMN10","COLUMN11"],
+		"lat": "COLUMN13",
+		"lon": "COLUMN12"
 	}
 }

--- a/sources/de/th/statewide.json
+++ b/sources/de/th/statewide.json
@@ -4,7 +4,7 @@
         	"state": "th",
 	      	"ISO 3166": { "alpha2": "DE-TH" }
 	},
-	"data": "http://geoportal.geoportal-th.de/hausko_umr/HK-TH.zip",
+	"data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/sergiyprotsiv/d22567/thuringen.txt.zip",
 	"website": "https://onlineshop.thueringen.de/th9/tlvermgeo/geoshop/flure/hauskoordinaten/",
 	"type": "http",
 	"compression": "zip",
@@ -12,9 +12,10 @@
 		"type": "csv",
 		"csvsplit": ";",
 		"headers":-1,
-    		"file": "adressen-TH.txt",
+    		"file": "thuringen.txt",
     		"srs": "EPSG:4647",
 		"street": "COLUMN14",
+		"city": "COLUMN19",
 		"number": ["COLUMN10","COLUMN11"],
 		"lat": "COLUMN13",
 		"lon": "COLUMN12"


### PR DESCRIPTION
Could not pass by this statewide source for Thüringen. No specific license, but is is under the "open data" section of the official geoportal.
The source contains only street and address, city and other information is provided via foreign keys (which I skip to be able to use the source directly). 
No field names, so this is how I am guessing they should work. No specific SRID either, but the source mentions UTM Zone 32, so the first guess is that the SRID is 25832.