### PR TITLE
Portugal Countrywide

### DIFF
--- a/scripts/pt/portugal_geoedif.py
+++ b/scripts/pt/portugal_geoedif.py
@@ -1,0 +1,66 @@
+import json
+import os.path
+
+# The source data can be obtained by running
+# esri2geojson https://inenetw05.ine.pt:6443/arcgis/rest/services/GeoEdif/GEOEDIF_AC25/MapServer/0 pt-azores25.json
+# esri2geojson https://inenetw05.ine.pt:6443/arcgis/rest/services/GeoEdif/GEOEDIF_AC26/MapServer/0 pt-azores26.json
+# esri2geojson https://inenetw05.ine.pt:6443/arcgis/rest/services/GeoEdif/GEOEDIF_MAD/MapServer/0 pt-madeira.json
+# esri2geojson https://inenetw05.ine.pt:6443/arcgis/rest/services/GeoEdif/GEOEDIF_CONT/MapServer/0 pt-continente.json
+# In practice the continental dataset is too large (>3M points), so the server fails before returning the count. Forcing esri2geojson to use OIDs does the trick
+
+
+tmp_dir = "./tmp"
+common_db_path = os.path.abspath("./portugal_geoedif.db")
+common_csv_path = os.path.abspath("./portugal_geoedif.csv")
+
+small_files = ['pt-azores25','pt-azores26','pt-madeira']
+large_files = ['pt-continente']
+
+# Copy the small files to the temp directory
+for sf in small_files:
+    print "Copying " + sf + "..."
+    command = 'cp ' + sf + '.json ' + os.path.join(tmp_dir,sf + '.json')
+    os.system(command)
+
+# Spit the large files into chunks
+for lf in large_files:
+    stream = open(lf + '.json', 'r') 
+    
+    chunk_size = 100000
+    
+    header = stream.readline()
+    current_chunk = 0
+    has_more_lines = True
+    while has_more_lines:
+        print "Parsing chunk " + str(current_chunk+1) + "..."
+        target_path = os.path.join(tmp_dir,lf + '_' + str(current_chunk) + '.json')
+        target_file = open(target_path,'wb')
+        target_file.write(header)
+        current_chunk = current_chunk + 1
+        
+        for f in xrange(chunk_size):
+            feature = stream.readline()
+            if feature!=']}':
+            	target_file.write(feature)
+            else:
+                has_more_lines = False
+                break
+                
+        target_file.write("]}")
+        target_file.close()
+
+
+# Build up an SQLite database from all chunks
+if os.path.exists(common_db_path):
+	os.remove(common_db_path)
+
+for dp, dn, fn in os.walk(tmp_dir):
+	for file_name in [ fi for fi in fn if fi.endswith(".json") ]:
+		print file_name
+		command = 'ogr2ogr -append -f "SQLite" ' + common_db_path + ' ' + os.path.join(tmp_dir,file_name) + ' -t_srs EPSG:4326 -nln portugal_geoedif'
+		os.system(command)
+	
+# Combine the data into a common csv table
+print "Converting to csv and packaging as zip"
+os.system('ogr2ogr -f CSV ' + common_csv_path + ' ' + common_db_path)
+os.system('zip -9 portugal_geoedif.zip ' + common_csv_path)

--- a/scripts/pt/portugal_geoedif.py
+++ b/scripts/pt/portugal_geoedif.py
@@ -62,5 +62,5 @@ for dp, dn, fn in os.walk(tmp_dir):
 	
 # Combine the data into a common csv table
 print "Converting to csv and packaging as zip"
-os.system('ogr2ogr -f CSV ' + common_csv_path + ' ' + common_db_path)
+os.system('ogr2ogr -f CSV ' + common_csv_path + ' ' + common_db_path + ' -lco GEOMETRY=AS_XY')
 os.system('zip -9 portugal_geoedif.zip ' + common_csv_path)

--- a/sources/pt/countrywide.json
+++ b/sources/pt/countrywide.json
@@ -6,7 +6,7 @@
         },
         "country": "pt"
     },
-    "data": "https://www.dropbox.com/s/msbm9ij2tkibaeh/portugal_geoedif.zip?dl=1",
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/sergiyprotsiv/4afe61/portugal_geoedif.zip",
     "website": "http://mapas.ine.pt/download/metadados/bgri11.html",
     "type": "http",
     "compression": "zip",

--- a/sources/pt/countrywide.json
+++ b/sources/pt/countrywide.json
@@ -1,0 +1,24 @@
+{
+    "coverage": {
+        "ISO 3166": {
+            "country": "Portugal",
+            "alpha2": "PT"
+        },
+        "country": "pt"
+    },
+    "data": "https://www.dropbox.com/s/msbm9ij2tkibaeh/portugal_geoedif.zip?dl=1",
+    "website": "http://mapas.ine.pt/download/metadados/bgri11.html",
+    "type": "http",
+    "compression": "zip",
+    "conform": {
+        "type": "csv",
+        "srs": "EPSG:4326",
+        "number": "mor_no",
+        "street": ["mor_tpv_abr", "mor_rua"],
+        "id": "codcensoedif",
+        "postcode": "cp7",
+        "city": "mor_localidade",
+        "lat": "Y",
+        "lon": "X"
+    }
+}


### PR DESCRIPTION
A countrywide Portugal dataset, more than 3.5 million points, though it seems that it only covers residential buildings. It is hosted by INE (Portuguese statistical office).

It was created as part of the 2011 Census, and the database itself is called "Base geográfica de edifícios", but there is little specific info on the terms. Most census-related data in Europe are free to use (e.g. see the terms of the related Base Geográfica de Referenciação da Informação 2011, http://mapas.ine.pt/download/metadados/bgri11.html).

There are multiple similar sources on INE's webpage, but many of them return 0 count for the datapoints after a delay. I used a custom version of pyesridump with forced OID-based queries and it worked fine. Since the main dataset (for continental Portugal) needs a bit of pre-processing, I used that step to also merge in the data for the Azores and Madeira archipelagoes that were separate sources with separate projections. See the script file for more details.