### PR TITLE
Adding license for Thüringen, Germany

### DIFF
--- a/sources/de/th/statewide.json
+++ b/sources/de/th/statewide.json
@@ -8,6 +8,12 @@
 	"website": "https://onlineshop.thueringen.de/th9/tlvermgeo/geoshop/flure/hauskoordinaten/",
 	"type": "http",
 	"compression": "zip",
+	"license": {
+		"text": "dl-de/by-2-0",
+		"url": "https://www.govdata.de/dl-de/by-2-0",
+		"attribution": true,
+		"attribution name": "Freistaat Thüringen"
+	},
 	"conform": {
 		"type": "csv",
 		"csvsplit": ";",


### PR DESCRIPTION
Thanks a lot to @it4workflow for pointing out the specific data license for the dataset for Thüringen (https://github.com/openaddresses/openaddresses/issues/3008). I have now added the necessary information to the conform for that source.