### PR TITLE
fix typo: berline -> berlin

### DIFF
--- a/sources/de/berlin.json
+++ b/sources/de/berlin.json
@@ -1,7 +1,7 @@
 {
 	"coverage": {
 		"country": "de",
-		"state": "berline",
+		"state": "berlin",
 		"ISO 3166": {
             "alpha2": "DE-BE",
             "country": "Germany",


### PR DESCRIPTION
Berline is actually a valid way to say Berlin in Latvian, but it's probably not what was meant here.