### PR TITLE
[WIP] au/victoria split unit and number [need help]

### DIFF
--- a/sources/au/vic/statewide.json
+++ b/sources/au/vic/statewide.json
@@ -30,7 +30,16 @@
                     "format": "gdb",
                     "layer": "ADDRESS",
                     "id": "PFI",
-                    "number": "NUM_ADDRESS",
+                    "unit": {
+                        "function": "format",
+                        "fields": ["BLG_UNIT_PREFIX_1", "BLG_UNIT_ID_1", "BLG_UNIT_SUFFIX_1", "BLG_UNIT_PREFIX_2", "BLG_UNIT_ID_2", "BLG_UNIT_SUFFIX_2"],
+                        "format": "$1$2$3-$4$5$6"
+                    },
+                    "number": {
+                        "function": "format",
+                        "fields": ["HOUSE_PREFIX_1", "HOUSE_NUMBER_1", "HOUSE_SUFFIX_1", "HOUSE_PREFIX_2", "HOUSE_NUMBER_2", "HOUSE_SUFFIX_2"],
+                        "format": "$1$2$3-$4$5$6"
+                    },
                     "street": [
                         "ROAD_NAME",
                         "ROAD_TYPE",


### PR DESCRIPTION
I've sketched out splitting up the unit and number for au/victoria, which is something also proposed at https://github.com/openaddresses/openaddresses/pull/3354 but I don't think that it's right.

Currently we have `"number": "NUM_ADD"`. `NUM_ADD` is basically the UNIT and NUMBER pre combined.

This PR is actually a step back as it currently stands as I'm not sure how to deal with `hsaunitid`.

- [ ] The OA unit should be `hsaunitid` if defined, else use the format function in this PR, but I'm not sure how to express that. Any suggestions?

* I think for now we can ignore all the floor data. It's not right including it in `unit`, so best we omit it until OA has a structure for floors.
* same goes for building name

Good addresses for testing are:

> A7/6A-8C EVERGREEN MEWS
> 4-6/35D-35F BUCKLEY STREET

The documentation for the data is at  http://www.depi.vic.gov.au/__data/assets/word_doc/0016/340333/Vicmap-Address-Product-Description.docx