### PR TITLE
house numbers aren't just digits so regex was broken

### DIFF
--- a/sources/us/wi/waukesha.json
+++ b/sources/us/wi/waukesha.json
@@ -13,19 +13,18 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "number": {
-            "function": "regexp",
-            "field": "Full_Address",
-            "pattern": "^([0-9]+)"
-        },
+        "number": "StreetNumber",
         "street": {
-            "function": "regexp",
+            "function": "remove_prefix",
             "field": "Full_Address",
-            "pattern": "^(?:[0-9]+ )(.*)",
-            "replace": "$1"
+            "field_to_remove": "StreetNumber"
         },
         "city": "Municipality",
-        "postcode": "ZipCode",
+        "postcode": {
+            "function": "regexp",
+            "field": "ZipCode",
+            "pattern": "^(\\d+)"
+        },
         "accuracy": 1
     }
 }


### PR DESCRIPTION
`S28W31328` is also a valid house number