### PR TITLE
Add skip to all sources that use 39 Degrees North

### DIFF
--- a/sources/us/in/bartholomew.json
+++ b/sources/us/in/bartholomew.json
@@ -11,6 +11,8 @@
     },
     "data": "https://elb2.39dn.com/arcgis/rest/services/eGISDynamicServices/BartholomewINDynamic/MapServer/0",
     "type": "ESRI",
+    "skip": true,
+    "note": "39dn requested that we stop using data obtained from their servers on 2017-05-07",
     "conform": {
         "type": "geojson",
         "number": "NUMBER",

--- a/sources/us/in/benton.json
+++ b/sources/us/in/benton.json
@@ -11,6 +11,8 @@
     },
     "data": "https://elb2.39dn.com/arcgis/rest/services/eGISDynamicServices/BentonINDynamic/MapServer/15",
     "type": "ESRI",
+    "skip": true,
+    "note": "39dn requested that we stop using data obtained from their servers on 2017-05-07",
     "conform": {
       "number": "House",
       "street": [

--- a/sources/us/in/cass.json
+++ b/sources/us/in/cass.json
@@ -11,6 +11,8 @@
     },
     "data": "https://elb2.39dn.com/arcgis/rest/services/eGISDynamicServices/CassINDynamic/MapServer/6",
     "type": "ESRI",
+    "skip": true,
+    "note": "39dn requested that we stop using data obtained from their servers on 2017-05-07",
     "conform": {
       "number": "House",
       "street": [

--- a/sources/us/in/city-of-hobart.json
+++ b/sources/us/in/city-of-hobart.json
@@ -11,6 +11,8 @@
     },
     "data": "https://elb2.39dn.com/arcgis/rest/services/eGISDynamicServices/HobartINDynamic/MapServer/83",
     "type": "ESRI",
+    "skip": true,
+    "note": "39dn requested that we stop using data obtained from their servers on 2017-05-07",
     "conform": {
       "number": "Address",
       "street": "Street_Add",

--- a/sources/us/in/clark.json
+++ b/sources/us/in/clark.json
@@ -11,6 +11,8 @@
     },
     "data": "https://elb2.39dn.com/arcgis/rest/services/eGISDynamicServices/ClarkINDynamic/MapServer/11",
     "type": "ESRI",
+    "skip": true,
+    "note": "39dn requested that we stop using data obtained from their servers on 2017-05-07",
     "conform": {
       "number": "STRUCTURE",
       "street": "COMP_STR_N",

--- a/sources/us/in/elkhart.json
+++ b/sources/us/in/elkhart.json
@@ -11,6 +11,8 @@
     },
     "data": "https://elb2.39dn.com/arcgis/rest/services/eGISDynamicServices/ElkhartINDynamic/MapServer/59",
     "type": "ESRI",
+    "skip": true,
+    "note": "39dn requested that we stop using data obtained from their servers on 2017-05-07",
     "conform": {
       "number": "CompleteAddressNumber",
       "street": "CompleteStreetName",

--- a/sources/us/in/floyd.json
+++ b/sources/us/in/floyd.json
@@ -11,6 +11,8 @@
     },
     "data": "https://elb2.39dn.com/arcgis/rest/services/eGISDynamicServices/FloydINDynamic/MapServer/0",
     "type": "ESRI",
+    "skip": true,
+    "note": "39dn requested that we stop using data obtained from their servers on 2017-05-07",
     "conform": {
       "number": "Street_Number",
       "street": "Street_Name",

--- a/sources/us/in/grant.json
+++ b/sources/us/in/grant.json
@@ -11,6 +11,8 @@
     },
     "data": "https://elb2.39dn.com/arcgis/rest/services/eGISDynamicServices/GrantINDynamic/MapServer/4",
     "type": "ESRI",
+    "skip": true,
+    "note": "39dn requested that we stop using data obtained from their servers on 2017-05-07",
     "conform": {
       "number": "HouseNumber",
       "street": [

--- a/sources/us/in/harrison.json
+++ b/sources/us/in/harrison.json
@@ -11,6 +11,8 @@
     },
     "data": "https://elb2.39dn.com/arcgis/rest/services/eGISDynamicServices/HarrisonINDynamic/MapServer/29",
     "type": "ESRI",
+    "skip": true,
+    "note": "39dn requested that we stop using data obtained from their servers on 2017-05-07",
     "conform": {
       "number": {
           "function": "regexp",

--- a/sources/us/in/hendricks.json
+++ b/sources/us/in/hendricks.json
@@ -11,6 +11,8 @@
     },
     "data": "https://elb2.39dn.com/arcgis/rest/services/eGISDynamicServices/HendricksINDynamic/MapServer/27",
     "type": "ESRI",
+    "skip": true,
+    "note": "39dn requested that we stop using data obtained from their servers on 2017-05-07",
     "conform": {
       "number": {
           "function": "regexp",

--- a/sources/us/in/jay.json
+++ b/sources/us/in/jay.json
@@ -11,6 +11,8 @@
     },
     "data": "https://elb2.39dn.com/arcgis/rest/services/eGISDynamicServices/JayINDynamic/MapServer/0",
     "type": "ESRI",
+    "skip": true,
+    "note": "39dn requested that we stop using data obtained from their servers on 2017-05-07",
     "conform": {
       "number": "ADDRESS_NU",
       "street": [

--- a/sources/us/in/laporte.json
+++ b/sources/us/in/laporte.json
@@ -11,6 +11,8 @@
     },
     "data": "https://elb2.39dn.com/arcgis/rest/services/eGISDynamicServices/LaPorteINDynamic/MapServer/5",
     "type": "ESRI",
+    "skip": true,
+    "note": "39dn requested that we stop using data obtained from their servers on 2017-05-07",
     "conform": {
       "number": "SITE_ADD",
       "street": [

--- a/sources/us/in/lawrence.json
+++ b/sources/us/in/lawrence.json
@@ -11,6 +11,8 @@
     },
     "data": "https://elb2.39dn.com/arcgis/rest/services/eGISDynamicServices/LawrenceINDynamic/MapServer/9",
     "type": "ESRI",
+    "skip": true,
+    "note": "39dn requested that we stop using data obtained from their servers on 2017-05-07",
     "conform": {
       "number": "House",
       "street": "Street",

--- a/sources/us/in/martin.json
+++ b/sources/us/in/martin.json
@@ -11,6 +11,8 @@
     },
     "data": "https://elb2.39dn.com/arcgis/rest/services/eGISDynamicServices/MartinINDynamic/MapServer/7",
     "type": "ESRI",
+    "skip": true,
+    "note": "39dn requested that we stop using data obtained from their servers on 2017-05-07",
     "conform": {
       "number": "House",
       "street": [

--- a/sources/us/in/miami.json
+++ b/sources/us/in/miami.json
@@ -11,6 +11,8 @@
     },
     "data": "https://elb2.39dn.com/arcgis/rest/services/eGISDynamicServices/MiamiINDynamic/MapServer/8",
     "type": "ESRI",
+    "skip": true,
+    "note": "39dn requested that we stop using data obtained from their servers on 2017-05-07",
     "conform": {
       "number": {
           "function": "regexp",

--- a/sources/us/in/monroe.json
+++ b/sources/us/in/monroe.json
@@ -11,6 +11,8 @@
     },
     "data": "https://elb2.39dn.com/arcgis/rest/services/eGISDynamicServices/MonroeINDynamic/MapServer/5",
     "type": "ESRI",
+    "skip": true,
+    "note": "39dn requested that we stop using data obtained from their servers on 2017-05-07",
     "conform": {
       "number": {
           "function": "regexp",

--- a/sources/us/in/morgan.json
+++ b/sources/us/in/morgan.json
@@ -11,6 +11,8 @@
     },
     "data": "https://elb2.39dn.com/arcgis/rest/services/eGISDynamicServices/MorganINDynamic/MapServer/0",
     "type": "ESRI",
+    "skip": true,
+    "note": "39dn requested that we stop using data obtained from their servers on 2017-05-07",
     "conform": {
       "number": "HOUSE_NUM",
       "street": [

--- a/sources/us/in/orange.json
+++ b/sources/us/in/orange.json
@@ -11,6 +11,8 @@
     },
     "data": "https://elb2.39dn.com/arcgis/rest/services/eGISDynamicServices/OrangeINDynamic/MapServer/7",
     "type": "ESRI",
+    "skip": true,
+    "note": "39dn requested that we stop using data obtained from their servers on 2017-05-07",
     "conform": {
       "number": "House",
       "street": [

--- a/sources/us/in/owen.json
+++ b/sources/us/in/owen.json
@@ -11,6 +11,8 @@
     },
     "data": "https://elb2.39dn.com/arcgis/rest/services/eGISDynamicServices/OwenINDynamic/MapServer/1",
     "type": "ESRI",
+    "skip": true,
+    "note": "39dn requested that we stop using data obtained from their servers on 2017-05-07",
     "conform": {
       "number": "STR_NUM",
       "street": [

--- a/sources/us/in/white.json
+++ b/sources/us/in/white.json
@@ -11,6 +11,8 @@
     },
     "data": "https://elb2.39dn.com/arcgis/rest/services/eGISDynamicServices/WhiteINDynamic/MapServer/5",
     "type": "ESRI",
+    "skip": true,
+    "note": "39dn requested that we stop using data obtained from their servers on 2017-05-07",
     "conform": {
       "number": "STRUCTURE_NUM",
       "street": "COMP_STR_NAME",

--- a/sources/us/mo/new_madrid.json
+++ b/sources/us/mo/new_madrid.json
@@ -11,6 +11,8 @@
     },
     "data": "https://elb2.39dn.com/arcgis/rest/services/eGISDynamicServices/NewMadridMODynamic/MapServer/0",
     "type": "ESRI",
+    "skip": true,
+    "note": "39dn requested that we stop using data obtained from their servers on 2017-05-07",
     "conform": {
         "number": "STRUCTURE_NUM",
         "street": "COMP_STR_NAME",


### PR DESCRIPTION
We received a friendly request to "remove all data that has been harvested from the services that are hosted by 39 Degrees North immediately."

I'm starting this process by marking these sources with `skip: true` so that we don't request data going forward.