### PR TITLE
updated data url and conform (City of Cambridge, MA)

### DIFF
--- a/sources/us/ma/city_of_cambridge.json
+++ b/sources/us/ma/city_of_cambridge.json
@@ -16,12 +16,24 @@
         "state": "ma",
         "city": "Cambridge"
     },
-    "data": "https://raw.githubusercontent.com/cambridgegis/cambridgegis_data/master/Address/Address_Points/ADDRESS_AddressPoints.geojson",
+    "data": "https://raw.githubusercontent.com/cambridgegis/cambridgegis_data/master/Address/Address_Points/Master_Address_Database_with_MapLot_and_BldgID.csv",
     "website": "https://github.com/cambridgegis/cambridgegis_data/",
     "type": "http",
     "conform": {
-        "type": "geojson",
-        "number": "StNm",
-        "street": "StName"
+        "type": "csv",
+        "id": "address_id",
+        "number": {
+            "function": "format",
+            "fields": [
+                "street_number",
+                "street_number_suffix"
+            ],
+            "format": "$1-$2"
+        },
+        "street": [
+            "street_name",
+            "street_suffix",
+            "dir_suffix"
+        ]
     }
 }

--- a/sources/us/ma/city_of_cambridge.json
+++ b/sources/us/ma/city_of_cambridge.json
@@ -16,24 +16,13 @@
         "state": "ma",
         "city": "Cambridge"
     },
-    "data": "https://raw.githubusercontent.com/cambridgegis/cambridgegis_data/master/Address/Address_Points/Master_Address_Database_with_MapLot_and_BldgID.csv",
+    "data": "https://raw.githubusercontent.com/cambridgegis/cambridgegis_data/master/Address/Address_Points/ADDRESS_AddressPoints.geojson",
     "website": "https://github.com/cambridgegis/cambridgegis_data/",
     "type": "http",
     "conform": {
-        "type": "csv",
+        "type": "geojson",
         "id": "address_id",
-        "number": {
-            "function": "format",
-            "fields": [
-                "street_number",
-                "street_number_suffix"
-            ],
-            "format": "$1-$2"
-        },
-        "street": [
-            "street_name",
-            "street_suffix",
-            "dir_suffix"
-        ]
+        "number": "StNm",
+        "street": "StName"
     }
 }


### PR DESCRIPTION
I switched this from GeoJSON to CSV due to errors in the machine processing like this:

`ValueError: dict contains fields not in fieldnames: 'EditDate'`

Some, but not all, records from the source GeoJSON have a field named `EditDate`.  This was causing an issue because the machine converts the GeoJSON to CSV internally and the dictionary of keys is established from the first record (which doesn't contain `EditDate`) so when a record containing an unknown key comes along, the machine fails on the source.  

The CSV source is consistent in fields throughout the file.  
