### PR TITLE
Medellín, Colombia

### DIFF
--- a/scripts/co/medellin.py
+++ b/scripts/co/medellin.py
@@ -1,0 +1,34 @@
+import json
+import math
+import sys
+import logging
+
+from esridump.dumper import EsriDumper
+
+logging.basicConfig(level=logging.DEBUG)
+
+outfile_name = sys.argv[1] if len(sys.argv) > 1 else 'medellin.geojson'
+
+d = EsriDumper('https://www.medellin.gov.co/arcgis/rest/services/ServiciosPlaneacion/Pot_base1/MapServer/0')
+
+outfile = open(outfile_name, 'w')
+
+outfile.write('{"type":"FeatureCollection","features":[\n')
+
+features = iter(d)
+
+try:
+    feature = next(features)
+
+    while True:
+        if not feature.get('geometry') or feature['geometry']['coordinates'][0] == 'NaN' or (type(feature['geometry']['coordinates'][0]) is float and math.isnan(feature['geometry']['coordinates'][0])):
+            feature = next(features)
+            continue
+        outfile.write(json.dumps(feature))
+        feature = next(features)
+        outfile.write(',\n')
+except StopIteration:
+    outfile.write('\n')
+
+outfile.write(']}')
+

--- a/sources/co/ant/medellin.json
+++ b/sources/co/ant/medellin.json
@@ -11,6 +11,10 @@
     "conform": {
         "type": "geojson",
         "number": "PLACA",
-        "street": ["TIPO_VIA", "NUMERO_VIA", "APENDICE_VIA"]
+        "street": {
+            "function": "format",
+            "fields": ["TIPO_VIA", "NUMERO_VIA", "APENDICE_VIA"],
+            "format": "$1 $2$3"
+        }
     }
 }

--- a/sources/co/ant/medellin.json
+++ b/sources/co/ant/medellin.json
@@ -14,7 +14,7 @@
         "number": {
             "function": "regexp",
             "field": "PLACA",
-            "pattern": "^.*?(?:\\(.*\\).*?$"
+            "pattern": "^(.*?)(?:\\s*\\(.*\\).*?)?$"
         },
         "street": "VIA",
         "unit": "INTERIOR"

--- a/sources/co/ant/medellin.json
+++ b/sources/co/ant/medellin.json
@@ -10,11 +10,12 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "number": "PLACA",
-        "street": {
-            "function": "format",
-            "fields": ["TIPO_VIA", "NUMERO_VIA", "APENDICE_VIA"],
-            "format": "$1 $2$3"
-        }
+        "number": {
+            "function": "regexp",
+            "field": "PLACA",
+            "pattern": "^.*?(?:\(.*\).*?$"
+        },
+        "street": "VIA",
+        "unit": "INTERIOR"
     }
 }

--- a/sources/co/ant/medellin.json
+++ b/sources/co/ant/medellin.json
@@ -5,9 +5,10 @@
         "city": "Medellín",
         "geometry": { "type": "Point", "coordinates": [-75.59, 6.23] }
     },
-    "data": "https://www.medellin.gov.co/arcgis/rest/services/ServiciosPlaneacion/Pot_base1/MapServer/0",
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/thatdatabaseguy/b0ed7b/medellin.geojson.zip",
     "website": "https://www.medellin.gov.co/geomedellin/",
-    "type": "ESRI",
+    "type": "http",
+    "compression": "zip",
     "conform": {
         "type": "geojson",
         "number": {

--- a/sources/co/ant/medellin.json
+++ b/sources/co/ant/medellin.json
@@ -1,0 +1,16 @@
+{
+    "coverage": {
+        "country": "co",
+        "region": "ant",
+        "city": "Medellín",
+        "geometry": { "type": "Point", "coordinates": [-75.59, 6.23] }
+    },
+    "data": "https://www.medellin.gov.co/arcgis/rest/services/ServiciosPlaneacion/Pot_base1/MapServer/0",
+    "website": "https://www.medellin.gov.co/geomedellin/",
+    "type": "ESRI",
+    "conform": {
+        "type": "geojson",
+        "number": "PLACA",
+        "street": ["TIPO_VIA", "NUMERO_VIA", "APENDICE_VIA"]
+    }
+}

--- a/sources/co/ant/medellin.json
+++ b/sources/co/ant/medellin.json
@@ -5,7 +5,7 @@
         "city": "Medellín",
         "geometry": { "type": "Point", "coordinates": [-75.59, 6.23] }
     },
-    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/thatdatabaseguy/b0ed7b/medellin.geojson.zip",
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/thatdatabaseguy/a512bf/medellin.geojson.zip",
     "website": "https://www.medellin.gov.co/geomedellin/",
     "type": "http",
     "compression": "zip",

--- a/sources/co/ant/medellin.json
+++ b/sources/co/ant/medellin.json
@@ -13,7 +13,7 @@
         "number": {
             "function": "regexp",
             "field": "PLACA",
-            "pattern": "^.*?(?:\(.*\).*?$"
+            "pattern": "^.*?(?:\\(.*\\).*?$"
         },
         "street": "VIA",
         "unit": "INTERIOR"


### PR DESCRIPTION
This source contains a field called `INTERIOR` which I believe should be mappedto unit, but I am not sure.  Also, the house number field (`PLACA`) includes the contents of the `INTERIOR` field at the end, inside parentheses, so it should probably be regexed away.

The website mentioned in the source has an "open data" section, but it does not seem to specify the terms of use.  Moreover, I am not sure this source can actually be directly accessed from that section of the website.