### PR TITLE
Add unit tag to Mason Co WA

### DIFF
--- a/sources/us/wa/mason.json
+++ b/sources/us/wa/mason.json
@@ -20,6 +20,7 @@
         "type": "shapefile",
         "street": "STREET",
         "number": "STREETNUMB",
+        "unit": "STRNUMSUFF",
         "postcode": "ZIP_CD"
     }
 }


### PR DESCRIPTION
Per https://github.com/openaddresses/openaddresses/pull/3468#issuecomment-336237688

`unit` tag set to `STRNUMSUFF`

cc @trescube @ingalls 