### PR TITLE
House number must preserve the leading zero

### DIFF
--- a/sources/us/or/portland_metro.json
+++ b/sources/us/or/portland_metro.json
@@ -27,7 +27,7 @@
     "type": "http",
     "compression": "zip",
     "conform": {
-        "number": "HOUSE_NO",
+        "number": "HOUSE",
         "street": [
             "FDPRE",
             "FNAME",


### PR DESCRIPTION
It is invalid to discard the leading zero for the house numbers in this region because there are houses with and without the leading zero on opposite ends of the same street. Much confuse...