### PR TITLE
Canada STD

### DIFF
--- a/sources/ca/ab/province.json
+++ b/sources/ca/ab/province.json
@@ -1,10 +1,6 @@
 {
     "coverage": {
-        "ISO 3166": {
-            "alpha2": "CA-AB",
-            "country": "Canada",
-            "subdivision": "Alberta"
-        },
+        "ISO 3166": { "alpha2": "CA-AB", "country": "Canada", "subdivision": "Alberta" },
         "country": "ca",
         "state": "ab"
     },

--- a/sources/ca/nb/province.json
+++ b/sources/ca/nb/province.json
@@ -1,10 +1,6 @@
 {
     "coverage": {
-        "ISO 3166": {
-            "ISO 3166": {"alpha2": "CA-NB", "country": "Canada", "subdivision": "New Brunswick"},
-            "province": "New Brunswick",
-            "country": "Canada"
-        },
+        "ISO 3166": {"alpha2": "CA-NB", "country": "Canada", "subdivision": "New Brunswick"},
         "country": "ca",
         "state": "nb"
     },

--- a/sources/ca/ns/province.json
+++ b/sources/ca/ns/province.json
@@ -1,10 +1,6 @@
 {
     "coverage": {
-        "ISO 3166": {
-            "ISO 3166": {"alpha2": "CA-NS", "country": "Canada", "subdivision": "Nova Scotia"},
-            "province": "Nova Scotia",
-            "country": "Canada"
-        },
+        "ISO 3166": {"alpha2": "CA-NS", "country": "Canada", "subdivision": "Nova Scotia"},
         "country": "ca",
         "state": "ns"
     },

--- a/sources/ca/pe/province.json
+++ b/sources/ca/pe/province.json
@@ -1,10 +1,6 @@
 {
     "coverage": {
-        "ISO 3166": {
-            "ISO 3166": {"alpha2": "CA-PE", "country": "Canada", "subdivision": "Prince Edward Island"},
-            "province": "Prince Edward Island",
-            "country": "Canada"
-        },
+        "ISO 3166": {"alpha2": "CA-PE", "country": "Canada", "subdivision": "Prince Edward Island"},
         "country": "ca",
         "state": "pe"
     },


### PR DESCRIPTION
Standardize `ISO 3166` tags to avoid double nesting and more closely match the US tags. Before there was a mix of everything at the province level.