### PR TITLE
Fixing Kamloops BC CA data, website and license URLs

### DIFF
--- a/sources/ca/bc/kamloops.json
+++ b/sources/ca/bc/kamloops.json
@@ -5,9 +5,9 @@
         "city": "Kamloops",
         "geometry": { "type": "Point", "coordinates": [-120.36, 50.69] }
     },
-    "data": "http://www.kamloops.ca/downloads/maps/cadastralSHP.zip",
-    "website": "http://www.kamloops.ca/downloads/maps/launch.htm",
-    "license": "http://www.city.kamloops.bc.ca/maps/disclaimer.html",
+    "data": "http://maps.kamloops.ca/opendata/zipfiles/cadastralSHP.zip",
+    "website": "https://www.kamloops.ca/city-services/maps-apps",
+    "license": "https://www.kamloops.ca/node/29807",
     "type": "http",
     "compression": "zip",
     "conform": {


### PR DESCRIPTION
Fixing http://results.openaddresses.io/sources/ca/bc/kamloops