### PR TITLE
add missing au/victoria metadata

### DIFF
--- a/sources/au/victoria.json
+++ b/sources/au/victoria.json
@@ -25,6 +25,10 @@
         "street": [
             "ROAD_NAME",
             "ROAD_TYPE"
-        ]
+        ],
+        "unit": "HSE_SUF1",
+        "postcode": "POSTCODE",
+        "city": "LOCALITY",
+        "region": "STATE"
     }
 }


### PR DESCRIPTION
[edit] can we please review/merge https://github.com/openaddresses/openaddresses/pull/3173 first, this PR would be a good candidate for a rebase against that PR

as reported in https://github.com/pelias/pelias/issues/628, the `au/victoria` conform is missing some fields.

see: https://gist.github.com/missinglink/3b9d0e2e7e65ca7e8e638ebc1a0c58f9 for example

note: I wasn't sure how to handle the `1A/1-35 KILFEERA ROAD BENALLA 3672` entry in that example, please advise.