### PR TITLE
revert change to Montevideo

### DIFF
--- a/sources/uy/mo/montevideo.json
+++ b/sources/uy/mo/montevideo.json
@@ -13,7 +13,8 @@
             "subdivision": "Montevideo"
         },
         "country": "uy",
-        "state": "mo"
+        "state": "mo",
+        "city": "Montevideo"
     },
     "data": "http://intgis.montevideo.gub.uy/sit/tmp/v_mdg_accesos.zip",
     "website": "http://sig.montevideo.gub.uy/",


### PR DESCRIPTION
I verified that, contrary to what is claimed on Wikipedia, Montevideo department has only one municipality. Thus, my previous change was incorrect.