### PR TITLE
enabled, sharpened-up regexes

### DIFF
--- a/sources/ca/sk/saskatoon.json
+++ b/sources/ca/sk/saskatoon.json
@@ -29,6 +29,7 @@
     },
     "conform": {
         "type": "xml",
+        "file": "ParcelAddress.kml",
         "number": {
             "function": "regexp",
             "field": "Name",

--- a/sources/ca/sk/saskatoon.json
+++ b/sources/ca/sk/saskatoon.json
@@ -29,8 +29,6 @@
     },
     "conform": {
         "type": "xml",
-        "lon": "X",
-        "lat": "Y",
         "number": {
             "function": "regexp",
             "field": "Name",

--- a/sources/ca/sk/saskatoon.json
+++ b/sources/ca/sk/saskatoon.json
@@ -38,8 +38,7 @@
         "street": {
             "function": "regexp",
             "field": "Name",
-            "pattern": "^(?:\\d+(?:[a-zA-Z]|\/\\d+)?)\\s(.*?),",
-            "replace": "$1"
+            "pattern": "^(?:\\d+(?:[a-zA-Z]|\/\\d+)?)\\s+(.*?),"
         }
     }
 }

--- a/sources/ca/sk/saskatoon.json
+++ b/sources/ca/sk/saskatoon.json
@@ -15,6 +15,7 @@
     "website": "http://opendata-saskatoon.cloudapp.net/",
     "license": "http://www.saskatoon.ca/DEPARTMENTS/Corporate%20Services/Corporate%20Information%20Services/OpenData/Pages/TermsofService.aspx",
     "type": "http",
+    "compression": "zip",
     "note": {
         "file extension": "kml",
         "examples": [

--- a/sources/ca/sk/saskatoon.json
+++ b/sources/ca/sk/saskatoon.json
@@ -25,6 +25,7 @@
             "317B Taylor St E, Saskatoon,  SK CA",
             "233/235 11th St E, Saskatoon,  SK CA",
             "304 A 111th St W, Saskatoon, SK CA",
+            "1205 Ave O S, Saskatoon, SK CA",
             "N/A, Saskatoon,  SK CA",
             "U OF S, Saskatoon, SK CA"
         ]
@@ -35,7 +36,7 @@
         "number": {
             "function": "regexp",
             "field": "Name",
-            "pattern": "^(\\d+(?:[A-Z]|\/\\d+|\\s+[A-DF-MO-RT-VX-Z])?)"
+            "pattern": "^(\\d+(?:[A-Z]|\/\\d+|\\s+[A-DF-MO-RT-VX-Z])?)\\s+"
         },
         "street": {
             "function": "regexp",

--- a/sources/ca/sk/saskatoon.json
+++ b/sources/ca/sk/saskatoon.json
@@ -19,10 +19,12 @@
     "note": {
         "file extension": "kml",
         "examples": [
+            "1102 Spadina Cres W, Saskatoon,  SK CA",
             "1139 4th St E, Saskatoo, SK CA",
             "102 Sears Cove, Saskatoon, SK CA",
             "317B Taylor St E, Saskatoon,  SK CA",
             "233/235 11th St E, Saskatoon,  SK CA",
+            "304 A 111th St W, Saskatoon, SK CA",
             "N/A, Saskatoon,  SK CA",
             "U OF S, Saskatoon, SK CA"
         ]
@@ -33,12 +35,12 @@
         "number": {
             "function": "regexp",
             "field": "Name",
-            "pattern": "^(\\d+(?:[a-zA-Z]|\/\\d+)?)"
+            "pattern": "^(\\d+(?:[A-Z]|\/\\d+|\\s+[A-DF-MO-RT-VX-Z])?)"
         },
         "street": {
             "function": "regexp",
             "field": "Name",
-            "pattern": "^(?:\\d+(?:[a-zA-Z]|\/\\d+)?)\\s+(.*?),"
+            "pattern": "^(?:\\d+(?:[A-Z]|\/\\d+|\\s+[A-DF-MO-RT-VX-Z])?)\\s+(.*?),"
         }
     }
 }

--- a/sources/ca/sk/saskatoon.json
+++ b/sources/ca/sk/saskatoon.json
@@ -1,28 +1,44 @@
 {
     "coverage": {
+        "geometry": {
+            "type": "Point",
+            "coordinates": [
+                -106.717,
+                52.139
+            ]
+        },
         "country": "ca",
         "state": "sk",
         "city": "Saskatoon"
     },
-    "skip": true,
-    "data": "https://saskatoonopendataconfig.blob.core.windows.net/converteddata/ParcelAddress.csv",
+    "data": "http://opendata-saskatoon.cloudapp.net/DataBrowser/DownloadKml?container=SaskatoonOpenDataCatalogueBeta&entitySet=ParcelAddress&filter=NOFILTER",
     "website": "http://opendata-saskatoon.cloudapp.net/",
     "license": "http://www.saskatoon.ca/DEPARTMENTS/Corporate%20Services/Corporate%20Information%20Services/OpenData/Pages/TermsofService.aspx",
     "type": "http",
-    "note": "file extension is CSV",
+    "note": {
+        "file extension": "kml",
+        "examples": [
+            "1139 4th St E, Saskatoo, SK CA",
+            "102 Sears Cove, Saskatoon, SK CA",
+            "317B Taylor St E, Saskatoon,  SK CA",
+            "233/235 11th St E, Saskatoon,  SK CA",
+            "N/A, Saskatoon,  SK CA",
+            "U OF S, Saskatoon, SK CA"
+        ]
+    },
     "conform": {
-        "type": "csv",
-        "lon": "x",
-        "lat": "y",
+        "type": "xml",
+        "lon": "X",
+        "lat": "Y",
         "number": {
             "function": "regexp",
-            "field": "name",
-            "pattern": "^(\\S+)"
+            "field": "Name",
+            "pattern": "^(\\d+(?:[a-zA-Z]|\/\\d+)?)"
         },
         "street": {
             "function": "regexp",
-            "field": "name",
-            "pattern": "^(?:\\S+ )(.*)",
+            "field": "Name",
+            "pattern": "^(?:\\d+(?:[a-zA-Z]|\/\\d+)?)\\s(.*?),",
             "replace": "$1"
         }
     }


### PR DESCRIPTION
Source already existed but was set to skip, file was CSV w/o lat/lon info, and regexes needed to be refined.  Also added examples. 

Fixes #2412 