### PR TITLE
Change number flag, Mason County WA

### DIFF
--- a/sources/us/wa/mason.json
+++ b/sources/us/wa/mason.json
@@ -19,7 +19,7 @@
     "conform":{
         "type": "shapefile",
         "street": "STREET",
-        "number": "ADDRESS",
+        "number": "STREETNUMB",
         "postcode": "ZIP_CD"
     }
 }


### PR DESCRIPTION
The `number` flag currently uses the `ADDRESS` field, which contains the full street address, rather than the `STREETNUMB` field, which contains only the address number.

cc @ingalls 