### PR TITLE
Korea countrywide

### DIFF
--- a/scripts/kr/korea.py
+++ b/scripts/kr/korea.py
@@ -1,0 +1,23 @@
+import csv
+import sys
+import subprocess
+
+if (len(sys.argv) < 2):
+    sys.exit('Usage: python korea.py file1 [file2 ...]')
+
+filenames = sys.argv[1:]
+
+for filename in filenames:
+    infile = open(filename)
+    outfile = open('{}.out'.format(filename), 'w')
+    reader = csv.reader(infile, delimiter='|')
+    writer = csv.writer(outfile, delimiter='|')
+    for line in reader:
+        building_number = line[9]
+        building_sub = line[10]
+        if building_number and not all((c == '0' for c in building_sub)):
+            building_number = '-'.join((building_number, building_sub))
+        writer.writerow(list(line) + [building_number])
+    subprocess.check_call(['mv', '{}.out'.format(filename), filename])
+    infile.close()
+    outfile.close()

--- a/sources/kr/11/provincewide.json
+++ b/sources/kr/11/provincewide.json
@@ -29,7 +29,7 @@
             ],
             "separator": " "
         },
-        
+        "csvsplit" : "|",
         "street": "COLUMN8",
         "postcode": "COLUMN13",
         "district": "COLUMN6",

--- a/sources/kr/11/provincewide.json
+++ b/sources/kr/11/provincewide.json
@@ -8,7 +8,7 @@
         "country": "kr",
         "state": "11"
     },
-    "data": "http://www.juso.go.kr/dn.do?boardId=GEODATA&fileName=%EA%B3%B5%EA%B0%84%EC%A0%95%EB%B3%B4%EC%9A%94%EC%95%BDDB_2%EC%9B%94%EB%B6%84.zip&realFileName=ENTRC_DB_1702.zip&regYmd=2017&num=10&fileNo=76008&logging=Y",
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/sergiyprotsiv/40a526/korea-feb2017.zip",
     "website": "http://www.juso.go.kr/addrlink/addressBuildDevNew.do?menu=geodata",
     "license": {
         "attribution name": "Ministry of the Interior"
@@ -21,14 +21,7 @@
         "file": "entrc_seoul.txt",
         "headers": -1,
         "encoding": "CP949",
-        "number": {
-            "function": "join",
-            "fields": [
-                "COLUMN10",
-                "COLUMN11"
-            ],
-            "separator": " "
-        },
+        "number": "COLUMN19",
         "csvsplit" : "|",
         "street": "COLUMN8",
         "postcode": "COLUMN13",

--- a/sources/kr/11/provincewide.json
+++ b/sources/kr/11/provincewide.json
@@ -41,7 +41,7 @@
             "function": "join",
             "separator": "-"
         },
-        "srs": "EPCG:5179",
+        "srs": "EPSG:5179",
         "lat": "COLUMN18",
         "lon": "COLUMN17"
     }

--- a/sources/kr/11/provincewide.json
+++ b/sources/kr/11/provincewide.json
@@ -20,7 +20,7 @@
         "type": "csv",
         "file": "entrc_seoul.txt",
         "headers": -1,
-        "encoding": "EUCKR",
+        "encoding": "CP949",
         "number": {
             "function": "join",
             "fields": [

--- a/sources/kr/26/provincewide.json
+++ b/sources/kr/26/provincewide.json
@@ -29,7 +29,7 @@
             ],
             "separator": " "
         },
-        
+        "csvsplit" : "|",
         "street": "COLUMN8",
         "postcode": "COLUMN13",
         "district": "COLUMN6",

--- a/sources/kr/26/provincewide.json
+++ b/sources/kr/26/provincewide.json
@@ -8,7 +8,7 @@
         "country": "kr",
         "state": "26"
     },
-    "data": "http://www.juso.go.kr/dn.do?boardId=GEODATA&fileName=%EA%B3%B5%EA%B0%84%EC%A0%95%EB%B3%B4%EC%9A%94%EC%95%BDDB_2%EC%9B%94%EB%B6%84.zip&realFileName=ENTRC_DB_1702.zip&regYmd=2017&num=10&fileNo=76008&logging=Y",
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/sergiyprotsiv/40a526/korea-feb2017.zip",
     "website": "http://www.juso.go.kr/addrlink/addressBuildDevNew.do?menu=geodata",
     "license": {
         "attribution name": "Ministry of the Interior"

--- a/sources/kr/26/provincewide.json
+++ b/sources/kr/26/provincewide.json
@@ -41,7 +41,7 @@
             "function": "join",
             "separator": "-"
         },
-        "srs": "EPCG:5179",
+        "srs": "EPSG:5179",
         "lat": "COLUMN18",
         "lon": "COLUMN17"
     }

--- a/sources/kr/26/provincewide.json
+++ b/sources/kr/26/provincewide.json
@@ -20,7 +20,7 @@
         "type": "csv",
         "file": "entrc_busan.txt",
         "headers": -1,
-        "encoding": "EUCKR",
+        "encoding": "CP949",
         "number": {
             "function": "join",
             "fields": [

--- a/sources/kr/26/provincewide.json
+++ b/sources/kr/26/provincewide.json
@@ -21,14 +21,7 @@
         "file": "entrc_busan.txt",
         "headers": -1,
         "encoding": "CP949",
-        "number": {
-            "function": "join",
-            "fields": [
-                "COLUMN10",
-                "COLUMN11"
-            ],
-            "separator": " "
-        },
+        "number": "COLUMN19",
         "csvsplit" : "|",
         "street": "COLUMN8",
         "postcode": "COLUMN13",

--- a/sources/kr/27/provincewide.json
+++ b/sources/kr/27/provincewide.json
@@ -8,7 +8,7 @@
         "country": "kr",
         "state": "27"
     },
-    "data": "http://www.juso.go.kr/dn.do?boardId=GEODATA&fileName=%EA%B3%B5%EA%B0%84%EC%A0%95%EB%B3%B4%EC%9A%94%EC%95%BDDB_2%EC%9B%94%EB%B6%84.zip&realFileName=ENTRC_DB_1702.zip&regYmd=2017&num=10&fileNo=76008&logging=Y",
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/sergiyprotsiv/40a526/korea-feb2017.zip",
     "website": "http://www.juso.go.kr/addrlink/addressBuildDevNew.do?menu=geodata",
     "license": {
         "attribution name": "Ministry of the Interior"

--- a/sources/kr/27/provincewide.json
+++ b/sources/kr/27/provincewide.json
@@ -29,7 +29,7 @@
             ],
             "separator": " "
         },
-        
+        "csvsplit" : "|",
         "street": "COLUMN8",
         "postcode": "COLUMN13",
         "district": "COLUMN6",

--- a/sources/kr/27/provincewide.json
+++ b/sources/kr/27/provincewide.json
@@ -21,14 +21,7 @@
         "file": "entrc_daegu.txt",
         "headers": -1,
         "encoding": "CP949",
-        "number": {
-            "function": "join",
-            "fields": [
-                "COLUMN10",
-                "COLUMN11"
-            ],
-            "separator": " "
-        },
+        "number": "COLUMN19",
         "csvsplit" : "|",
         "street": "COLUMN8",
         "postcode": "COLUMN13",

--- a/sources/kr/27/provincewide.json
+++ b/sources/kr/27/provincewide.json
@@ -20,7 +20,7 @@
         "type": "csv",
         "file": "entrc_daegu.txt",
         "headers": -1,
