### PR TITLE
Uppsala, Sweden

### DIFF
--- a/sources/se/municipality_of_uppsala.json
+++ b/sources/se/municipality_of_uppsala.json
@@ -11,6 +11,11 @@
         "city": "Uppsala"
     },
     "data": "https://dzgisweb01.uppsala.se/ags02/rest/services/iExternaKartan/ByggaBo/MapServer/11",
+    "website": "https://www.uppsala.se/boende-och-trafik/kartor-och-statistik/baskarta/",
+    "license": {
+		"attribution": true,
+		"share-alike": false
+	},
     "type": "ESRI",
     "conform": {
         "type": "geojson",

--- a/sources/se/municipality_of_uppsala.json
+++ b/sources/se/municipality_of_uppsala.json
@@ -1,0 +1,35 @@
+{
+    "coverage": {
+        "geometry": {
+            "type": "Point",
+            "coordinates": [
+                17.645,
+                59.858
+            ]
+        },
+        "country": "se",
+        "city": "Uppsala"
+    },
+    "data": "https://dzgisweb01.uppsala.se/ags02/rest/services/iExternaKartan/ByggaBo/MapServer/11",
+    "type": "ESRI",
+    "conform": {
+        "type": "geojson",
+        "number": {
+            "function": "regexp",
+            "field": "Name",
+            "pattern": "^(?:.*?)\\s*([\\d]+\\w*(?:\\-[\\d]+\\w*)?)$"
+        },
+        "street": {
+            "function": "regexp",
+            "field": "Name",
+            "pattern": "^(.*?)\\s*(?:[\\d]+\\w*(?:\\-[\\d]+\\w*)?)$"
+        },
+        "city": "PostCity",
+        "postcode": {
+            "function": "regexp",
+            "field": "PostCode",
+            "pattern": "^([\\d]{3})([\\d]{2})$",
+            "replace": "$1 $2"
+        }
+    }
+}


### PR DESCRIPTION
Here's one of the Swedish municipalities (4th largest city) that appears to be licensed under CC-BY.

Following the links from https://www.uppsala.se/boende-och-trafik/kartor-och-statistik/baskarta/ (which specifies the license as CC-BY) and asking for metadata in the map that opens, you can get to https://uppsalakommun.maps.arcgis.com/home/item.html?id=da1fdd3af6994c9cb931c7a0b7ebb650.

This is where this dataset is imported from.