### PR TITLE
Fix Stanislaus County CA

### DIFF
--- a/schema/source_schema.json
+++ b/schema/source_schema.json
@@ -485,13 +485,14 @@
           "minItems": 1,
           "items": {
             "oneOf": [
-              { "$ref": "#/definitions/function_regexp" },
-              { "$ref": "#/definitions/function_prefixed_number" },
-              { "$ref": "#/definitions/function_remove_prefix" },
-              { "$ref": "#/definitions/function_remove_postfix" },
-              { "$ref": "#/definitions/function_join" },
-              { "$ref": "#/definitions/function_format" },
-              { "$ref": "#/definitions/function_chain" }
+                { "$ref": "#/definitions/base_conform_field_value" },
+                { "$ref": "#/definitions/function_regexp" },
+                { "$ref": "#/definitions/function_postfixed_street" },
+                { "$ref": "#/definitions/function_remove_prefix" },
+                { "$ref": "#/definitions/function_remove_postfix" },
+                { "$ref": "#/definitions/function_join" },
+                { "$ref": "#/definitions/function_format" },
+                { "$ref": "#/definitions/function_chain" }
             ]
           }
         }

--- a/sources/us/ca/stanislaus.json
+++ b/sources/us/ca/stanislaus.json
@@ -12,15 +12,27 @@
     "conform": {
         "type": "geojson",
         "number": {
-            "function": "regexp",
-            "field": "Situs2",
-            "pattern": "^([0-9]+)"
+            "function": "prefixed_number",
+            "field": "Situs2"
         },
         "street": {
+            "function": "chain",
+            "variable": "Situs2_wip",
+            "functions": [{
+                "function": "postfixed_street",
+                "field": "Situs2"
+            },{
+                "function": "regexp",
+                "field": "Situs2_wip",
+                "pattern": "(.*?)( #[A-Za-z0-9])",
+                "replace": "$1"
+            }]
+        },
+        "unit": {
             "function": "regexp",
             "field": "Situs2",
-            "pattern": "^(?:[0-9]+ )(.*)",
-            "replace": "$1"
+            "pattern": "(.*?)( #[A-Za-z0-9])",
+            "replace": "$2"
         }
     },
     "attribution": "Stanislaus County",

--- a/sources/us/ca/stanislaus.json
+++ b/sources/us/ca/stanislaus.json
@@ -16,17 +16,10 @@
             "field": "Situs2"
         },
         "street": {
-            "function": "chain",
-            "variable": "Situs2_wip",
-            "functions": [{
-                "function": "postfixed_street",
-                "field": "Situs2"
-            },{
-                "function": "regexp",
-                "field": "Situs2_wip",
-                "pattern": "(.*?)( #[A-Za-z0-9])",
-                "replace": "$1"
-            }]
+            "function": "regexp",
+            "field": "Situs2_wip",
+            "pattern": "(.*?)( #[A-Za-z0-9])",
+            "replace": "$1"
         },
         "unit": {
             "function": "regexp",


### PR DESCRIPTION
Stanislaus County has a single Situs2 field which we parse out.

Examples For `SELECT DISTINCT _text FROM address WHERE source ='stanislaus';`
```
SYLVIA CT
 EDMONTON LN
 CAMELIA
 GREYSTONE LN
 TERHUNE CT
 SATARIANO LN
 ALYSHEBA DR
 WILLOW SONG CT
 CUTTING HORSE DR #126
 CEDAR CREEK DR #7
 JANEL ST
 TURNSTONE DR
 TULLY RD #112
 VAUGHN ST
```

At the moment we don't handle the unit/appt numbers prefixed with #. This adds slightly more complicated regex functions to ensure everything gets to the correct output column.