### PR TITLE
added more fields

### DIFF
--- a/sources/us/az/maricopa.json
+++ b/sources/us/az/maricopa.json
@@ -9,17 +9,23 @@
         "state": "az",
         "county": "Maricopa"
     },
-    "data": "http://gis.mcassessor.maricopa.gov/arcgis/rest/services/Parcel_Numbers/MapServer/0",
-    "type": "ESRI",
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/trescube/94c52d/us-az-maricopa.geojson.zip",
+    "note": "the source is http://gis.mcassessor.maricopa.gov/arcgis/rest/services/Parcel_Numbers/MapServer/0 but times out several times so this was generated using pyesridump with OBJECTID offsets.",
+    "type": "http",
+    "compression": "zip",
     "conform": {
         "type": "geojson",
         "number": "PHYSICAL_STREET_NUM",
         "street": [
             "PHYSICAL_STREET_DIR",
             "PHYSICAL_STREET_NAME",
-            "PHYSICAL_STREET_TYPE"
+            "PHYSICAL_STREET_TYPE",
+            "PHYSICAL_STREET_POSTDIR"
         ],
-        "unit": "PHYSICAL_SUITE",
+        "unit": [
+            "PHYSICAL_SUITE",
+            "PHYSICAL_STREET_SUFFIX"
+        ],
         "postcode": "PHYSICAL_ZIP",
         "city": "PHYSICAL_CITY"
     }


### PR DESCRIPTION
This source was missing the post-directional on `street`.  Additionally, the `PHYSICAL_STREET_SUFFIX` field appears to contain unit information.  I used the `join` function for `unit` to hopefully identify correct since in the data I've seen only one of `PHYSICAL_SUITE` and `PHYSICAL_STREET_SUFFIX` are populated.

The source times out quite a bit so the data may have to be cached.  