### PR TITLE
update address point URL to map service 

### DIFF
--- a/sources/us/pa/cumberland.json
+++ b/sources/us/pa/cumberland.json
@@ -9,7 +9,7 @@
         "state": "pa",
         "county": "Cumberland"
     },
-    "data": "http://gis.ccpa.net/arcgiswebadaptor/rest/services/Zoning/MapServer/1",
+    "data": "http://gis.ccpa.net/arcgiswebadaptor/rest/services/SCTF/AddressPoints/MapServer/0",
     "website": "http://www.ccpa.net/index.aspx?NID=2080",
     "type": "ESRI",
     "conform": {
@@ -18,7 +18,8 @@
         "street": [
             "PRD",
             "STN",
-            "STS"
+            "STS",
+            "POD"
         ],
         "unit": "APTNUM",
         "city": "CITY"


### PR DESCRIPTION
The map service currently used in this repo has a definition query set, so only some records are being accessed.  The updated map service contains all records from the address points dataset.

I've also added the post-directional field from the service (POD).