-        "encoding": "EUCKR",
+        "encoding": "CP949",
         "number": {
             "function": "join",
             "fields": [

--- a/sources/kr/27/provincewide.json
+++ b/sources/kr/27/provincewide.json
@@ -41,7 +41,7 @@
             "function": "join",
             "separator": "-"
         },
-        "srs": "EPCG:5179",
+        "srs": "EPSG:5179",
         "lat": "COLUMN18",
         "lon": "COLUMN17"
     }

--- a/sources/kr/28/provincewide.json
+++ b/sources/kr/28/provincewide.json
@@ -20,7 +20,7 @@
         "type": "csv",
         "file": "entrc_incheon.txt",
         "headers": -1,
-        "encoding": "EUCKR",
+        "encoding": "CP949",
         "number": {
             "function": "join",
             "fields": [

--- a/sources/kr/28/provincewide.json
+++ b/sources/kr/28/provincewide.json
@@ -29,7 +29,7 @@
             ],
             "separator": " "
         },
-        
+        "csvsplit" : "|",
         "street": "COLUMN8",
         "postcode": "COLUMN13",
         "district": "COLUMN6",

--- a/sources/kr/28/provincewide.json
+++ b/sources/kr/28/provincewide.json
@@ -41,7 +41,7 @@
             "function": "join",
             "separator": "-"
         },
-        "srs": "EPCG:5179",
+        "srs": "EPSG:5179",
         "lat": "COLUMN18",
         "lon": "COLUMN17"
     }

--- a/sources/kr/28/provincewide.json
+++ b/sources/kr/28/provincewide.json
@@ -21,14 +21,7 @@
         "file": "entrc_incheon.txt",
         "headers": -1,
         "encoding": "CP949",
-        "number": {
-            "function": "join",
-            "fields": [
-                "COLUMN10",
-                "COLUMN11"
-            ],
-            "separator": " "
-        },
+        "number": "COLUMN19",
         "csvsplit" : "|",
         "street": "COLUMN8",
         "postcode": "COLUMN13",

--- a/sources/kr/28/provincewide.json
+++ b/sources/kr/28/provincewide.json
@@ -8,7 +8,7 @@
         "country": "kr",
         "state": "28"
     },
-    "data": "http://www.juso.go.kr/dn.do?boardId=GEODATA&fileName=%EA%B3%B5%EA%B0%84%EC%A0%95%EB%B3%B4%EC%9A%94%EC%95%BDDB_2%EC%9B%94%EB%B6%84.zip&realFileName=ENTRC_DB_1702.zip&regYmd=2017&num=10&fileNo=76008&logging=Y",
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/sergiyprotsiv/40a526/korea-feb2017.zip",
     "website": "http://www.juso.go.kr/addrlink/addressBuildDevNew.do?menu=geodata",
     "license": {
         "attribution name": "Ministry of the Interior"

--- a/sources/kr/29/provincewide.json
+++ b/sources/kr/29/provincewide.json
@@ -8,7 +8,7 @@
         "country": "kr",
         "state": "29"
     },
-    "data": "http://www.juso.go.kr/dn.do?boardId=GEODATA&fileName=%EA%B3%B5%EA%B0%84%EC%A0%95%EB%B3%B4%EC%9A%94%EC%95%BDDB_2%EC%9B%94%EB%B6%84.zip&realFileName=ENTRC_DB_1702.zip&regYmd=2017&num=10&fileNo=76008&logging=Y",
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/sergiyprotsiv/40a526/korea-feb2017.zip",
     "website": "http://www.juso.go.kr/addrlink/addressBuildDevNew.do?menu=geodata",
     "license": {
         "attribution name": "Ministry of the Interior"

--- a/sources/kr/29/provincewide.json
+++ b/sources/kr/29/provincewide.json
@@ -21,14 +21,7 @@
         "file": "entrc_gwangju.txt",
         "headers": -1,
         "encoding": "CP949",
-        "number": {
-            "function": "join",
-            "fields": [
-                "COLUMN10",
-                "COLUMN11"
-            ],
-            "separator": " "
-        },
+        "number": "COLUMN19",
         "csvsplit" : "|",
         "street": "COLUMN8",
         "postcode": "COLUMN13",

--- a/sources/kr/29/provincewide.json
+++ b/sources/kr/29/provincewide.json
@@ -29,7 +29,7 @@
             ],
             "separator": " "
         },
-        
+        "csvsplit" : "|",
         "street": "COLUMN8",
         "postcode": "COLUMN13",
         "district": "COLUMN6",

--- a/sources/kr/29/provincewide.json
+++ b/sources/kr/29/provincewide.json
@@ -41,7 +41,7 @@
             "function": "join",
             "separator": "-"
         },
-        "srs": "EPCG:5179",
+        "srs": "EPSG:5179",
         "lat": "COLUMN18",
         "lon": "COLUMN17"
     }

--- a/sources/kr/29/provincewide.json
+++ b/sources/kr/29/provincewide.json
@@ -20,7 +20,7 @@
         "type": "csv",
         "file": "entrc_gwangju.txt",
         "headers": -1,
-        "encoding": "EUCKR",
+        "encoding": "CP949",
         "number": {
             "function": "join",
             "fields": [

--- a/sources/kr/30/provincewide.json
+++ b/sources/kr/30/provincewide.json
@@ -21,14 +21,7 @@
         "file": "entrc_daejeon.txt",
         "headers": -1,
         "encoding": "CP949",
-        "number": {
-            "function": "join",
-            "fields": [
-                "COLUMN10",
-                "COLUMN11"
-            ],
-            "separator": " "
-        },
+        "number": "COLUMN19",
         "csvsplit" : "|",
         "street": "COLUMN8",
         "postcode": "COLUMN13",

--- a/sources/kr/30/provincewide.json
+++ b/sources/kr/30/provincewide.json
@@ -29,7 +29,7 @@
             ],
             "separator": " "
         },
-        
+        "csvsplit" : "|",
         "street": "COLUMN8",
         "postcode": "COLUMN13",
         "district": "COLUMN6",

--- a/sources/kr/30/provincewide.json
+++ b/sources/kr/30/provincewide.json
@@ -8,7 +8,7 @@
         "country": "kr",
         "state": "30"
     },
-    "data": "http://www.juso.go.kr/dn.do?boardId=GEODATA&fileName=%EA%B3%B5%EA%B0%84%EC%A0%95%EB%B3%B4%EC%9A%94%EC%95%BDDB_2%EC%9B%94%EB%B6%84.zip&realFileName=ENTRC_DB_1702.zip&regYmd=2017&num=10&fileNo=76008&logging=Y",
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/sergiyprotsiv/40a526/korea-feb2017.zip",
     "website": "http://www.juso.go.kr/addrlink/addressBuildDevNew.do?menu=geodata",
     "license": {
         "attribution name": "Ministry of the Interior"

--- a/sources/kr/30/provincewide.json
+++ b/sources/kr/30/provincewide.json
@@ -20,7 +20,7 @@
         "type": "csv",
         "file": "entrc_daejeon.txt",
         "headers": -1,
-        "encoding": "EUCKR",
+        "encoding": "CP949",
         "number": {
             "function": "join",
             "fields": [

--- a/sources/kr/30/provincewide.json
+++ b/sources/kr/30/provincewide.json
@@ -41,7 +41,7 @@
             "function": "join",
             "separator": "-"
         },
-        "srs": "EPCG:5179",
+        "srs": "EPSG:5179",
         "lat": "COLUMN18",
         "lon": "COLUMN17"
     }

--- a/sources/kr/31/provincewide.json
+++ b/sources/kr/31/provincewide.json
@@ -29,7 +29,7 @@
             ],
             "separator": " "
         },
