### PR TITLE
Portugal - Lisboa

### DIFF
--- a/sources/pt/11/lisboa.json
+++ b/sources/pt/11/lisboa.json
@@ -10,7 +10,7 @@
         "number": {
             "function": "regexp",
             "field": "NP",
-            "pattern": "(.*)(\\(.*\\))$"
+            "pattern": "(.*)(\\(.*\\))?$"
         },        
         "street": "MORADA"
     }

--- a/sources/pt/11/lisboa.json
+++ b/sources/pt/11/lisboa.json
@@ -11,7 +11,11 @@
             "function": "regexp",
             "field": "NP",
             "pattern": "([^\\(]+)"
-        },        
-        "street": "MORADA"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "MORADA",
+            "pattern": "([^\\(]+)"
+        }
     }
 }

--- a/sources/pt/11/lisboa.json
+++ b/sources/pt/11/lisboa.json
@@ -1,13 +1,17 @@
 {
     "coverage": {
         "country": "pt",
-        "city": "Lisboa"
+        "county": "Lisboa"
     },
     "data": "https://gis.cm-lisboa.pt/arcgis/rest/services/Arcgis_Online/Lx_MapaBase/MapServer/2",
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "number": "NP",
+        "number": {
+            "function": "regexp",
+            "field": "NP",
+            "pattern": "(.*)(\(.*\))$"
+        },        
         "street": "MORADA"
     }
 }

--- a/sources/pt/11/lisboa.json
+++ b/sources/pt/11/lisboa.json
@@ -10,7 +10,7 @@
         "number": {
             "function": "regexp",
             "field": "NP",
-            "pattern": "(.*)(\\(.*\\))?$"
+            "pattern": "([^\\(]+)"
         },        
         "street": "MORADA"
     }

--- a/sources/pt/11/lisboa.json
+++ b/sources/pt/11/lisboa.json
@@ -1,0 +1,13 @@
+{
+    "coverage": {
+        "country": "pt",
+        "city": "Lisboa"
+    },
+    "data": "https://gis.cm-lisboa.pt/arcgis/rest/services/Arcgis_Online/Lx_MapaBase/MapServer/2",
+    "type": "ESRI",
+    "conform": {
+        "type": "geojson",
+        "number": "NP",
+        "street": "MORADA"
+    }
+}

--- a/sources/pt/11/lisboa.json
+++ b/sources/pt/11/lisboa.json
@@ -10,7 +10,7 @@
         "number": {
             "function": "regexp",
             "field": "NP",
-            "pattern": "(.*)(\(.*\))$"
+            "pattern": "(.*)(\\(.*\\))$"
         },        
         "street": "MORADA"
     }


### PR DESCRIPTION
This is a minimal source for Lisbon, Portugal. Covers just the municipality itself. There are two more address datasets in the source, but the others are designed for lower zoom levels.

Coverage does not contain geometry so far, will add it to all Portuguese sources eventually.