### PR TITLE
Fix us/tx/city_of_austin

### DIFF
--- a/sources/us/tx/city_of_austin.json
+++ b/sources/us/tx/city_of_austin.json
@@ -33,7 +33,7 @@
                 {
                     "function": "regexp",
                     "field": "address",
-                    "pattern": "(\\d+)\\.?",
+                    "pattern": "(\\d+)\\.?(.*)",
                     "replace": "$1"
                 },
                 {

--- a/sources/us/tx/city_of_austin.json
+++ b/sources/us/tx/city_of_austin.json
@@ -27,32 +27,13 @@
     "compression": "zip",
     "conform": {
         "number": {
-            "function": "chain",
-            "variable": "number_wip",
-            "functions": [
-                {
-                    "function": "regexp",
-                    "field": "address",
-                    "pattern": "(\\d+)\\.?(.*)",
-                    "replace": "$1"
-                },
-                {
-                    "function": "join",
-                    "fields": [
-                        "number_wip",
-                        "address_fr",
-                        "address_su"
-                    ]
-                }
-            ]
+            "function": "prefixed_number",
+            "field": "full_stree"
         },
-        "street": [
-            "prefix_dir",
-            "prefix_typ",
-            "street_nam",
-            "street_typ",
-            "suffix_dir"
-        ],
+        "street": {
+            "function": "postfixed_street",
+            "field": "full_stree"
+        },
         "format": "shapefile"
     }
 }

--- a/sources/us/tx/city_of_austin.json
+++ b/sources/us/tx/city_of_austin.json
@@ -16,8 +16,8 @@
         "state": "tx",
         "city": "Austin"
     },
-    "website": "https://data.austintexas.gov/Geodata/Address-Points/bpa2-q2tj",
-    "data": "https://data.austintexas.gov/api/geospatial/bpa2-q2tj?method=export&format=Shapefile",
+    "website": "https://data.austintexas.gov/Locations-and-Maps/Addresses/mkjr-t5r2",
+    "data": "https://data.austintexas.gov/api/geospatial/mkjr-t5r2?method=export&format=Shapefile",
     "license": {
         "text": "Public Domain",
         "attribution": false,
@@ -26,10 +26,32 @@
     "protocol": "http",
     "compression": "zip",
     "conform": {
-        "number": "ADDRESS",
+        "number": {
+            "function": "chain",
+            "variable": "number_wip",
+            "functions": [
+                {
+                    "function": "regexp",
+                    "field": "address",
+                    "pattern": "(\\d+)\\.?",
+                    "replace": "$1"
+                },
+                {
+                    "function": "join",
+                    "fields": [
+                        "number_wip",
+                        "address_fr",
+                        "address_su"
+                    ]
+                }
+            ]
+        },
         "street": [
-            "STREET_NAM",
-            "STREET_TYP"
+            "prefix_dir",
+            "prefix_typ",
+            "street_nam",
+            "street_typ",
+            "suffix_dir"
         ],
         "format": "shapefile"
     }


### PR DESCRIPTION
Change source url to updated source.  Also fixed a couple of issues where street directions were not being picked up.  

I'm seeing an issue with extra spaces in the street concatenation though, where a row like "S,,CONGRESS" is becoming "S  CONGRESS" (with two spaces).  How can I fix it (assuming it doesn't get cleaned up later in the process)?  