### PR TITLE
Removed postcode from Chester

### DIFF
--- a/sources/us/pa/chester.json
+++ b/sources/us/pa/chester.json
@@ -22,7 +22,6 @@
         "unit": [
           "UNIT",
           "UNIT_N"
-        ],
-        "postcode": "ZIP1"
+        ]
     }
 }


### PR DESCRIPTION
As the one in the data source is for the owner's address, and thus is incorrect quite often.