### PR TITLE
add Matosinhos, Portugal

### DIFF
--- a/sources/pt/13/matosinhos.json
+++ b/sources/pt/13/matosinhos.json
@@ -4,8 +4,10 @@
         "county": "Matosinhos",
         "geometry": { "type": "Point", "coordinates": [-8.7, 41.18] }
     },
-    "data": "http://web2.cm-matosinhos.pt/arcgis/rest/services/Limite_Planos/MapServer/3",
-    "type": "ESRI",
+    "website": "http://web2.cm-matosinhos.pt/portal/",
+    "note": "Cached from http://web2.cm-matosinhos.pt/arcgis/rest/services/Limite_Planos/MapServer/3",
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/astoff/773774/matosinhos.geojson",
+    "type": "http",
     "conform": {
         "type": "geojson",
         "number": "NUM",

--- a/sources/pt/13/matosinhos.json
+++ b/sources/pt/13/matosinhos.json
@@ -1,0 +1,14 @@
+{
+    "coverage": {
+        "country": "pt",
+        "county": "Matosinhos",
+        "geometry": { "type": "Point", "coordinates": [-8.7, 41.18] }
+    },
+    "data": "http://web2.cm-matosinhos.pt/arcgis/rest/services/Limite_Planos/MapServer/3",
+    "type": "ESRI",
+    "conform": {
+        "type": "geojson",
+        "number": "NUM",
+        "street": "RUA"
+    }
+}


### PR DESCRIPTION
Portuguese "freguesias" are like US civil townships, therefore that field in the original data is not relevant here.