### PR TITLE
removing house number prefix from street name in WV

### DIFF
--- a/sources/us/wv/statewide.json
+++ b/sources/us/wv/statewide.json
@@ -14,7 +14,11 @@
     "conform": {
         "type": "geojson",
         "number": "ADDRNUM",
-        "street": "FULLNAME",
+        "street": {
+            "function": "remove_prefix",
+            "field": "FULLNAME",
+            "field_to_remove": "ADDRNUM"
+        },
         "unit": [
             "UNITTYPE",
             "UNITID"


### PR DESCRIPTION
A fraction of the street names contain house numbers, but luckily ADDRNUM is populated in almost all cases.