### PR TITLE
updated Cook County, IL, USA

### DIFF
--- a/scripts/us/il/cook/.gitignore
+++ b/scripts/us/il/cook/.gitignore
@@ -1,0 +1,2 @@
+data
+node_modules

--- a/scripts/us/il/cook/README.md
+++ b/scripts/us/il/cook/README.md
@@ -1,0 +1,8 @@
+This script reads all Cook County, IL address point sections from:
+
+https://datacatalog.cookcountyil.gov/browse?q=address%20points&sortBy=relevance&utf8=%E2%9C%93
+
+To install: `npm i`
+To run: `node index.js`
+
+All intermediate files and final output are saved into `./data/`.  The final output is written to `./data/us-il-cook.geojson`.

--- a/scripts/us/il/cook/index.js
+++ b/scripts/us/il/cook/index.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const request = require('request');
+const fs = require('fs-extra');
+const _ = require('lodash');
+const path = require('path');
+
+const output_filename = path.resolve('data', 'us-il-cook.geojson');
+
+let count = 0;
+
+const sections = [
+  'qzpp-jhf6',
+  '4977-ijic',
+  '7832-c962',
+  '5krr-vb4m',
+  '38yg-b73x',
+  'nkzg-ucit',
+  'rxi4-nx3v',
+  'ivv7-q3um',
+  'syzq-55pd',
+  'c4y3-uesx',
+  'uf63-xagj',
+  '6265-sdqf',
+  '6y64-fiuv',
+  '7rcp-cifk',
+  'ai6s-9ihv',
+  'e9gq-iquy',
+  'jaeu-u2u6',
+  'b83i-7zxa',
+  'y9wi-jd57',
+  '24hu-vx3h',
+  'uhv8-ar4p',
+  'mqn9-4wmy',
+  'kkvn-vsd7',
+  'ntax-x2zf',
+  '6uxp-xqj6',
+  'pz8d-arh6',
+  'vhk7-x9yc',
+  'gug2-e5qv',
+  'd8c2-rize',
+  'k7z8-ma9h',
+  'mqsd-unjm',
+  'q6ik-zx2p',
+  '7fn9-axdp'
+];
+
+fs.ensureDirSync('data');
+
+sections.forEach((section) => {
+  const url = `https://datacatalog.cookcountyil.gov/api/geospatial/${section}?method=export&format=GeoJSON`;
+
+  request(url).pipe(fs.createWriteStream(`data/${section}.geojson`)).on('finish', () => {
+    console.log(`retrieved ${section} (${count+1}/${sections.length})`);
+
+    if (++count === sections.length) {
+      console.log(`finished retrieving ${sections.length} sections`);
+      dumpToOneBigFile();
+    }
+
+  });
+
+});
+
+function dumpToOneBigFile() {
+  const write_stream = fs.createWriteStream(output_filename);
+  write_stream.write('{"type":"FeatureCollection","features":[\n');
+
+  sections.forEach((section, section_idx) => {
+    const contents = JSON.parse(fs.readFileSync(path.resolve('data', `${section}.geojson`)));
+
+    console.log(`read ${contents.features.length} features from ${section} (${section_idx+1}/${sections.length})`);
+
+    contents.features.forEach((feature, feature_idx) => {
+      feature.properties = _.pick(feature.properties, ['addrnocom', 'stnamecom', 'placename', 'zip5']);
+      write_stream.write(JSON.stringify(feature));
+
+      if (section_idx < sections.length-1 || feature_idx < contents.features.length-1) {
+        write_stream.write(',');
+      }
+
+      write_stream.write('\n');
+
+    });
+
+  });
+
+  write_stream.write(']}');
+  console.log(`finished writing ${sections.length} sections to ${output_filename}`);
+
+}

--- a/scripts/us/il/cook/package.json
+++ b/scripts/us/il/cook/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "cook",
+  "version": "1.0.0",
+  "description": "Scraper for Cook County, IL, USA",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "trescube",
+  "license": "MIT",
+  "dependencies": {
+    "fs-extra": "^3.0.1"
+  }
+}

--- a/sources/us/il/city_of_chicago.json
+++ b/sources/us/il/city_of_chicago.json
@@ -16,15 +16,6 @@
         "state": "il",
         "place": "Chicago"
     },
-    "data": "https://datacatalog.cookcountyil.gov/api/geospatial/jev2-4wjs?method=export&format=Original",
-    "note": "Cook county addresses within the city of Chicago",
-    "type": "http",
-    "compression": "zip",
-    "conform": {
-        "type": "shapefile",
-        "number": "ADDRNOCOM",
-        "street": "STNAMECOM",
-        "city": "PLACENAME",
-        "postcode": "ZIP5"
-    }
+    "skip": true,
+    "note": "Superseded by sources/us/il/cook.json as source data has restructured"
 }

--- a/sources/us/il/city_of_chicago.json
+++ b/sources/us/il/city_of_chicago.json
@@ -1,4 +1,5 @@
 {
+    "skip": true,
     "coverage": {
         "geometry": {
             "type": "Point",
@@ -16,6 +17,7 @@
         "state": "il",
         "place": "Chicago"
     },
-    "skip": true,
-    "note": "Superseded by sources/us/il/cook.json as source data has restructured"
+    "note": "Superseded by sources/us/il/cook.json as source data has restructured and this exact data is no longer available",
+    "type": "http",
+    "data": "https://datacatalog.cookcountyil.gov/api/geospatial/jev2-4wjs?method=export&format=Original"
 }

--- a/sources/us/il/cook.json
+++ b/sources/us/il/cook.json
@@ -9,15 +9,15 @@
         "state": "il",
         "county": "Cook"
     },
-    "data": "https://datacatalog.cookcountyil.gov/api/geospatial/6mf5-x8ic?method=export&format=Original",
-    "note": "Cook county addresses NOT within the city of Chicago (suburban areas)",
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/trescube/ee477e/us-il-cook.geojson.zip",
+    "note": "All Cook County addresses including the city of Chicago",
     "type": "http",
     "compression": "zip",
     "conform": {
-        "type": "shapefile",
-        "number": "ADDRNOCOM",
-        "street": "STNAMECOM",
-        "city": "PLACENAME",
-        "postcode": "ZIP5"
+        "type": "geojson",
+        "number": "addrnocom",
+        "street": "stnamecom",
+        "city": "placename",
+        "postcode": "zip5"
     }
 }


### PR DESCRIPTION
Source data has Cook County split up into 33 sections (there are 119 cities in Cook County [according to WOF](https://datacatalog.cookcountyil.gov/browse?q=address%20points&sortBy=relevance&utf8=%E2%9C%93)).  This PR adds scripts/us/il/cook to download, trim, and assemble into one big file.  