### PR TITLE
Mexico Countrywide

### DIFF
--- a/scripts/mx/process_inegi_census_files.py
+++ b/scripts/mx/process_inegi_census_files.py
@@ -1,0 +1,122 @@
+import json
+import requests
+import zipfile
+import os.path
+import time
+
+
+json_dir = "./output"
+cache_dir = "./cache"
+tmp_dir = "./tmp"
+
+
+# Returns the path where a file should be cached
+def cache_file_path(url):
+	return os.path.join(cache_dir, os.path.basename(url))
+
+# Returns True if we have a valid (i.e. completely downloaded) file already cached. If a file is damaged it is removed.
+def file_already_cached(url):
+	local_path = cache_file_path(url)
+	
+	if not os.path.exists(local_path):
+		return False
+	
+	file_ok = True
+	try:
+		with zipfile.ZipFile(local_path, 'r') as zip_file:
+			file_ok = zip_file.testzip() is None
+	except:
+		file_ok = False
+	
+	if not file_ok:
+		os.remove(local_path)
+		
+	return file_ok
+	
+# Downloads a file to cache
+def download_file_to_cache(url, chunk_size):
+	response = requests.get(url, stream=True)
+	with open(cache_file_path(url), "wb") as cached_file:
+		for chunk in response.iter_content(chunk_size = chunk_size):
+			cached_file.write(chunk)
+
+
+# First we get the URLs of necessary files to be downloaded
+# Currently using the JSON files pre-populated by Mapbox, would normally need to scrap the INEGI website for links
+
+
+relevant_urls = set()
+
+for dp, dn, fn in os.walk(json_dir):
+	for file_name in [ fi for fi in fn if fi.endswith(".json") ]:
+		file_path = os.path.join(dp, file_name)
+		
+		if os.stat(file_path).st_size == 0:
+			continue
+		
+		with open(os.path.join(dp, file_name)) as json_file:
+			data = json.load(json_file)
+    		relevant_urls.add(data["data"])
+  
+print "There are " + str(len(relevant_urls)) + " files to download."  		
+
+# Filter out the ones that have already been downloaded
+urls_to_download = filter(lambda x: not file_already_cached(x), relevant_urls)
+
+# Attempt to download all the files one by one (not to overload the server, multiple streams result in many 403 responses)
+# Progressively decrease the chunk size which increases reliability of downloads at the expense of speed
+chunk_size = 512
+
+while len(urls_to_download) > 0:
+	url_count = len(urls_to_download)
+	print str(url_count) + " files remain to be cached..."
+
+	i = 0
+	for url in urls_to_download:
+		i = i + 1
+		print "Downloading " + os.path.basename(url) + " [" + str(i) + "/" + str(url_count) + "]"
+		download_file_to_cache(url, chunk_size)
+		time.sleep(2)
+	
+	chunk_size = max(chunk_size / 2, 1)
+	urls_to_download = filter(lambda x: not file_already_cached(x), urls_to_download)
+	time.sleep(10)
+
+
+	
+print "All files are cached, building the common data source"
+
+common_shape_path = os.path.abspath("./mexico_ne.shp")
+if os.path.exists(common_shape_path):
+	os.remove(common_shape_path)
+
+# Checks the zip file for the presence of address shapefiles and extracts them into a common shapefile (OGR seems to have an issue with appending to csv)
+def extract_shapes_from_zip(zip_path):
+	with zipfile.ZipFile(zip_path, 'r') as zip_file:
+		zip_member_names = zip_file.namelist()
+		for shp_name in [ fi for fi in zip_member_names if fi.endswith("ne.shp")]:
+			command = 'ogr2ogr -f "ESRI Shapefile" -append ' + common_shape_path + ' /vsizip/' + os.path.abspath(os.path.join(zip_path, shp_name))
+			os.system(command)
+			
+# Recursively extract the shapefiles from a zip file and all the other zipfiles within it			
+def extract_all_relevant_data_from_zip(zip_path):
+	print "Extracting from " + zip_path
+	extract_shapes_from_zip(zip_path)
+	with zipfile.ZipFile(zip_path, 'r') as zip_file:
+		zip_member_names = zip_file.namelist()
+		for zipped_zip in [ fi for fi in zip_member_names if fi.endswith(".zip")]:
+			zip_file.extract(zipped_zip,tmp_dir)
+			temp_path = os.path.join(tmp_dir, zipped_zip)
+			extract_all_relevant_data_from_zip(temp_path)
+			os.remove(temp_path)
+
+
+for dp, dn, fn in os.walk(cache_dir):
+	for file_name in [ fi for fi in fn if fi.endswith(".zip") ]:
+		extract_all_relevant_data_from_zip(os.path.join(dp, file_name))
+
+print "Done with extraction, converting to CSV..."
+
+common_csv_path = os.path.abspath("./mexico_ne.csv")
+csv_command = 'ogr2ogr -f CSV ' + common_csv_path + ' ' + common_shape_path + ' -lco GEOMETRY=AS_XY'
+os.system(csv_command)

