### PR TITLE
Portugal - Porto

### DIFF
--- a/sources/pt/13/porto.json
+++ b/sources/pt/13/porto.json
@@ -13,6 +13,11 @@
         "lat": "Y",
         "lon": "X",
         "number": "N_POLICIA",        
-        "street": "TOPONIMO"
+        "street": "TOPONIMO",
+        "postcode": {
+            "function": "join",
+            "fields": ["CP_4", "CP_3"],
+            "separator": "-"
+        }
     }
 }

--- a/sources/pt/13/porto.json
+++ b/sources/pt/13/porto.json
@@ -1,0 +1,18 @@
+{
+    "coverage": {
+        "country": "pt",
+        "county": "Porto"
+    },
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/sergiyprotsiv/5b3a41/pt-porto.zip",
+    "website": "http://mipweb.cm-porto.pt/arcgis/rest/services/Cache/CACHE_ENQUADRAMENTO/MapServer/0",
+    "type": "http",
+    "compression" : "zip",
+    "conform": {
+        "type": "csv",
+        "file": "pt-porto.csv",
+        "lat": "Y",
+        "lon": "X",
+        "number": "N_POLICIA",        
+        "street": "TOPONIMO"
+    }
+}


### PR DESCRIPTION
Municipality of Porto. 
It is a cache of the (somewhat unstable) source here: http://mipweb.cm-porto.pt/arcgis/rest/services/Cache/CACHE_ENQUADRAMENTO/MapServer/0
Since the source did not have the name of the street, but it was in a related layer (http://mipweb.cm-porto.pt/arcgis/rest/services/Cache/CACHE_ENQUADRAMENTO/MapServer/1), this is a join of the two.