### PR TITLE
Monmount County, NJ, USA: updated coverage nv->nj

### DIFF
--- a/sources/us/nj/monmouth.json
+++ b/sources/us/nj/monmouth.json
@@ -3,10 +3,10 @@
         "US Census": {
             "geoid": "34025",
             "name": "Monmouth County",
-            "state": "Nevada"
+            "state": "New Jersey"
         },
         "country": "us",
-        "state": "nv",
+        "state": "nj",
         "county": "Monmouth"
     },
     "data": "http://maps.co.monmouth.nj.us/maps/rest/services/PublicData/Parcels/MapServer/0",


### PR DESCRIPTION
For some reason coverage said Nevada, switched to New Jersey.