--- a/scripts/mx/process_inegi_census_files.py
+++ b/scripts/mx/process_inegi_census_files.py
@@ -118,5 +118,5 @@ for dp, dn, fn in os.walk(cache_dir):
 print "Done with extraction, converting to CSV..."
 
 common_csv_path = os.path.abspath("./mexico_ne.csv")
-csv_command = 'ogr2ogr -f CSV ' + common_csv_path + ' ' + common_shape_path + ' -lco GEOMETRY=AS_XY'
+csv_command = 'ogr2ogr -t_srs EPSG:4326 -f CSV ' + common_csv_path + ' ' + common_shape_path + ' -nln mexico_ne_wgs84 -lco GEOMETRY=AS_XY'
 os.system(csv_command)

--- a/sources/mx/countrywide.json
+++ b/sources/mx/countrywide.json
@@ -5,13 +5,13 @@
             "alpha2": "MX"
         }
     },
-    "data": "https://www.dropbox.com/s/zs5leqn1wkdw1ki/mexico_ne20170328.zip?dl=1",
+    "data": "https://www.dropbox.com/s/t33vmdsbl6pcrnd/mexico_ne_wgs84.zip?dl=1",
     "website": "http://buscador.inegi.org.mx/search?client=ProductosR&proxystylesheet=ProductosR&num=10&getfields=*&sort=meta:edicion:D:E:::D&entsp=a__inegi_politica_p72&lr=lang_es%7Clang_en&oe=UTF-8&ie=UTF-8&entqr=3&filter=0&ip=10.210.100.253&site=ProductosBuscador&tlen=260&ulang=en&access=p&entqrm=0&ud=1&q=N%C3%BAmeros+Exteriores+inmeta:Tema%3DCartograf%C3%ADa%2520Geoestad%C3%ADstica&dnavs=inmeta:Tema%3DCartograf%C3%ADa%2520Geoestad%C3%ADstica",
     "type": "http",
     "compression": "zip",
     "conform": {
         "type": "csv",
-        "src": "EPSG:6263",
+        "srs": "EPSG:4326",
         "number": "NUMEXT",
         "street": ["TIPOVIAL", "NOMVIAL"],
         "id": {

--- a/sources/mx/countrywide.json
+++ b/sources/mx/countrywide.json
@@ -1,0 +1,28 @@
+{
+    "coverage": {
+        "ISO 3166": {
+            "country": "Mexico",
+            "alpha2": "MX"
+        }
+    },
+    "data": "https://www.dropbox.com/s/zs5leqn1wkdw1ki/mexico_ne20170328.zip?dl=1",
+    "website": "http://buscador.inegi.org.mx/search?client=ProductosR&proxystylesheet=ProductosR&num=10&getfields=*&sort=meta:edicion:D:E:::D&entsp=a__inegi_politica_p72&lr=lang_es%7Clang_en&oe=UTF-8&ie=UTF-8&entqr=3&filter=0&ip=10.210.100.253&site=ProductosBuscador&tlen=260&ulang=en&access=p&entqrm=0&ud=1&q=N%C3%BAmeros+Exteriores+inmeta:Tema%3DCartograf%C3%ADa%2520Geoestad%C3%ADstica&dnavs=inmeta:Tema%3DCartograf%C3%ADa%2520Geoestad%C3%ADstica",
+    "type": "http",
+    "compression": "zip",
+    "conform": {
+        "type": "csv",
+        "src": "EPSG:6263",
+        "number": "NUMEXT",
+        "street": ["TIPOVIAL", "NOMVIAL"],
+        "id": {
+             "function": "join",
+             "fields": [
+                 "CVEGEO",
+                 "IDUNICO"
+             ],
+             "separator": "-"
+        },
+        "lat": "Y",
+        "lon": "X"
+    }
+}


### PR DESCRIPTION
A first attempt to load the countrywide Mexican data. Almost 30 million addresses - lets see if the machine can handle this.

I am attaching the script that relies on the JSON file linked to in https://github.com/openaddresses/openaddresses/issues/2593 to get the file names necessary for downloading. When an updated dataset is released, the INEGI website will need to be scrapped again for the file links. The updates are supposed to happen every five years (they are related to the census), but so far this is the only one I found.

The script recursively imports the shapefiles from zips and then from zips within zips, etc. The internal structure is not uniform (sometimes there is a shapefile in a folder, sometimes directly in a zip, sometimes in folder in a zip within a zip, etc). The resulting combined shapefile is 32 GB, but the csv is more manageable (1 GB compressed). I have put it on Dropbox for now, since the S3 upload limit is 256 MB. Can be split up into statewide sources if necessary.

A couple of things to note:
- The datasource as it is now only merges the data that is actually within the shapefiles. This means that the metadata on the municipality is lost (as this is only known when browsing the web). It can definitely be added as an extra column at the expense of a more processed source (and the need to process the shape data in Python instead of relying on command-line OGR). Should be straightforward, let me know if this is better.

- Houses in rural towns rarely have the house number. In the files this is denoted as "SN". My understanding is that the relevant information then is some identifier for the block the house is in, particularly the two intersecting streets (one before and one after). The data on these intersecting streets are actually in the file as well - the question is what is the best way to model it (if necessary).