### PR TITLE
Taiwan - Tainan

### DIFF
--- a/sources/tw/tnn/regionwide.json
+++ b/sources/tw/tnn/regionwide.json
@@ -11,7 +11,11 @@
     "conform": {
         "type": "geojson",
         "number": "NO",
-        "street": ["ROADNAME","LANE"],
+        "street": {
+            "function": "join",
+            "fields": ["ROADNAME","LANE"],
+            "separator": "-"
+        },
         "city": "VILLAGE",
         "district": "DISTRICT",
         "region": "COUNTY"

--- a/sources/tw/tnn/regionwide.json
+++ b/sources/tw/tnn/regionwide.json
@@ -10,11 +10,20 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "number": "NO",
+        "number":{
+            "function": "regexp",
+            "field": "NO",
+            "pattern": "^([0-9\uff10-\uff19]+號?)"
+        },
+        "unit":{
+            "function": "regexp",
+            "field": "NO",
+            "pattern": "^(?:[0-9\uff10-\uff19]+號?)(.*)"
+        },
         "street": {
             "function": "join",
             "fields": ["ROADNAME","LANE"],
-            "separator": "-"
+            "separator": ""
         },
         "city": "VILLAGE",
         "district": "DISTRICT",

--- a/sources/tw/tnn/regionwide.json
+++ b/sources/tw/tnn/regionwide.json
@@ -14,6 +14,6 @@
         "street": ["ROADNAME","LANE"],
         "city": "VILLAGE",
         "district": "DISTRICT",
-        "region": "COUNTY",
+        "region": "COUNTY"
     }
 }

--- a/sources/tw/tnn/regionwide.json
+++ b/sources/tw/tnn/regionwide.json
@@ -13,12 +13,12 @@
         "number":{
             "function": "regexp",
             "field": "NO",
-            "pattern": "^([0-9\uff10-\uff19]+號?)"
+            "pattern": "^([0-9\uff10-\uff19]+\u865f?)"
         },
         "unit":{
             "function": "regexp",
             "field": "NO",
-            "pattern": "^(?:[0-9\uff10-\uff19]+號?)(.*)"
+            "pattern": "^(?:[0-9\uff10-\uff19]+\u865f?)(.*)"
         },
         "street": {
             "function": "join",

--- a/sources/tw/tnn/regionwide.json
+++ b/sources/tw/tnn/regionwide.json
@@ -1,0 +1,19 @@
+{
+    "coverage": {
+        "ISO 3166": {
+            "alpha2": "TW-TNN",
+            "country": "Taiwan"
+        },
+        "country": "tw"
+    },
+    "data": "http://water.tainan.gov.tw/tnwrbarcgis/rest/services/TNRW/Address/MapServer/0",
+    "type": "ESRI",
+    "conform": {
+        "type": "geojson",
+        "number": "NO",
+        "street": ["ROADNAME","LANE"],
+        "city": "VILLAGE",
+        "district": "DISTRICT",
+        "region": "COUNTY",
+    }
+}


### PR DESCRIPTION
Tainan county of Taiwan. An ESRI source from the government website.

I will shortly be uploading a few more Taiwan sources that cover most of the populous parts of the country.

Appreciate comments on the Chinese street naming and numbering system. The combined "address" field lists "street" then "lane" then "house number". I have combined "street" and "lane" to form the OA "street field. Perhaps the space should be skipped.  