### PR TITLE
Add Longueuil, Canada.

### DIFF
--- a/sources/ca/qc/longueuil.json
+++ b/sources/ca/qc/longueuil.json
@@ -15,6 +15,7 @@
     "conform": {
         "type": "geojson",
         "number": "NO_CIVIQUE",
-        "street": "GEOCODE_RUE"
+        "street": "GEOCODE_RUE",
+        "postcode": "CODE_POSTAL"
     }
 }

--- a/sources/ca/qc/longueuil.json
+++ b/sources/ca/qc/longueuil.json
@@ -1,0 +1,20 @@
+{
+    "coverage": {
+        "country": "ca",
+        "state": "qc",
+        "city": "Longueuil",
+        "geometry": {
+            "type": "Point",
+            "coordinates": [-73.5780032, 45.5112881]
+        }
+    },
+    "data": "https://www.longueuil.quebec/sites/longueuil/files/donnees_ouvertes/adresses.json",
+    "website": "https://www.longueuil.quebec/fr/donnees-ouvertes/adresses",
+    "license": "https://www.longueuil.quebec/fr/licence-utilisation",
+    "type": "http",
+    "conform": {
+        "type": "geojson",
+        "number": "NO_CIVIQUE",
+        "street": "GEOCODE_RUE"
+    }
+}


### PR DESCRIPTION
Source is the city's own open data [portal](https://www.longueuil.quebec/fr/donnees-ouvertes/adresses).