### PR TITLE
Update source for Dallas County Texas US

### DIFF
--- a/sources/us/tx/dallas.json
+++ b/sources/us/tx/dallas.json
@@ -10,18 +10,17 @@
         "county": "Dallas",
         "city": "Dallas"
     },
-    "data": "http://gis4.dfwmaps.com/arcgis/rest/services/ICDallas/Dallasbaselayers_VE/MapServer/4",
+    "data": "https://maps.dcad.org/prdwa/rest/services/Property/ParcelQuery/MapServer/4/",
     "type": "ESRI",
     "conform": {
-        "number": "ST_NUM",
-        "street": [
-            "ST_DIR",
-            "ST_NAME",
-            "ST_TYPE"
-        ],
-        "unit": "UNITID",
-        "city": "CITY",
-        "district": "COUNTY",
+        "number": {
+            "function": "prefixed_number",
+            "field": "SITEADDRESS"
+        },
+        "street": {
+            "function": "postfixed_street",
+            "field": "SITEADDRESS"
+        },
         "type": "geojson"
     }
 }


### PR DESCRIPTION
The ArcGIS server for Dallas County has been down since April 2017. The original data for this county came from the [North Central Texas Council of Governments](http://www.nctcog.org/index.asp), where the original map is still down http://www.dfwmaps.com/.

These new addresses are from the [Dallas Central Appraisal District](http://www.dallascad.org/). According to their website, DCAD is "responsible for appraising property for the purpose of ad valorem property tax assessment on behalf of the 61 local governing bodies in Dallas County." Unfortunately, this data source doesn't include fields other than a single `SITEADDRESS`, unlike the original source. Check out [this query](https://maps.dcad.org/prdwa/rest/services/Property/ParcelQuery/MapServer/4/query?where=&text=&objectIds=0%2C1%2C2%2C3%2C4%2C5%2C6%2C7%2C8%2C9&time=&geometry=&geometryType=esriGeometryEnvelope&inSR=&spatialRel=esriSpatialRelIntersects&relationParam=&outFields=*&returnGeometry=true&returnTrueCurves=false&maxAllowableOffset=&geometryPrecision=&outSR=&returnIdsOnly=false&returnCountOnly=false&orderByFields=&groupByFieldsForStatistics=&outStatistics=&returnZ=false&returnM=false&gdbVersion=&returnDistinctValues=false&resultOffset=&resultRecordCount=&queryByDistance=&returnExtentsOnly=false&datumTransformation=&parameterValues=&rangeValues=&f=html) to see sample data from the source.

cc @ingalls


