### PR TITLE
Update New York State file

### DIFF
--- a/sources/us/ny/statewide.json
+++ b/sources/us/ny/statewide.json
@@ -5,7 +5,7 @@
         "state": "ny"
     },
     "website": "http://gis.ny.gov/gisdata/inventories/details.cfm?DSID=921",
-    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/iandees/b7bf5a/Craig Fargione - OpenAddresses_NYS_20170331.zip",
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/iandees/2ad924/Craig Fargione - OpenAddresses_NYS_20170331_SAM_Master_Statewide_Database.gdb.zip",
     "type": "http",
     "compression": "zip",
     "note": "Data dictionary found at http://gis.ny.gov/gisdata/supportfiles/org_522_streets_addresspoints_data_dictionary.zip",
@@ -17,6 +17,7 @@
         "city": "CityTownName",
         "region": "State",
         "district": "CountyName",
+        "postcode": "ZipCode",
         "id": "NYSAddressPointID"
     }
 }

--- a/sources/us/ny/statewide.json
+++ b/sources/us/ny/statewide.json
@@ -4,13 +4,13 @@
         "country": "us",
         "state": "ny"
     },
-    "note": "NOTICE: DO NOT ADD THE FIELDS ZipCode nor ZipName TO OPENADDRESSES. The rest of this is open data, but it also includes those two fields which include information copyright to HERE. Don't import these fields.",
     "website": "http://gis.ny.gov/gisdata/inventories/details.cfm?DSID=921",
-    "data": "http://gisservices.dhses.ny.gov/arcgis/rest/services/SAM_Address_Points/MapServer/1",
-    "type": "ESRI",
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/iandees/b7bf5a/Craig Fargione - OpenAddresses_NYS_20170331.zip",
+    "type": "http",
+    "compression": "zip",
     "note": "Data dictionary found at http://gis.ny.gov/gisdata/supportfiles/org_522_streets_addresspoints_data_dictionary.zip",
     "conform": {
-        "type": "geojson",
+        "type": "gdb",
         "number": ["PrefixAddressNumber", "AddressNumber", "SuffixAddressNumber"],
         "street": "CompleteStreetName",
         "unit": "Unit",


### PR DESCRIPTION
Two changes here:

- The source data switched to a zipped GDB that the New York State GIS folks sent me. It explicitly has New York City carved out of the dataset. They will be sending it to me quarterly.
- A few months ago the New York State GIS team negotiated an agreement with Here to allow the zipcodes that are part of this dataset to be free and open, so I removed the note and added back in the zipcodes.