### PR TITLE
Cached source for Wuhan, China

### DIFF
--- a/sources/cn/42/wuhan.json
+++ b/sources/cn/42/wuhan.json
@@ -4,8 +4,9 @@
         "state": "42",
         "city": "Wuhan"
     },
-    "data": "http://www.digitalwuhan.gov.cn:8399/arcgis/rest/services/HHLJ/hhljdy/MapServer/0",
-    "type": "ESRI",
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/thatdatabaseguy/9810d4/wuhan.geojson.zip",
+    "type": "http",
+    "compression": "zip",
     "conform": {
         "type": "geojson",
         "number": {


### PR DESCRIPTION
pyesridump may not retrieve everything for sources that do not support feature count. This cached version contains all 3429 records in the Wuhan data set.

Related: #2387, #2427.