### PR TITLE
Change source from Garfield CO to Garfield WA

### DIFF
--- a/sources/us/wa/garfield.json
+++ b/sources/us/wa/garfield.json
@@ -26,7 +26,7 @@
             "function": "regexp",
             "field": "ADD_3",
             "pattern": "(.*)(\\d{5})$",
-            "replace": "$1"
+            "replace": "$2"
         },
         "city": {
             "function": "regexp",

--- a/sources/us/wa/garfield.json
+++ b/sources/us/wa/garfield.json
@@ -16,20 +16,20 @@
         "type": "geojson",
         "number": {
             "function": "prefixed_number",
-            "field": "ADDR_1"
+            "field": "ADD_1"
         },
         "street": {
             "function": "postfixed_street",
-            "field": "ADDR_1"
+            "field": "ADD_1"
         },
         "postcode": {
             "function": "regexp",
-            "field": "ADDR_3",
+            "field": "ADD_3",
             "pattern": "\\d{5}$"
         },
         "city": {
             "function": "regexp",
-            "field": "ADDR_3",
+            "field": "ADD_3",
             "pattern": "(.*?)(, WA)",
             "replace": "$2"
         }

--- a/sources/us/wa/garfield.json
+++ b/sources/us/wa/garfield.json
@@ -25,7 +25,7 @@
         "postcode": {
             "function": "regexp",
             "field": "ADDR_3",
-            "pattern": "\d{5}$"
+            "pattern": "\\d{5}$"
         },
         "city": {
             "function": "regexp",

--- a/sources/us/wa/garfield.json
+++ b/sources/us/wa/garfield.json
@@ -25,12 +25,13 @@
         "postcode": {
             "function": "regexp",
             "field": "ADD_3",
-            "pattern": "\\d{5}$"
+            "pattern": "(.*)(\\d{5})$",
+            "replace": "$1"
         },
         "city": {
             "function": "regexp",
             "field": "ADD_3",
-            "pattern": "(.*?)(, WA)",
+            "pattern": "(.*?)(, WA)(.*)",
             "replace": "$1"
         }
     }

--- a/sources/us/wa/garfield.json
+++ b/sources/us/wa/garfield.json
@@ -9,20 +9,29 @@
         "state": "wa",
         "county": "Garfield"
     },
-    "data": "http://www.garfield-county.com/geographic-information-systems/documents/parcels/ParcelsSHP.zip",
-    "website": "http://www.co.cowlitz.wa.us/index.aspx?nid=201",
-    "type": "http",
-    "compression": "zip",
+    "data": "https://services5.arcgis.com/1UmAlNNRc6UDVQ4y/ArcGIS/rest/services/Garfield_parcels/FeatureServer/0",
+    "website": "https://www.arcgis.com/home/item.html?id=25f924757dd845d19e7d6f516729f0ff",
+    "type": "ESRI",
     "conform": {
-        "type": "shapefile-polygon",
-        "number": "STREETNO",
-        "unit": "UNITNUMBER",
-        "street": [
-            "STREETDIR",
-            "STREETNAME",
-            "STREETSUF"
-        ],
-        "postcode": "SITUSZIP",
-        "city": "LOCCITY"
+        "type": "geojson",
+        "number": {
+            "function": "prefixed_number",
+            "field": "ADDR_1"
+        },
+        "street": {
+            "function": "postfixed_street",
+            "field": "ADDR_1"
+        },
+        "postcode": {
+            "function": "regexp",
+            "field": "ADDR_3",
+            "pattern": "\d{5}$"
+        },
+        "city": {
+            "function": "regexp",
+            "field": "ADDR_3",
+            "pattern": "(.*?)(, WA)",
+            "replace": "$2"
+        }
     }
 }

--- a/sources/us/wa/garfield.json
+++ b/sources/us/wa/garfield.json
@@ -16,11 +16,11 @@
         "type": "geojson",
         "number": {
             "function": "prefixed_number",
-            "field": "ADD_1"
+            "field": "ADD_2"
         },
         "street": {
             "function": "postfixed_street",
-            "field": "ADD_1"
+            "field": "ADD_2"
         },
         "postcode": {
             "function": "regexp",
@@ -31,7 +31,7 @@
             "function": "regexp",
             "field": "ADD_3",
             "pattern": "(.*?)(, WA)",
-            "replace": "$2"
+            "replace": "$1"
         }
     }
 }


### PR DESCRIPTION
The Garfield WA source sources/us/wa/garfield.json pointed to Garfield County Colorado data rather than Garfield County Washington data. PR adds the Garfield WA source.

cc @ingalls 