### PR TITLE
Deprecate Node 4 Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,4 @@ cache:
   directories:
     - node_modules
 node_js:
-  - 4
   - 6


### PR DESCRIPTION
Node 4 is quite old at this point and isn't actively being maintained. This PR removes the Node 4 test from the travis matrix, leaving Node 6.