### PR TITLE
South Africa countrywide

### DIFF
--- a/sources/za/countrywide.json
+++ b/sources/za/countrywide.json
@@ -1,0 +1,23 @@
+{
+    "type": "http",
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/sergiyprotsiv/a76ed3/za-countrywide.csv.zip",
+    "website": "https://drive.google.com/open?id=1KpLwbwq9YeYNLVFJDFsGwx8egfw6eeay",
+    "compression": "zip",
+    "coverage": {
+        "ISO 3166": {
+            "alpha2": "ZA",
+            "country": "Republic of South Africa"
+        },
+        "country": "za"
+    },
+    "conform": {
+        "type": "csv",
+        "id": "Unique_ID",
+        "number": "Str_Num",
+        "street": ["Str_Name","Str_Suff"],
+        "lon": "X",
+        "lat": "Y",
+        "city": "M_Place",
+        "region": "Munic"
+    }
+}


### PR DESCRIPTION
This is the data from the source described in https://github.com/openaddresses/openaddresses/issues/4106. Simply exported to csv via QGIS and uploaded.
It does appear to contain almost every address in South Africa, almost 14 million in total.
If anyone can confirm the licensing is fine, please merge this in.