-        
+        "csvsplit" : "|",
         "street": "COLUMN8",
         "postcode": "COLUMN13",
         "district": "COLUMN6",

--- a/sources/kr/31/provincewide.json
+++ b/sources/kr/31/provincewide.json
@@ -20,7 +20,7 @@
         "type": "csv",
         "file": "entrc_ulsan.txt",
         "headers": -1,
-        "encoding": "EUCKR",
+        "encoding": "CP949",
         "number": {
             "function": "join",
             "fields": [

--- a/sources/kr/31/provincewide.json
+++ b/sources/kr/31/provincewide.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "ISO 3166": {
+            "alpha2": "KR-31",
+            "country": "Republic of Korea",
+            "subdivision": "Ulsan"
+        },
+        "country": "kr",
+        "state": "31"
+    },
+    "data": "http://www.juso.go.kr/dn.do?boardId=GEODATA&fileName=%EA%B3%B5%EA%B0%84%EC%A0%95%EB%B3%B4%EC%9A%94%EC%95%BDDB_2%EC%9B%94%EB%B6%84.zip&realFileName=ENTRC_DB_1702.zip&regYmd=2017&num=10&fileNo=76008&logging=Y",
+    "website": "http://www.juso.go.kr/addrlink/addressBuildDevNew.do?menu=geodata",
+    "license": {
+        "attribution name": "Ministry of the Interior"
+        },
+    "type": "http",
+    "compression": "zip",
+    "language": "kr",
+    "conform": {
+        "type": "csv",
+        "file": "entrc_ulsan.txt",
+        "headers": -1,
+        "encoding": "EUCKR",
+        "number": {
+            "function": "join",
+            "fields": [
+                "COLUMN10",
+                "COLUMN11"
+            ],
+            "separator": " "
+        },
+        
+        "street": "COLUMN8",
+        "postcode": "COLUMN13",
+        "district": "COLUMN6",
+        "city": "COLUMN5",
+        "region": "COLUMN4",
+        "addrtype": "COLUMN14",
+        "id": {
+            "fields": ["COLUMN3","COLUMN2"],
+            "function": "join",
+            "separator": "-"
+        },
+        "srs": "EPCG:5179",
+        "lat": "COLUMN18",
+        "lon": "COLUMN17"
+    }
+}

--- a/sources/kr/31/provincewide.json
+++ b/sources/kr/31/provincewide.json
@@ -21,14 +21,7 @@
         "file": "entrc_ulsan.txt",
         "headers": -1,
         "encoding": "CP949",
-        "number": {
-            "function": "join",
-            "fields": [
-                "COLUMN10",
-                "COLUMN11"
-            ],
-            "separator": " "
-        },
+        "number": "COLUMN19",
         "csvsplit" : "|",
         "street": "COLUMN8",
         "postcode": "COLUMN13",

--- a/sources/kr/31/provincewide.json
+++ b/sources/kr/31/provincewide.json
@@ -8,7 +8,7 @@
         "country": "kr",
         "state": "31"
     },
-    "data": "http://www.juso.go.kr/dn.do?boardId=GEODATA&fileName=%EA%B3%B5%EA%B0%84%EC%A0%95%EB%B3%B4%EC%9A%94%EC%95%BDDB_2%EC%9B%94%EB%B6%84.zip&realFileName=ENTRC_DB_1702.zip&regYmd=2017&num=10&fileNo=76008&logging=Y",
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/sergiyprotsiv/40a526/korea-feb2017.zip",
     "website": "http://www.juso.go.kr/addrlink/addressBuildDevNew.do?menu=geodata",
     "license": {
         "attribution name": "Ministry of the Interior"

--- a/sources/kr/31/provincewide.json
+++ b/sources/kr/31/provincewide.json
@@ -41,7 +41,7 @@
             "function": "join",
             "separator": "-"
         },
-        "srs": "EPCG:5179",
+        "srs": "EPSG:5179",
         "lat": "COLUMN18",
         "lon": "COLUMN17"
     }

--- a/sources/kr/41/provincewide.json
+++ b/sources/kr/41/provincewide.json
@@ -21,14 +21,7 @@
         "file": "entrc_gyunggi.txt",
         "headers": -1,
         "encoding": "CP949",
-        "number": {
-            "function": "join",
-            "fields": [
-                "COLUMN10",
-                "COLUMN11"
-            ],
-            "separator": " "
-        },
+        "number": "COLUMN19",
         "csvsplit" : "|",
         "street": "COLUMN8",
         "postcode": "COLUMN13",

--- a/sources/kr/41/provincewide.json
+++ b/sources/kr/41/provincewide.json
@@ -29,7 +29,7 @@
             ],
             "separator": " "
         },
-        
+        "csvsplit" : "|",
         "street": "COLUMN8",
         "postcode": "COLUMN13",
         "district": "COLUMN6",

--- a/sources/kr/41/provincewide.json
+++ b/sources/kr/41/provincewide.json
@@ -20,7 +20,7 @@
         "type": "csv",
         "file": "entrc_gyunggi.txt",
         "headers": -1,
-        "encoding": "EUCKR",
+        "encoding": "CP949",
         "number": {
             "function": "join",
             "fields": [

--- a/sources/kr/41/provincewide.json
+++ b/sources/kr/41/provincewide.json
@@ -8,7 +8,7 @@
         "country": "kr",
         "state": "41"
     },
-    "data": "http://www.juso.go.kr/dn.do?boardId=GEODATA&fileName=%EA%B3%B5%EA%B0%84%EC%A0%95%EB%B3%B4%EC%9A%94%EC%95%BDDB_2%EC%9B%94%EB%B6%84.zip&realFileName=ENTRC_DB_1702.zip&regYmd=2017&num=10&fileNo=76008&logging=Y",
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/sergiyprotsiv/40a526/korea-feb2017.zip",
     "website": "http://www.juso.go.kr/addrlink/addressBuildDevNew.do?menu=geodata",
     "license": {
         "attribution name": "Ministry of the Interior"

--- a/sources/kr/41/provincewide.json
+++ b/sources/kr/41/provincewide.json
@@ -41,7 +41,7 @@
             "function": "join",
             "separator": "-"
         },
-        "srs": "EPCG:5179",
+        "srs": "EPSG:5179",
         "lat": "COLUMN18",
         "lon": "COLUMN17"
     }

