### PR TITLE
Adding unit attribute for danish addresses

### DIFF
--- a/sources/dk/countrywide.json
+++ b/sources/dk/countrywide.json
@@ -5,7 +5,11 @@
         "street": "vejnavn",
         "lat": "wgs84koordinat_bredde",
         "number": "husnr",
-        "postcode": "postnr"
+        "postcode": "postnr",
+        "unit": {
+            "function": "join",
+            "fields": ["etage", "dør"]
+        }
     },
     "attribution": "Contains information from the Danish Ministry of Housing, Urban and Rural Address Web Services (AWS).",
     "website": "http://download.aws.dk/",


### PR DESCRIPTION
Resolving #3511 by adding mapping for Unit attribute as a join of etage(floor level) and dør(door/apartment number) for danish address import.

Tested as far as I could, projects tests run fine and output from a data load with openaddresses/machine for Denmark with this change looks as expected.

from out.csv ...
```
LON,LAT,NUMBER,STREET,UNIT,CITY,DISTRICT,REGION,POSTCODE,ID,HASH
12.5631006,55.6794112,43,Vester Farimagsgade,5,,,,1606,,a350ce17b20165c2
12.5631006,55.6794112,43,Vester Farimagsgade,2,,,,1606,,791113343ce55a94
12.5631006,55.6794112,43,Vester Farimagsgade,kl,,,,1606,,ab3be57c588f30b9
12.5631006,55.6794112,43,Vester Farimagsgade,st,,,,1606,,bb4ce4a653d5cb3d
12.5397865,55.6700515,1A,Vesterfælledvej,3,,,,1750,,4e4ef4af62c0936e
12.5397865,55.6700515,1A,Vesterfælledvej,2,,,,1750,,f9c1a4b391f8874b
12.5397865,55.6700515,1A,Vesterfælledvej,4,,,,1750,,e5b7aaa84a92b513
12.5397865,55.6700515,1A,Vesterfælledvej,1,,,,1750,,1ecaddaf6189f944
12.5398779,55.6698801,1B,Vesterfælledvej,2 tv,,,,1750,,9e8b8ccc54a6986e
12.5398779,55.6698801,1B,Vesterfælledvej,5 5,,,,1750,,5c65ed7137365a48
12.5398779,55.6698801,1B,Vesterfælledvej,5 4,,,,1750,,0f3ae96db418d52a
12.5398779,55.6698801,1B,Vesterfælledvej,4 th,,,,1750,,181b6015b0465cc4
12.5398779,55.6698801,1B,Vesterfælledvej,3 th,,,,1750,,28f5060f521b0b4b
12.5398779,55.6698801,1B,Vesterfælledvej,4 tv,,,,1750,,5b7b1196652b82e9
...
```