### PR TITLE
fixing elisions and house numbers in Laval, QC

### DIFF
--- a/sources/ca/qc/laval.json
+++ b/sources/ca/qc/laval.json
@@ -14,12 +14,7 @@
     "type": "http",
     "conform": {
         "type": "geojson",
-        "number": "CIVIQUE",
-        "street": [
-            "GENERIQUE",
-            "LIEN",
-            "TOPONYME"
-        ],
-        "unit": "ALPHA"
+        "number": "NO_CIVIQUE",
+        "street": "NOM_ADRESSE"
     }
 }


### PR DESCRIPTION
As with [Gatineau](https://github.com/openaddresses/openaddresses/pull/2266) it's better to use the full street name where available in French rather than concatenating components with spaces so things like "rue d'Amboise" don't become "rue d' Amboise".

Also the ALPHA field appears to refer to different house numbers ("[4148 Boulevard Sainte-Rose](https://www.google.com/maps/place/4148+Boulevard+Sainte-Rose,+Laval,+QC+H7R+3S8,+Canada/@45.5519853,-73.8728966,17z/data=!3m1!4b1!4m5!3m4!1s0x4cc9250d2dd23817:0xa85899911cf8721!8m2!3d45.5519816!4d-73.8707079)" and "[4148A Boulevard Sainte-Rose](https://www.google.com/maps/place/4148a+Boulevard+Sainte-Rose,+Laval,+QC+H7R+3S8,+Canada/@45.5519488,-73.8728878,17z/data=!3m1!4b1!4m5!3m4!1s0x4cc9250d2dd9b677:0x22a362d20869fd32!8m2!3d45.5519451!4d-73.8706991)" for instance).