### PR TITLE
Add note to: us/md/statewide

### DIFF
--- a/sources/us/md/statewide.json
+++ b/sources/us/md/statewide.json
@@ -7,7 +7,7 @@
         "country": "us",
         "state": "md"
     },
-    "note": "Does not cover the entire state. Referred to link from https://www.arcgis.com/home/item.html?id=20878dd2c20949a8a14a5a282ab98807",
+    "note": "Does not cover the entire state. Referred to link from https://www.arcgis.com/home/item.html?id=20878dd2c20949a8a14a5a282ab98807. Also note that about 25,000 addresses is incorrectly positioned at -81.5291885,37.5772618 (you might want to filter those out)",
     "data": "http://s3.amazonaws.com/data.openaddresses.io/cache/uploads/migurski/mdpvgeoc10.zip",
     "website": "http://geodata.md.gov/imap/rest/services/PlanningCadastre/MD_PropertyData/MapServer/exts/MDiMapDataDownload/customLayers/0",
     "type": "http",


### PR DESCRIPTION
Added note to Statewide MD dataset about incorrect coordinates. A customer helped track down this oddity.

For now, we're just going to filter out those addresses, but I wanted to add a note here as well.

I assume that there's no good way to do this on the OA-side right now? (Without needing to do custom scripts)