### PR TITLE
si/countrywide: Adjusted CSV so that it can be compressed better

### DIFF
--- a/scripts/si/addNames.py
+++ b/scripts/si/addNames.py
@@ -91,6 +91,10 @@ def main(path):
         for rowIn in reader:
             rowOut = rowIn
 
+            # round the coordinates to 7 decimals (roughly 1cm precision)
+            rowOut[0] = round(float(rowIn[0]), 7)
+            rowOut[1] = round(float(rowIn[1]), 7)
+
             # map IDs to values
             rowOut[3] = streets.get(rowIn[3], cities.get(rowIn[4], '??'))
             rowOut[4] = cities.get(rowIn[4], '??')

--- a/scripts/si/makeCSVs.sh
+++ b/scripts/si/makeCSVs.sh
@@ -19,7 +19,9 @@ ogr2ogr -t_srs "EPSG:4326" -f CSV ${folder}addresses-noname.csv ${folder}HS-etrs
 		PO_MID,
 		PT_MID,
 		HS_MID
-	FROM 'SI.GURS.RPE.PUB.HS-etrs89' WHERE STATUS ='V' ORDER BY HS_MID" \
+	FROM 'SI.GURS.RPE.PUB.HS-etrs89' 
+	WHERE STATUS ='V'
+	ORDER BY OB_MID, NA_MID, UL_MID, HS, HD, HS_MID" \
  -nln addresses-noname
 
 # Street names


### PR DESCRIPTION
zip with unordered csv was 15.6 MB, order by HS_MID only was 13.5MB, now 12.9MB
Rounding the coordinates to 7 decimal digits (same as openaddresses output, roughly 1cm precision) reduced the zip size further down to 7.6 MB