### PR TITLE
Data download issue with San Mateo, California

### DIFF
--- a/sources/us/ca/san_mateo.json
+++ b/sources/us/ca/san_mateo.json
@@ -15,7 +15,7 @@
     "type": "http",
     "compression": "zip",
     "conform": {
-        "file": "SAN_MATEO_COUNTY_ACTIVE_PARCELS/SAN_MATEO_COUNTY_ACTIVE_PARCELS.shp",
+        "file": "SAN_MATEO_COUNTY_ACTIVE_PARCELS.shp",
         "type": "shapefile-polygon",
         "number": {
             "function": "regexp",

--- a/sources/us/ca/san_mateo.json
+++ b/sources/us/ca/san_mateo.json
@@ -10,12 +10,12 @@
         "county": "San Mateo"
     },
     "attribution": "San Mateo County",
-    "data": "http://maps.smcgov.org/GIS_data_download/SAN_MATEO_COUNTY_PARCELS.zip",
+    "data": "http://maps.smcgov.org/GIS_data_download/SAN_MATEO_COUNTY_ACTIVE_PARCELS.zip",
     "license": "https://isd.smcgov.org/gis-data-download",
     "type": "http",
     "compression": "zip",
     "conform": {
-        "file": "SAN MATEO COUNTY PARCELS/ACTIVE_PARCELS_ADDRESS.shp",
+        "file": "SAN_MATEO_COUNTY_ACTIVE_PARCELS/SAN_MATEO_COUNTY_ACTIVE_PARCELS.shp",
         "type": "shapefile-polygon",
         "number": {
             "function": "regexp",


### PR DESCRIPTION
The original file download link was invalid, as was the path to the file within the zip file. Fixed both.