### PR TITLE
fixing street name field capitalization in Brevard County, FL

### DIFF
--- a/sources/us/fl/brevard.json
+++ b/sources/us/fl/brevard.json
@@ -18,7 +18,7 @@
         "number": "SiteHouseNo",
         "street": [
             "SiteDir",
-            "SiteStreetName",
+            "SiteStreetname",
             "SiteType"
         ],
         "unit": "SiteAptNo",


### PR DESCRIPTION
street name was missing, changing /SiteStreetName/SiteStreetname/