--- a/sources/kr/41/provincewide.json
+++ b/sources/kr/41/provincewide.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "ISO 3166": {
+            "alpha2": "KR-41",
+            "country": "Republic of Korea",
+            "subdivision": "Gyeonggi"
+        },
+        "country": "kr",
+        "state": "41"
+    },
+    "data": "http://www.juso.go.kr/dn.do?boardId=GEODATA&fileName=%EA%B3%B5%EA%B0%84%EC%A0%95%EB%B3%B4%EC%9A%94%EC%95%BDDB_2%EC%9B%94%EB%B6%84.zip&realFileName=ENTRC_DB_1702.zip&regYmd=2017&num=10&fileNo=76008&logging=Y",
+    "website": "http://www.juso.go.kr/addrlink/addressBuildDevNew.do?menu=geodata",
+    "license": {
+        "attribution name": "Ministry of the Interior"
+        },
+    "type": "http",
+    "compression": "zip",
+    "language": "kr",
+    "conform": {
+        "type": "csv",
+        "file": "entrc_gyunggi.txt",
+        "headers": -1,
+        "encoding": "EUCKR",
+        "number": {
+            "function": "join",
+            "fields": [
+                "COLUMN10",
+                "COLUMN11"
+            ],
+            "separator": " "
+        },
+        
+        "street": "COLUMN8",
+        "postcode": "COLUMN13",
+        "district": "COLUMN6",
+        "city": "COLUMN5",
+        "region": "COLUMN4",
+        "addrtype": "COLUMN14",
+        "id": {
+            "fields": ["COLUMN3","COLUMN2"],
+            "function": "join",
+            "separator": "-"
+        },
+        "srs": "EPCG:5179",
+        "lat": "COLUMN18",
+        "lon": "COLUMN17"
+    }
+}

--- a/sources/kr/42/provincewide.json
+++ b/sources/kr/42/provincewide.json
@@ -29,7 +29,7 @@
             ],
             "separator": " "
         },
-        
+        "csvsplit" : "|",
         "street": "COLUMN8",
         "postcode": "COLUMN13",
         "district": "COLUMN6",

--- a/sources/kr/42/provincewide.json
+++ b/sources/kr/42/provincewide.json
@@ -20,7 +20,7 @@
         "type": "csv",
         "file": "entrc_gangwon.txt",
         "headers": -1,
-        "encoding": "EUCKR",
+        "encoding": "CP949",
         "number": {
             "function": "join",
             "fields": [

--- a/sources/kr/42/provincewide.json
+++ b/sources/kr/42/provincewide.json
@@ -41,7 +41,7 @@
             "function": "join",
             "separator": "-"
         },
-        "srs": "EPCG:5179",
+        "srs": "EPSG:5179",
         "lat": "COLUMN18",
         "lon": "COLUMN17"
     }

--- a/sources/kr/42/provincewide.json
+++ b/sources/kr/42/provincewide.json
@@ -8,7 +8,7 @@
         "country": "kr",
         "state": "42"
     },
-    "data": "http://www.juso.go.kr/dn.do?boardId=GEODATA&fileName=%EA%B3%B5%EA%B0%84%EC%A0%95%EB%B3%B4%EC%9A%94%EC%95%BDDB_2%EC%9B%94%EB%B6%84.zip&realFileName=ENTRC_DB_1702.zip&regYmd=2017&num=10&fileNo=76008&logging=Y",
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/sergiyprotsiv/40a526/korea-feb2017.zip",
     "website": "http://www.juso.go.kr/addrlink/addressBuildDevNew.do?menu=geodata",
     "license": {
         "attribution name": "Ministry of the Interior"

--- a/sources/kr/42/provincewide.json
+++ b/sources/kr/42/provincewide.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "ISO 3166": {
+            "alpha2": "KR-42",
+            "country": "Republic of Korea",
+            "subdivision": "Gangwon"
+        },
+        "country": "kr",
+        "state": "42"
+    },
+    "data": "http://www.juso.go.kr/dn.do?boardId=GEODATA&fileName=%EA%B3%B5%EA%B0%84%EC%A0%95%EB%B3%B4%EC%9A%94%EC%95%BDDB_2%EC%9B%94%EB%B6%84.zip&realFileName=ENTRC_DB_1702.zip&regYmd=2017&num=10&fileNo=76008&logging=Y",
+    "website": "http://www.juso.go.kr/addrlink/addressBuildDevNew.do?menu=geodata",
+    "license": {
+        "attribution name": "Ministry of the Interior"
+        },
+    "type": "http",
+    "compression": "zip",
+    "language": "kr",
+    "conform": {
+        "type": "csv",
+        "file": "entrc_gangwon.txt",
+        "headers": -1,
+        "encoding": "EUCKR",
+        "number": {
+            "function": "join",
+            "fields": [
+                "COLUMN10",
+                "COLUMN11"
+            ],
+            "separator": " "
+        },
+        
+        "street": "COLUMN8",
+        "postcode": "COLUMN13",
+        "district": "COLUMN6",
+        "city": "COLUMN5",
+        "region": "COLUMN4",
+        "addrtype": "COLUMN14",
+        "id": {
+            "fields": ["COLUMN3","COLUMN2"],
+            "function": "join",
+            "separator": "-"
+        },
+        "srs": "EPCG:5179",
+        "lat": "COLUMN18",
+        "lon": "COLUMN17"
+    }
+}

--- a/sources/kr/42/provincewide.json
+++ b/sources/kr/42/provincewide.json
@@ -21,14 +21,7 @@
         "file": "entrc_gangwon.txt",
         "headers": -1,
         "encoding": "CP949",
-        "number": {
-            "function": "join",
-            "fields": [
-                "COLUMN10",
-                "COLUMN11"
-            ],
-            "separator": " "
-        },
+        "number": "COLUMN19",
         "csvsplit" : "|",
         "street": "COLUMN8",
         "postcode": "COLUMN13",

--- a/sources/kr/43/provincewide.json
+++ b/sources/kr/43/provincewide.json
@@ -29,7 +29,7 @@
             ],
             "separator": " "
         },
-        
+        "csvsplit" : "|",
         "street": "COLUMN8",
         "postcode": "COLUMN13",
         "district": "COLUMN6",

--- a/sources/kr/43/provincewide.json
+++ b/sources/kr/43/provincewide.json
@@ -8,7 +8,7 @@
         "country": "kr",
         "state": "43"
     },
-    "data": "http://www.juso.go.kr/dn.do?boardId=GEODATA&fileName=%EA%B3%B5%EA%B0%84%EC%A0%95%EB%B3%B4%EC%9A%94%EC%95%BDDB_2%EC%9B%94%EB%B6%84.zip&realFileName=ENTRC_DB_1702.zip&regYmd=2017&num=10&fileNo=76008&logging=Y",
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/sergiyprotsiv/40a526/korea-feb2017.zip",
     "website": "http://www.juso.go.kr/addrlink/addressBuildDevNew.do?menu=geodata",
     "license": {
         "attribution name": "Ministry of the Interior"

--- a/sources/kr/43/provincewide.json
+++ b/sources/kr/43/provincewide.json
@@ -20,7 +20,7 @@
         "type": "csv",
         "file": "entrc_chungbuk.txt",
         "headers": -1,
-        "encoding": "EUCKR",
+        "encoding": "CP949",
         "number": {
             "function": "join",
             "fields": [

--- a/sources/kr/43/provincewide.json
+++ b/sources/kr/43/provincewide.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "ISO 3166": {
+            "alpha2": "KR-43",
+            "country": "Republic of Korea",
+            "subdivision": "Chungbuk"
+        },
+        "country": "kr",
+        "state": "43"
+    },
+    "data": "http://www.juso.go.kr/dn.do?boardId=GEODATA&fileName=%EA%B3%B5%EA%B0%84%EC%A0%95%EB%B3%B4%EC%9A%94%EC%95%BDDB_2%EC%9B%94%EB%B6%84.zip&realFileName=ENTRC_DB_1702.zip&regYmd=2017&num=10&fileNo=76008&logging=Y",
+    "website": "http://www.juso.go.kr/addrlink/addressBuildDevNew.do?menu=geodata",
+    "license": {
+        "attribution name": "Ministry of the Interior"
+        },
+    "type": "http",
+    "compression": "zip",
+    "language": "kr",
+    "conform": {
+        "type": "csv",
+        "file": "entrc_chungbuk.txt",
+        "headers": -1,
+        "encoding": "EUCKR",
+        "number": {
+            "function": "join",
+            "fields": [
+                "COLUMN10",
+                "COLUMN11"
+            ],
+            "separator": " "
+        },
+        
+        "street": "COLUMN8",
+        "postcode": "COLUMN13",
+        "district": "COLUMN6",
+        "city": "COLUMN5",
+        "region": "COLUMN4",
+        "addrtype": "COLUMN14",
+        "id": {
+            "fields": ["COLUMN3","COLUMN2"],
+            "function": "join",
+            "separator": "-"
+        },
+        "srs": "EPCG:5179",
+        "lat": "COLUMN18",
+        "lon": "COLUMN17"
+    }
+}

--- a/sources/kr/43/provincewide.json
+++ b/sources/kr/43/provincewide.json
@@ -41,7 +41,7 @@
             "function": "join",
             "separator": "-"
         },
