### PR TITLE
add Sector field to Bucharest

### DIFF
--- a/sources/ro/bucharest.json
+++ b/sources/ro/bucharest.json
@@ -16,6 +16,11 @@
         "type": "geojson",
         "number": "NRPOSTAL",
         "street": "TIPNUMESTRADA",
+        "district": {
+            "function": "format",
+            "fields": ["SECTOR"],
+            "format": "Sector $1"
+        },
         "postcode": "CODULPOSTALE"
     }
 }


### PR DESCRIPTION
A lot of these addresses are written like "București, Sector 6", adding the "Sector 6" part as a district. City is "București", although wasn't clear on whether it's kosher to add static values to sources.