### PR TITLE
Better source for Becker

### DIFF
--- a/sources/us/mn/becker.json
+++ b/sources/us/mn/becker.json
@@ -9,18 +9,14 @@
         "state": "mn",
         "county": "Becker"
     },
-    "data": "http://gis-server.co.becker.mn.us/arcgis/rest/services/BECKER_INTERNAL_101/MapServer/34",
+    "data": "http://gis-server.co.becker.mn.us/arcgis/rest/services/BECKER_INTERNAL_101/MapServer/23",
     "protocol": "ESRI",
     "conform": {
         "format": "geojson",
-        "number": {
-            "function": "prefixed_number",
-            "field": "SAAdddress"
-        },
-        "street": {
-            "function": "postfixed_street",
-            "field": "SAAddress"
-        },
-        "city": "SACity"
+        "number": "BLD_NUM",
+        "street": "BASENAME",
+        "city": "CITY",
+        "postcode":"ZIP",
+        "region":"STATE"
     }
 }

--- a/sources/us/mn/becker.json
+++ b/sources/us/mn/becker.json
@@ -9,11 +9,14 @@
         "state": "mn",
         "county": "Becker"
     },
-    "data": "http://gis-server.co.becker.mn.us/arcgis/rest/services/BECKER_INTERNAL_101/MapServer/23",
-    "protocol": "ESRI",
+    "website": "https://www.co.becker.mn.us/online_services/GIS_data.aspx",
+    "data": "http://gis-server.co.becker.mn.us/data/gis/shapefiles/drive_pnts.zip",
+    "compression": "zip",
+    "protocol": "http",
     "conform": {
-        "format": "geojson",
+        "format": "shapefile",
         "number": "BLD_NUM",
+        "unit": "UNIT",
         "street": "BASENAME",
         "city": "CITY",
         "postcode":"ZIP",


### PR DESCRIPTION
This driveway point source appears to be better. The BASENAME field only has 11 records with nulls, and ADDRESS has 15, some of which otherwise appear to have real data. So this field mapping looks like an upgrade over using ADDRESS with a postfixed_street function.