-        "srs": "EPCG:5179",
+        "srs": "EPSG:5179",
         "lat": "COLUMN18",
         "lon": "COLUMN17"
     }

--- a/sources/kr/43/provincewide.json
+++ b/sources/kr/43/provincewide.json
@@ -21,14 +21,7 @@
         "file": "entrc_chungbuk.txt",
         "headers": -1,
         "encoding": "CP949",
-        "number": {
-            "function": "join",
-            "fields": [
-                "COLUMN10",
-                "COLUMN11"
-            ],
-            "separator": " "
-        },
+        "number": "COLUMN19",
         "csvsplit" : "|",
         "street": "COLUMN8",
         "postcode": "COLUMN13",

--- a/sources/kr/44/provincewide.json
+++ b/sources/kr/44/provincewide.json
@@ -21,14 +21,7 @@
         "file": "entrc_chungnam.txt",
         "headers": -1,
         "encoding": "CP949",
-        "number": {
-            "function": "join",
-            "fields": [
-                "COLUMN10",
-                "COLUMN11"
-            ],
-            "separator": " "
-        },
+        "number": "COLUMN19",
         "csvsplit" : "|",
         "street": "COLUMN8",
         "postcode": "COLUMN13",

--- a/sources/kr/44/provincewide.json
+++ b/sources/kr/44/provincewide.json
@@ -29,7 +29,7 @@
             ],
             "separator": " "
         },
-        
+        "csvsplit" : "|",
         "street": "COLUMN8",
         "postcode": "COLUMN13",
         "district": "COLUMN6",

--- a/sources/kr/44/provincewide.json
+++ b/sources/kr/44/provincewide.json
@@ -41,7 +41,7 @@
             "function": "join",
             "separator": "-"
         },
-        "srs": "EPCG:5179",
+        "srs": "EPSG:5179",
         "lat": "COLUMN18",
         "lon": "COLUMN17"
     }

--- a/sources/kr/44/provincewide.json
+++ b/sources/kr/44/provincewide.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "ISO 3166": {
+            "alpha2": "KR-44",
+            "country": "Republic of Korea",
+            "subdivision": "Chungnam"
+        },
+        "country": "kr",
+        "state": "44"
+    },
+    "data": "http://www.juso.go.kr/dn.do?boardId=GEODATA&fileName=%EA%B3%B5%EA%B0%84%EC%A0%95%EB%B3%B4%EC%9A%94%EC%95%BDDB_2%EC%9B%94%EB%B6%84.zip&realFileName=ENTRC_DB_1702.zip&regYmd=2017&num=10&fileNo=76008&logging=Y",
+    "website": "http://www.juso.go.kr/addrlink/addressBuildDevNew.do?menu=geodata",
+    "license": {
+        "attribution name": "Ministry of the Interior"
+        },
+    "type": "http",
+    "compression": "zip",
+    "language": "kr",
+    "conform": {
+        "type": "csv",
+        "file": "entrc_chungnam.txt",
+        "headers": -1,
+        "encoding": "EUCKR",
+        "number": {
+            "function": "join",
+            "fields": [
+                "COLUMN10",
+                "COLUMN11"
+            ],
+            "separator": " "
+        },
+        
+        "street": "COLUMN8",
+        "postcode": "COLUMN13",
+        "district": "COLUMN6",
+        "city": "COLUMN5",
+        "region": "COLUMN4",
+        "addrtype": "COLUMN14",
+        "id": {
+            "fields": ["COLUMN3","COLUMN2"],
+            "function": "join",
+            "separator": "-"
+        },
+        "srs": "EPCG:5179",
+        "lat": "COLUMN18",
+        "lon": "COLUMN17"
+    }
+}

--- a/sources/kr/44/provincewide.json
+++ b/sources/kr/44/provincewide.json
@@ -20,7 +20,7 @@
         "type": "csv",
         "file": "entrc_chungnam.txt",
         "headers": -1,
-        "encoding": "EUCKR",
+        "encoding": "CP949",
         "number": {
             "function": "join",
             "fields": [

--- a/sources/kr/44/provincewide.json
+++ b/sources/kr/44/provincewide.json
@@ -8,7 +8,7 @@
         "country": "kr",
         "state": "44"
     },
-    "data": "http://www.juso.go.kr/dn.do?boardId=GEODATA&fileName=%EA%B3%B5%EA%B0%84%EC%A0%95%EB%B3%B4%EC%9A%94%EC%95%BDDB_2%EC%9B%94%EB%B6%84.zip&realFileName=ENTRC_DB_1702.zip&regYmd=2017&num=10&fileNo=76008&logging=Y",
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/sergiyprotsiv/40a526/korea-feb2017.zip",
     "website": "http://www.juso.go.kr/addrlink/addressBuildDevNew.do?menu=geodata",
     "license": {
         "attribution name": "Ministry of the Interior"

--- a/sources/kr/45/provincewide.json
+++ b/sources/kr/45/provincewide.json
@@ -29,7 +29,7 @@
             ],
             "separator": " "
         },
-        
+        "csvsplit" : "|",
         "street": "COLUMN8",
         "postcode": "COLUMN13",
         "district": "COLUMN6",

--- a/sources/kr/45/provincewide.json
+++ b/sources/kr/45/provincewide.json
@@ -8,7 +8,7 @@
         "country": "kr",
         "state": "45"
     },
-    "data": "http://www.juso.go.kr/dn.do?boardId=GEODATA&fileName=%EA%B3%B5%EA%B0%84%EC%A0%95%EB%B3%B4%EC%9A%94%EC%95%BDDB_2%EC%9B%94%EB%B6%84.zip&realFileName=ENTRC_DB_1702.zip&regYmd=2017&num=10&fileNo=76008&logging=Y",
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/sergiyprotsiv/40a526/korea-feb2017.zip",
     "website": "http://www.juso.go.kr/addrlink/addressBuildDevNew.do?menu=geodata",
     "license": {
         "attribution name": "Ministry of the Interior"

--- a/sources/kr/45/provincewide.json
+++ b/sources/kr/45/provincewide.json
@@ -41,7 +41,7 @@
             "function": "join",
             "separator": "-"
         },
-        "srs": "EPCG:5179",
+        "srs": "EPSG:5179",
         "lat": "COLUMN18",
         "lon": "COLUMN17"
     }

