### PR TITLE
Russia - Nenetskiy avtonomnyy okrug

### DIFF
--- a/sources/ru/nen/regionwide.json
+++ b/sources/ru/nen/regionwide.json
@@ -1,0 +1,19 @@
+{
+    "coverage": {
+        "ISO 3166": {
+            "alpha2": "RU-NEN",
+            "country": "Russian Federation",
+            "subdivision": "Nenetskiy avtonomnyy okrug"
+        },
+        "country": "ru",
+        "state": "NEN"
+    },
+    "data": "http://gisnao.ru/arcgis/rest/services/Topo/Topomap_Nao/MapServer/2",
+    "type": "ESRI",
+    "language": "ru",
+    "conform": {
+        "number": "Numbd",
+        "street":  "Namestrit",
+        "type": "geojson"
+    }
+}


### PR DESCRIPTION
This one is a special place - twice the area of Portugal, but with less than 50K inhabitants. 
Most of them cluster around the capital (https://upload.wikimedia.org/wikipedia/commons/4/4b/Nenetsia_map.png) and this source only covers the addresses in this cluster. Since the naming of the source implies full coverage of the region and the source covers multiple towns, I am putting the whole region in the coverage.