### PR TITLE
Better source for Wilkin

### DIFF
--- a/sources/us/mn/wilkin.json
+++ b/sources/us/mn/wilkin.json
@@ -9,7 +9,8 @@
         "state": "mn",
         "county": "Wilkin"
     },
-    "data": "http://gisweb.co.wilkin.mn.us/arcgis/rest/services/WilkinPublic/MapServer/16",
+    "data": "http://gisweb.co.wilkin.mn.us/arcgis/rest/services/OpenData/OpenData/MapServer/0",
+    "website": "http://share-wilkinco.opendata.arcgis.com/",
     "type": "ESRI",
     "conform": {
       "type": "geojson",

--- a/sources/us/mn/wilkin.json
+++ b/sources/us/mn/wilkin.json
@@ -24,6 +24,6 @@
         },
         "city": "CITY",
         "region": "STATE",
-        "postcode": "ZIP"
+        "postcode": "ZIPCODE"
     }
 }


### PR DESCRIPTION
This source has more records and is likely to be better and more permanent, via their new open data website: http://share-wilkinco.opendata.arcgis.com/