### PR TITLE
fixed source data, updated for helper functions

### DIFF
--- a/sources/ca/on/lambton.json
+++ b/sources/ca/on/lambton.json
@@ -5,20 +5,17 @@
         "county": "Lambton"
     },
     "type": "http",
-    "data": "http://data.openaddresses.io/cache/ca-on-lambton.geojson",
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/trescube/fd83c4/ca-on-lambton.geojson.zip",
+    "compression": "zip",
     "conform":{
         "type": "geojson",
         "number": {
-            "function": "regexp",
-            "field": "ADDRESS",
-            "pattern": "^([0-9]+)( .*)",
-            "replace": "$1"
+            "function": "prefixed_number",
+            "field": "ADDRESS"
         },
         "street": {
-            "function": "regexp",
-            "field": "ADDRESS",
-            "pattern": "^(?:[0-9]+ )(.*)",
-            "replace": "$1"
+            "function": "postfixed_street",
+            "field": "ADDRESS"
         },
         "city": "MUNICIPALITY"
     },


### PR DESCRIPTION
Old source data had invalid JSON (trailing `,` after last feature).  This has been fixed and cached on s3.  