### PR TITLE
[WIP] fix au/tas/launceston

### DIFF
--- a/sources/au/tas/launceston_city_council.json
+++ b/sources/au/tas/launceston_city_council.json
@@ -16,12 +16,39 @@
     "type": "ESRI",
     "conform": {
         "type": "geojson",
-        "number": "Address",
-        "street": {
+        "unit": {
             "function": "regexp",
-            "field": "Address",
-            "pattern": "^(?:[0-9]+ )(.*)",
+            "field": "houselabel",
+            "pattern": "^([^\\/]+)\\/",
             "replace": "$1"
+        },
+        "number": {
+            "function": "regexp",
+            "field": "houselabel",
+            "pattern": "\/?(.*)$",
+            "replace": "$1"
+        },
+        "street": {
+            "function": "remove_prefix",
+            "field": "address",
+            "field_to_remove": "houselabel"
+        },
+        "city": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "\\s([A-Z ]+)\\s(?:\\w*)\\s(?:[0-9]*)$",
+            "replace": "$1"
+        },
+        "region": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "\\s(\\w*)\\s(?:[0-9]*)$",
+            "replace": "$1"
+        },
+        "postcode": {
+            "function": "regexp",
+            "field": "address",
+            "pattern": "([0-9]*)$"
         }
     }
 }


### PR DESCRIPTION
continuing on from #3932 which was prematurely merged.

Source data looks like this:

**address**: `1/10 Teal Court NEWNHAM TAS 7248`
**houselabel**: `1/10`

which we want transformed into

| k | v |
|---|---|
| **unit** | 1 |
| **number** | 10 |
| **street** | Teal Court |
| **city** | NEWNHAM |
| **region** | TAS |
| **postcode** | 7248 |

with this PR it looks like:

| k | v |
|---|---|
| **unit** | 110 |
| **number** | 1/10 |
| **street** | Teal Court NEWNHAM TAS 7248|
| **city** | 1/10 Teal CourtNEWNHAM |
| **region** | 1/10 Teal Court NEWNHAMTAS |
| **postcode** | 7248 |

which is really wrong, so this PR isn't ready to be merged yet, but I'm stuck and can't get it to work so any help in either:

1. how to fix the regexp's, or
2. how I can test it locally (without needing to re-download every time) so I can try fiddling with the regexp to try to get it to work

would be very much appreciated. Thanks.