### PR TITLE
Update NH state to remove units from street name

### DIFF
--- a/sources/us/nh/statewide.json
+++ b/sources/us/nh/statewide.json
@@ -1,33 +1,33 @@
 {
-    "coverage": {
-        "US Census": {
-            "geoid": "33",
-            "state": "New Hampshire"
-        },
-        "country": "us",
-        "state": "nh"
-    },
-    "data": "http://granitweb.sr.unh.edu:6080/arcgis/rest/services/MapServices/Parcels/MapServer/0",
-    "website": "http://www.granit.unh.edu/data/onlinemapservices/mapservicesoverview.html",
-    "type": "ESRI",
-    "conform": {
-        "type": "geojson",
-        "number": {
-            "function": "regexp",
-            "field": "Address",
-            "pattern": "^([0-9]+)"
-        },
-        "street": {
-            "function": "regexp",
-            "field": "Address",
-            "pattern": "^(?:[0-9]+ )(.*?)(?:\s(?:\(?(?:Unit|UNIT)?\s?#).*(\)?))",
-            "replace": "$1"
-        },
-        "unit": {
-            "function": "regexp",
-            "field": "Address",
-            "pattern": "(?:\(?(?:Unit|UNIT)?\s?#).*(\)?)"
-        },
-        "city": "TOWN_NAME"
-    }
+	"coverage": {
+		"US Census": {
+			"geoid": "33",
+			"state": "New Hampshire"
+		},
+		"country": "us",
+		"state": "nh"
+	},
+	"data": "http://granitweb.sr.unh.edu:6080/arcgis/rest/services/MapServices/Parcels/MapServer/0",
+	"website": "http://www.granit.unh.edu/data/onlinemapservices/mapservicesoverview.html",
+	"type": "ESRI",
+	"conform": {
+		"type": "geojson",
+		"number": {
+			"function": "regexp",
+			"field": "Address",
+			"pattern": "^([0-9]+)"
+		},
+		"street": {
+			"function": "regexp",
+			"field": "Address",
+			"pattern": "^(?:[0-9]+ )(.*?)(?:\\s(?:\\(?(?:Unit|UNIT)?\\s?#).*(\\)?))",
+			"replace": "$1"
+		},
+		"unit": {
+			"function": "regexp",
+			"field": "Address",
+			"pattern": "(?:\\(?(?:Unit|UNIT)?\\s?#).*(\\)?)"
+		},
+		"city": "TOWN_NAME"
+	}
 }

--- a/sources/us/nh/statewide.json
+++ b/sources/us/nh/statewide.json
@@ -20,8 +20,13 @@
         "street": {
             "function": "regexp",
             "field": "Address",
-            "pattern": "^(?:[0-9]+ )(.*)",
+            "pattern": "^(?:[0-9]+ )(.*?)(?:\s(?:\(?(?:Unit|UNIT)?\s?#).*(\)?))",
             "replace": "$1"
+        },
+        "unit": {
+            "function": "regexp",
+            "field": "Address",
+            "pattern": "(?:\(?(?:Unit|UNIT)?\s?#).*(\)?)"
         },
         "city": "TOWN_NAME"
     }

--- a/sources/us/nh/statewide.json
+++ b/sources/us/nh/statewide.json
@@ -26,7 +26,7 @@
 		"unit": {
 			"function": "regexp",
 			"field": "Address",
-			"pattern": "(?:\\(?(?:Unit|UNIT)?\\s?#).*(\\)?)"
+			"pattern": "\\(?(?:Unit|UNIT)?\\s?#).*(\\)?"
 		},
 		"city": "TOWN_NAME"
 	}


### PR DESCRIPTION
The NH statewide source has a ton of unit numbers in the raw data.

Examples include

```
APPLE BROOK WY #1
ABBEY LN UNIT #28
95L SCOBIE POND RD #A
ARTIST FALLS RD UNIT#4
A SOONIPI CIRCLE #A-H
BLACKBERRY RD #L&R
BRACKETT ROAD (#29)
DR TRUE RD #1/2/3
```