### PR TITLE
Update Lubbock Co Texas US

### DIFF
--- a/sources/us/tx/lubbock.json
+++ b/sources/us/tx/lubbock.json
@@ -12,7 +12,7 @@
         "street": [
             "PREFIX",
             "STREET",
-            "STREET_TYP"
+            "STREET_TYPE"
         ],
         "unit": "SUITE",
         "type": "geojson"


### PR DESCRIPTION
Fixes a typo that was preventing street suffixes from being included in the output data.

cc @ingalls 