### PR TITLE
Set Mason County WA SRS to EPSG:2927

### DIFF
--- a/sources/us/wa/mason.json
+++ b/sources/us/wa/mason.json
@@ -18,7 +18,7 @@
     "website": "http://www.co.mason.wa.us/gis/",
     "conform":{
         "type": "shapefile",
-        "srs": "EPSG::2927",
+        "srs": "EPSG:2927",
         "street": "STREET",
         "number": "ADDRESS",
         "postcode": "ZIP_CD"

--- a/sources/us/wa/mason.json
+++ b/sources/us/wa/mason.json
@@ -18,6 +18,7 @@
     "website": "http://www.co.mason.wa.us/gis/",
     "conform":{
         "type": "shapefile",
+        "srs": "EPSG::2927",
         "street": "STREET",
         "number": "ADDRESS",
         "postcode": "ZIP_CD"


### PR DESCRIPTION
Mason County WA is currently being reprojected incorrectly; set the srs to EPSG:2927.

cc @ingalls 