### PR TITLE
La Reunion Encoding

### DIFF
--- a/sources/fr/la_reunion.json
+++ b/sources/fr/la_reunion.json
@@ -17,8 +17,7 @@
         "lon": "lon",
         "lat": "lat",
         "city": "nom_commune",
-        "postcode": "code_post",
-        "encoding": "ISO-8859-1"
+        "postcode": "code_post"
     },
     "email": "adresse@data.gouv.fr",
     "language": "fr",


### PR DESCRIPTION
Our La Reunion source has an encoding issue as can be seen from the screenshots below.

![screenshot from 2018-10-05 13-43-58](https://user-images.githubusercontent.com/1297009/46551254-45bd6800-c8a5-11e8-81e2-662f7e4b750c.png)
![screenshot from 2018-10-05 13-42-17](https://user-images.githubusercontent.com/1297009/46551255-45bd6800-c8a5-11e8-9bf0-136aceacb84e.png)

This PR will be removed once the encoding issue is identified and fixed.