--- a/sources/kr/45/provincewide.json
+++ b/sources/kr/45/provincewide.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "ISO 3166": {
+            "alpha2": "KR-45",
+            "country": "Republic of Korea",
+            "subdivision": "Jeonbuk"
+        },
+        "country": "kr",
+        "state": "45"
+    },
+    "data": "http://www.juso.go.kr/dn.do?boardId=GEODATA&fileName=%EA%B3%B5%EA%B0%84%EC%A0%95%EB%B3%B4%EC%9A%94%EC%95%BDDB_2%EC%9B%94%EB%B6%84.zip&realFileName=ENTRC_DB_1702.zip&regYmd=2017&num=10&fileNo=76008&logging=Y",
+    "website": "http://www.juso.go.kr/addrlink/addressBuildDevNew.do?menu=geodata",
+    "license": {
+        "attribution name": "Ministry of the Interior"
+        },
+    "type": "http",
+    "compression": "zip",
+    "language": "kr",
+    "conform": {
+        "type": "csv",
+        "file": "entrc_jeonbuk.txt",
+        "headers": -1,
+        "encoding": "EUCKR",
+        "number": {
+            "function": "join",
+            "fields": [
+                "COLUMN10",
+                "COLUMN11"
+            ],
+            "separator": " "
+        },
+        
+        "street": "COLUMN8",
+        "postcode": "COLUMN13",
+        "district": "COLUMN6",
+        "city": "COLUMN5",
+        "region": "COLUMN4",
+        "addrtype": "COLUMN14",
+        "id": {
+            "fields": ["COLUMN3","COLUMN2"],
+            "function": "join",
+            "separator": "-"
+        },
+        "srs": "EPCG:5179",
+        "lat": "COLUMN18",
+        "lon": "COLUMN17"
+    }
+}

--- a/sources/kr/45/provincewide.json
+++ b/sources/kr/45/provincewide.json
@@ -20,7 +20,7 @@
         "type": "csv",
         "file": "entrc_jeonbuk.txt",
         "headers": -1,
-        "encoding": "EUCKR",
+        "encoding": "CP949",
         "number": {
             "function": "join",
             "fields": [

--- a/sources/kr/45/provincewide.json
+++ b/sources/kr/45/provincewide.json
@@ -21,14 +21,7 @@
         "file": "entrc_jeonbuk.txt",
         "headers": -1,
         "encoding": "CP949",
-        "number": {
-            "function": "join",
-            "fields": [
-                "COLUMN10",
-                "COLUMN11"
-            ],
-            "separator": " "
-        },
+        "number": "COLUMN19",
         "csvsplit" : "|",
         "street": "COLUMN8",
         "postcode": "COLUMN13",

--- a/sources/kr/46/provincewide.json
+++ b/sources/kr/46/provincewide.json
@@ -29,7 +29,7 @@
             ],
             "separator": " "
         },
-        
+        "csvsplit" : "|",
         "street": "COLUMN8",
         "postcode": "COLUMN13",
         "district": "COLUMN6",

--- a/sources/kr/46/provincewide.json
+++ b/sources/kr/46/provincewide.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "ISO 3166": {
+            "alpha2": "KR-46",
+            "country": "Republic of Korea",
+            "subdivision": "Jeonnam"
+        },
+        "country": "kr",
+        "state": "46"
+    },
+    "data": "http://www.juso.go.kr/dn.do?boardId=GEODATA&fileName=%EA%B3%B5%EA%B0%84%EC%A0%95%EB%B3%B4%EC%9A%94%EC%95%BDDB_2%EC%9B%94%EB%B6%84.zip&realFileName=ENTRC_DB_1702.zip&regYmd=2017&num=10&fileNo=76008&logging=Y",
+    "website": "http://www.juso.go.kr/addrlink/addressBuildDevNew.do?menu=geodata",
+    "license": {
+        "attribution name": "Ministry of the Interior"
+        },
+    "type": "http",
+    "compression": "zip",
+    "language": "kr",
+    "conform": {
+        "type": "csv",
+        "file": "entrc_jeonnam.txt",
+        "headers": -1,
+        "encoding": "EUCKR",
+        "number": {
+            "function": "join",
+            "fields": [
+                "COLUMN10",
+                "COLUMN11"
+            ],
+            "separator": " "
+        },
+        
+        "street": "COLUMN8",
+        "postcode": "COLUMN13",
+        "district": "COLUMN6",
+        "city": "COLUMN5",
+        "region": "COLUMN4",
+        "addrtype": "COLUMN14",
+        "id": {
+            "fields": ["COLUMN3","COLUMN2"],
+            "function": "join",
+            "separator": "-"
+        },
+        "srs": "EPCG:5179",
+        "lat": "COLUMN18",
+        "lon": "COLUMN17"
+    }
+}

--- a/sources/kr/46/provincewide.json
+++ b/sources/kr/46/provincewide.json
@@ -8,7 +8,7 @@
         "country": "kr",
         "state": "46"
     },
-    "data": "http://www.juso.go.kr/dn.do?boardId=GEODATA&fileName=%EA%B3%B5%EA%B0%84%EC%A0%95%EB%B3%B4%EC%9A%94%EC%95%BDDB_2%EC%9B%94%EB%B6%84.zip&realFileName=ENTRC_DB_1702.zip&regYmd=2017&num=10&fileNo=76008&logging=Y",
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/sergiyprotsiv/40a526/korea-feb2017.zip",
     "website": "http://www.juso.go.kr/addrlink/addressBuildDevNew.do?menu=geodata",
     "license": {
         "attribution name": "Ministry of the Interior"

--- a/sources/kr/46/provincewide.json
+++ b/sources/kr/46/provincewide.json
@@ -41,7 +41,7 @@
             "function": "join",
             "separator": "-"
         },
-        "srs": "EPCG:5179",
+        "srs": "EPSG:5179",
         "lat": "COLUMN18",
         "lon": "COLUMN17"
     }

--- a/sources/kr/46/provincewide.json
+++ b/sources/kr/46/provincewide.json
@@ -21,14 +21,7 @@
         "file": "entrc_jeonnam.txt",
         "headers": -1,
         "encoding": "CP949",
-        "number": {
-            "function": "join",
-            "fields": [
-                "COLUMN10",
-                "COLUMN11"
-            ],
-            "separator": " "
-        },
+        "number": "COLUMN19",
         "csvsplit" : "|",
         "street": "COLUMN8",
         "postcode": "COLUMN13",

--- a/sources/kr/46/provincewide.json
+++ b/sources/kr/46/provincewide.json
@@ -20,7 +20,7 @@
         "type": "csv",
         "file": "entrc_jeonnam.txt",
         "headers": -1,
