### PR TITLE
Belarus countrywide

### DIFF
--- a/sources/by/countrywide.json
+++ b/sources/by/countrywide.json
@@ -1,10 +1,10 @@
 {
 	"coverage": {
         "country": "by",
-      "ISO 3166": {
-          "alpha2": "BY",
-          "country": "Belarus"
-      }
+	"ISO 3166": {
+		"alpha2": "BY",
+		"country": "Belarus"
+	}
     },
 	"data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/migurski/e29094/belarus.zip",
 	"website": "http://map.nca.by/",
@@ -15,18 +15,18 @@
 		"share-alike": false
 	},
   "conform": {
-		"type": "csv",
-		"city": "obj_name",
-		"street": ["elementtyp", "elementnam"],
-		"number": {
-      "function": "join",
-      "fields": ["num_house", "ind_house"],
-      "separator": ""
-    },
-    "unit" : "num_corp".
-    "district" : "namedistr",
-    "region": "nameregion",
-		"lat": "POINT_Y",
-		"lon": "POINT_X"
-	}
+	"type": "csv",
+	"city": "obj_name",
+	"street": ["elementtyp", "elementnam"],
+	"number": {
+	      "function": "join",
+	      "fields": ["num_house", "ind_house"],
+	      "separator": ""
+	    },
+    	"unit" : "num_corp",
+    	"district" : "namedistr",
+    	"region": "nameregion",
+	"lat": "POINT_Y",
+	"lon": "POINT_X"
+   }
 }

--- a/sources/by/countrywide.json
+++ b/sources/by/countrywide.json
@@ -1,0 +1,32 @@
+{
+	"coverage": {
+        "country": "by",
+      "ISO 3166": {
+          "alpha2": "BY",
+          "country": "Belarus"
+      }
+    },
+	"data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/migurski/e29094/belarus.zip",
+	"website": "http://map.nca.by/",
+	"type": "http",
+	"compression": "zip",
+	"license": {
+		"url": "http://map.nca.by",
+		"share-alike": false
+	},
+  "conform": {
+		"type": "csv",
+		"city": "obj_name",
+		"street": ["elementtyp", "elementnam"],
+		"number": {
+      "function": "join",
+      "fields": ["num_house", "ind_house"],
+      "separator": ""
+    },
+    "unit" : "num_corp".
+    "district" : "namedistr",
+    "region": "nameregion",
+		"lat": "POINT_Y",
+		"lon": "POINT_X"
+	}
+}


### PR DESCRIPTION
A conform to import the source for Belarus discussed in https://github.com/openaddresses/openaddresses/issues/3404.

@thatdatabaseguy, could you please check the preferred format for addresses. Specifically, whether we should have "korpus" as part of the house number or as a unit.

Some fields in the input csv were obviously created as numeric, might need a regex on them to remove decimals and replace zeroes with nulls.