### PR TITLE
fix address number field for us-tx-el_paso

### DIFF
--- a/sources/us/tx/el_paso.json
+++ b/sources/us/tx/el_paso.json
@@ -15,7 +15,7 @@
     "note": "polygon, and street directionals/type fields are missing",
     "conform": {
         "street": "situs_stre",
-        "number": "situs_num",
+        "number": "situs_numb",
         "unit": "situs_unit",
         "city": "situs_city",
         "region": "situs_stat",


### PR DESCRIPTION
Corrects a misnamed field.

![image](https://user-images.githubusercontent.com/31717/28789031-7739514e-75f1-11e7-9d3f-1a5bf06f3e00.png)