-        "encoding": "EUCKR",
+        "encoding": "CP949",
         "number": {
             "function": "join",
             "fields": [

--- a/sources/kr/47/provincewide.json
+++ b/sources/kr/47/provincewide.json
@@ -21,14 +21,7 @@
         "file": "entrc_gyeongbuk.txt",
         "headers": -1,
         "encoding": "CP949",
-        "number": {
-            "function": "join",
-            "fields": [
-                "COLUMN10",
-                "COLUMN11"
-            ],
-            "separator": " "
-        },
+        "number": "COLUMN19",
         "csvsplit" : "|",
         "street": "COLUMN8",
         "postcode": "COLUMN13",

--- a/sources/kr/47/provincewide.json
+++ b/sources/kr/47/provincewide.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "ISO 3166": {
+            "alpha2": "KR-47",
+            "country": "Republic of Korea",
+            "subdivision": "Gyeongbuk"
+        },
+        "country": "kr",
+        "state": "47"
+    },
+    "data": "http://www.juso.go.kr/dn.do?boardId=GEODATA&fileName=%EA%B3%B5%EA%B0%84%EC%A0%95%EB%B3%B4%EC%9A%94%EC%95%BDDB_2%EC%9B%94%EB%B6%84.zip&realFileName=ENTRC_DB_1702.zip&regYmd=2017&num=10&fileNo=76008&logging=Y",
+    "website": "http://www.juso.go.kr/addrlink/addressBuildDevNew.do?menu=geodata",
+    "license": {
+        "attribution name": "Ministry of the Interior"
+        },
+    "type": "http",
+    "compression": "zip",
+    "language": "kr",
+    "conform": {
+        "type": "csv",
+        "file": "entrc_gyeongbuk.txt",
+        "headers": -1,
+        "encoding": "EUCKR",
+        "number": {
+            "function": "join",
+            "fields": [
+                "COLUMN10",
+                "COLUMN11"
+            ],
+            "separator": " "
+        },
+        
+        "street": "COLUMN8",
+        "postcode": "COLUMN13",
+        "district": "COLUMN6",
+        "city": "COLUMN5",
+        "region": "COLUMN4",
+        "addrtype": "COLUMN14",
+        "id": {
+            "fields": ["COLUMN3","COLUMN2"],
+            "function": "join",
+            "separator": "-"
+        },
+        "srs": "EPCG:5179",
+        "lat": "COLUMN18",
+        "lon": "COLUMN17"
+    }
+}

--- a/sources/kr/47/provincewide.json
+++ b/sources/kr/47/provincewide.json
@@ -29,7 +29,7 @@
             ],
             "separator": " "
         },
-        
+        "csvsplit" : "|",
         "street": "COLUMN8",
         "postcode": "COLUMN13",
         "district": "COLUMN6",

--- a/sources/kr/47/provincewide.json
+++ b/sources/kr/47/provincewide.json
@@ -8,7 +8,7 @@
         "country": "kr",
         "state": "47"
     },
-    "data": "http://www.juso.go.kr/dn.do?boardId=GEODATA&fileName=%EA%B3%B5%EA%B0%84%EC%A0%95%EB%B3%B4%EC%9A%94%EC%95%BDDB_2%EC%9B%94%EB%B6%84.zip&realFileName=ENTRC_DB_1702.zip&regYmd=2017&num=10&fileNo=76008&logging=Y",
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/sergiyprotsiv/40a526/korea-feb2017.zip",
     "website": "http://www.juso.go.kr/addrlink/addressBuildDevNew.do?menu=geodata",
     "license": {
         "attribution name": "Ministry of the Interior"

--- a/sources/kr/47/provincewide.json
+++ b/sources/kr/47/provincewide.json
@@ -41,7 +41,7 @@
             "function": "join",
             "separator": "-"
         },
-        "srs": "EPCG:5179",
+        "srs": "EPSG:5179",
         "lat": "COLUMN18",
         "lon": "COLUMN17"
     }

--- a/sources/kr/47/provincewide.json
+++ b/sources/kr/47/provincewide.json
@@ -20,7 +20,7 @@
         "type": "csv",
         "file": "entrc_gyeongbuk.txt",
         "headers": -1,
-        "encoding": "EUCKR",
+        "encoding": "CP949",
         "number": {
             "function": "join",
             "fields": [

--- a/sources/kr/48/provincewide.json
+++ b/sources/kr/48/provincewide.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "ISO 3166": {
+            "alpha2": "KR-48",
+            "country": "Republic of Korea",
+            "subdivision": "Gyeongnam"
+        },
+        "country": "kr",
+        "state": "48"
+    },
+    "data": "http://www.juso.go.kr/dn.do?boardId=GEODATA&fileName=%EA%B3%B5%EA%B0%84%EC%A0%95%EB%B3%B4%EC%9A%94%EC%95%BDDB_2%EC%9B%94%EB%B6%84.zip&realFileName=ENTRC_DB_1702.zip&regYmd=2017&num=10&fileNo=76008&logging=Y",
+    "website": "http://www.juso.go.kr/addrlink/addressBuildDevNew.do?menu=geodata",
+    "license": {
+        "attribution name": "Ministry of the Interior"
+        },
+    "type": "http",
+    "compression": "zip",
+    "language": "kr",
+    "conform": {
+        "type": "csv",
+        "file": "entrc_gyeongnam.txt",
+        "headers": -1,
+        "encoding": "EUCKR",
+        "number": {
+            "function": "join",
+            "fields": [
+                "COLUMN10",
+                "COLUMN11"
+            ],
+            "separator": " "
+        },
+        
+        "street": "COLUMN8",
+        "postcode": "COLUMN13",
+        "district": "COLUMN6",
+        "city": "COLUMN5",
+        "region": "COLUMN4",
+        "addrtype": "COLUMN14",
+        "id": {
+            "fields": ["COLUMN3","COLUMN2"],
+            "function": "join",
+            "separator": "-"
+        },
+        "srs": "EPCG:5179",
+        "lat": "COLUMN18",
+        "lon": "COLUMN17"
+    }
+}

--- a/sources/kr/48/provincewide.json
+++ b/sources/kr/48/provincewide.json
@@ -8,7 +8,7 @@
         "country": "kr",
         "state": "48"
     },
-    "data": "http://www.juso.go.kr/dn.do?boardId=GEODATA&fileName=%EA%B3%B5%EA%B0%84%EC%A0%95%EB%B3%B4%EC%9A%94%EC%95%BDDB_2%EC%9B%94%EB%B6%84.zip&realFileName=ENTRC_DB_1702.zip&regYmd=2017&num=10&fileNo=76008&logging=Y",
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/sergiyprotsiv/40a526/korea-feb2017.zip",
     "website": "http://www.juso.go.kr/addrlink/addressBuildDevNew.do?menu=geodata",
     "license": {
         "attribution name": "Ministry of the Interior"

--- a/sources/kr/48/provincewide.json
+++ b/sources/kr/48/provincewide.json
@@ -29,7 +29,7 @@
             ],
             "separator": " "
         },
-        
+        "csvsplit" : "|",
         "street": "COLUMN8",
         "postcode": "COLUMN13",
         "district": "COLUMN6",

--- a/sources/kr/48/provincewide.json
+++ b/sources/kr/48/provincewide.json
@@ -20,7 +20,7 @@
         "type": "csv",
         "file": "entrc_gyeongnam.txt",
         "headers": -1,
-        "encoding": "EUCKR",
+        "encoding": "CP949",
         "number": {
             "function": "join",
             "fields": [

--- a/sources/kr/48/provincewide.json
+++ b/sources/kr/48/provincewide.json
@@ -21,14 +21,7 @@
         "file": "entrc_gyeongnam.txt",
         "headers": -1,
         "encoding": "CP949",
-        "number": {
-            "function": "join",
-            "fields": [
-                "COLUMN10",
-                "COLUMN11"
-            ],
-            "separator": " "
-        },
+        "number": "COLUMN19",
         "csvsplit" : "|",
         "street": "COLUMN8",
         "postcode": "COLUMN13",

--- a/sources/kr/48/provincewide.json
+++ b/sources/kr/48/provincewide.json
@@ -41,7 +41,7 @@
             "function": "join",
             "separator": "-"
         },
-        "srs": "EPCG:5179",
+        "srs": "EPSG:5179",
         "lat": "COLUMN18",
         "lon": "COLUMN17"
     }

