### PR TITLE
Remove unit numbers from street name

### DIFF
--- a/sources/us/wy/natrona.json
+++ b/sources/us/wy/natrona.json
@@ -14,12 +14,7 @@
     "conform": {
         "type": "geojson",
         "number": "STREET_NUM",
-        "street": {
-            "function": "regexp",
-            "field": "ADDRESS",
-            "pattern": "^(?:[0-9]+ )(.*)",
-            "replace": "$1"
-        },
+        "street": ["StreetName","StreetType"],
         "region": "STATE",
         "postcode": "ZIPCODE"
     }


### PR DESCRIPTION
`address` field contains unit numbers