### PR TITLE
Fixing Kreis Viersen - URL to updated KML data

### DIFF
--- a/sources/de/nw/kreis_viersen.json
+++ b/sources/de/nw/kreis_viersen.json
@@ -5,7 +5,7 @@
 		"county": "Viersen",
 		"geometry": { "type": "Point", "coordinates": [6.40, 51.26] }
 	},
-	"data": "https://www.offenesdatenportal.de/dataset/cd06d2ff-e0cd-42aa-bfd2-a83b09324a58/resource/7302ab00-fd58-4875-9201-1053a0d62d0c/download/2015-09-07hausnummernkreisviersen.zip",
+	"data": "https://www.offenesdatenportal.de/dataset/cd06d2ff-e0cd-42aa-bfd2-a83b09324a58/resource/4a1c942c-6d44-4cc6-9408-c70bb2f6c280/download/2017-12-01-hausnummernkml.zip",
 	"website": "https://www.offenesdatenportal.de/dataset/hausnummern-im-kreis-viersen",
 	"license": {
 		"text": "CC BY 4.0",
@@ -18,7 +18,7 @@
 	"type": "http",
 	"conform": {
 		"type": "xml",
-		"file": "2015-09-07_Hausnummern_Kreis_Viersen.kml",
+		"file": "2017-12-01 Hausnummern.kml",
 		"postcode": "POSTLEITZAHL",
 		"street": "STRASSENNAME",
 		"number": ["HAUS_NR", "HAUS_NR_ZUSATZ"],


### PR DESCRIPTION
Fixing http://results.openaddresses.io/sources/de/nw/kreis_viersen