--- a/sources/kr/49/provincewide.json
+++ b/sources/kr/49/provincewide.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "ISO 3166": {
+            "alpha2": "KR-49",
+            "country": "Republic of Korea",
+            "subdivision": "Jeju"
+        },
+        "country": "kr",
+        "state": "49"
+    },
+    "data": "http://www.juso.go.kr/dn.do?boardId=GEODATA&fileName=%EA%B3%B5%EA%B0%84%EC%A0%95%EB%B3%B4%EC%9A%94%EC%95%BDDB_2%EC%9B%94%EB%B6%84.zip&realFileName=ENTRC_DB_1702.zip&regYmd=2017&num=10&fileNo=76008&logging=Y",
+    "website": "http://www.juso.go.kr/addrlink/addressBuildDevNew.do?menu=geodata",
+    "license": {
+        "attribution name": "Ministry of the Interior"
+        },
+    "type": "http",
+    "compression": "zip",
+    "language": "kr",
+    "conform": {
+        "type": "csv",
+        "file": "entrc_jeju.txt",
+        "headers": -1,
+        "encoding": "EUCKR",
+        "number": {
+            "function": "join",
+            "fields": [
+                "COLUMN10",
+                "COLUMN11"
+            ],
+            "separator": " "
+        },
+        
+        "street": "COLUMN8",
+        "postcode": "COLUMN13",
+        "district": "COLUMN6",
+        "city": "COLUMN5",
+        "region": "COLUMN4",
+        "addrtype": "COLUMN14",
+        "id": {
+            "fields": ["COLUMN3","COLUMN2"],
+            "function": "join",
+            "separator": "-"
+        },
+        "srs": "EPCG:5179",
+        "lat": "COLUMN18",
+        "lon": "COLUMN17"
+    }
+}

--- a/sources/kr/49/provincewide.json
+++ b/sources/kr/49/provincewide.json
@@ -8,7 +8,7 @@
         "country": "kr",
         "state": "49"
     },
-    "data": "http://www.juso.go.kr/dn.do?boardId=GEODATA&fileName=%EA%B3%B5%EA%B0%84%EC%A0%95%EB%B3%B4%EC%9A%94%EC%95%BDDB_2%EC%9B%94%EB%B6%84.zip&realFileName=ENTRC_DB_1702.zip&regYmd=2017&num=10&fileNo=76008&logging=Y",
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/sergiyprotsiv/40a526/korea-feb2017.zip",
     "website": "http://www.juso.go.kr/addrlink/addressBuildDevNew.do?menu=geodata",
     "license": {
         "attribution name": "Ministry of the Interior"

--- a/sources/kr/49/provincewide.json
+++ b/sources/kr/49/provincewide.json
@@ -29,7 +29,7 @@
             ],
             "separator": " "
         },
-        
+        "csvsplit" : "|",
         "street": "COLUMN8",
         "postcode": "COLUMN13",
         "district": "COLUMN6",

--- a/sources/kr/49/provincewide.json
+++ b/sources/kr/49/provincewide.json
@@ -20,7 +20,7 @@
         "type": "csv",
         "file": "entrc_jeju.txt",
         "headers": -1,
-        "encoding": "EUCKR",
+        "encoding": "CP949",
         "number": {
             "function": "join",
             "fields": [

--- a/sources/kr/49/provincewide.json
+++ b/sources/kr/49/provincewide.json
@@ -41,7 +41,7 @@
             "function": "join",
             "separator": "-"
         },
-        "srs": "EPCG:5179",
+        "srs": "EPSG:5179",
         "lat": "COLUMN18",
         "lon": "COLUMN17"
     }

--- a/sources/kr/49/provincewide.json
+++ b/sources/kr/49/provincewide.json
@@ -21,14 +21,7 @@
         "file": "entrc_jeju.txt",
         "headers": -1,
         "encoding": "CP949",
-        "number": {
-            "function": "join",
-            "fields": [
-                "COLUMN10",
-                "COLUMN11"
-            ],
-            "separator": " "
-        },
+        "number": "COLUMN19",
         "csvsplit" : "|",
         "street": "COLUMN8",
         "postcode": "COLUMN13",

--- a/sources/kr/50/provincewide.json
+++ b/sources/kr/50/provincewide.json
@@ -29,7 +29,7 @@
             ],
             "separator": " "
         },
-        
+        "csvsplit" : "|",
         "street": "COLUMN8",
         "postcode": "COLUMN13",
         "district": "COLUMN6",

--- a/sources/kr/50/provincewide.json
+++ b/sources/kr/50/provincewide.json
@@ -20,7 +20,7 @@
         "type": "csv",
         "file": "entrc_sejong.txt",
         "headers": -1,
-        "encoding": "EUCKR",
+        "encoding": "CP949",
         "number": {
             "function": "join",
             "fields": [

--- a/sources/kr/50/provincewide.json
+++ b/sources/kr/50/provincewide.json
@@ -21,14 +21,7 @@
         "file": "entrc_sejong.txt",
         "headers": -1,
         "encoding": "CP949",
-        "number": {
-            "function": "join",
-            "fields": [
-                "COLUMN10",
-                "COLUMN11"
-            ],
-            "separator": " "
-        },
+        "number": "COLUMN19",
         "csvsplit" : "|",
         "street": "COLUMN8",
         "postcode": "COLUMN13",

--- a/sources/kr/50/provincewide.json
+++ b/sources/kr/50/provincewide.json
@@ -8,7 +8,7 @@
         "country": "kr",
         "state": "50"
     },
-    "data": "http://www.juso.go.kr/dn.do?boardId=GEODATA&fileName=%EA%B3%B5%EA%B0%84%EC%A0%95%EB%B3%B4%EC%9A%94%EC%95%BDDB_2%EC%9B%94%EB%B6%84.zip&realFileName=ENTRC_DB_1702.zip&regYmd=2017&num=10&fileNo=76008&logging=Y",
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/sergiyprotsiv/40a526/korea-feb2017.zip",
     "website": "http://www.juso.go.kr/addrlink/addressBuildDevNew.do?menu=geodata",
     "license": {
         "attribution name": "Ministry of the Interior"

--- a/sources/kr/50/provincewide.json
+++ b/sources/kr/50/provincewide.json
@@ -41,7 +41,7 @@
             "function": "join",
             "separator": "-"
         },
-        "srs": "EPCG:5179",
+        "srs": "EPSG:5179",
         "lat": "COLUMN18",
         "lon": "COLUMN17"
     }


### PR DESCRIPTION
I took a stab at the Korean data suggested by Justin: https://github.com/openaddresses/openaddresses/issues/2687. It's from the Ministry of the Interior. I did not see a clear license, but the Ministry is clearly trying to get everyone to use the addresses - lots of datasets and APIs.

The data seems quite complete, though positional accuracy is hard to judge relative to OSM data, since OSM rarely contains houses. 

There is a description of the address formats here: https://www.juso.go.kr/dn.do?fileName=GuideBook_eng.pdf&realFileName=GuideBook_eng.pdf&regYmd=2016 If someone has better familiarity with address formatting, let me know. There is also official Romanization available, but it has no coordinates, so it will need to be processed offline.