### PR TITLE
Reconsider fields for address street field for Blair

### DIFF
--- a/sources/us/pa/blair.json
+++ b/sources/us/pa/blair.json
@@ -15,7 +15,7 @@
     "conform": {
         "format": "csv",
         "number": "SAN",
-        "street": ["PRD","STP","STN","STS","POD"],
+        "street": ["STN"],
         "city": "MCN",
         "lon": "X",
         "lat": "Y",


### PR DESCRIPTION
## Context

Current fields to get the street name is making the data messy since the only field we need is `STN` field.

**Examples**
Duplicate address number
```
i.e. 
// Original fields
SAN: 305
STN: 305 60TH ST APT F 
STS: ST

// Output field
Number: 305
Street: 305 60TH ST APT F ST
```
Duplicate address road type
```

i.e.
// original fields:
SAN: 5375
STN: 2141 A CLOVER CREEK RD 
STS: RD

// output fields
Number: 5375
Street: 2141 A CLOVER CREEK RD RD
```

## Changes
- [x] Delete extra fields considered for address street property.

@ingalls 