### PR TITLE
Disabling Lithuania countrywide

### DIFF
--- a/sources/lt/countrywide.json
+++ b/sources/lt/countrywide.json
@@ -7,6 +7,7 @@
     "website": "http://www.lakd.lt/",
     "attribution": "The Lithuanian Road Administration",
     "type": "ESRI",
+    "skip": true,
     "conform": {
         "type": "geojson",
         "district": "SAV_PAV",


### PR DESCRIPTION
As per comments of @tomass, the countrywide source for Lithuania is not openly licensed (see https://github.com/openaddresses/openaddresses/issues/3015). Since the data is taken straight from the LAKD website with no immediate license info available, I would disable the source until further information is available. I have read about the plans of opening up the dataset, but can see no results of that so far.

@nvkelso, please merge this if you have no objections.