### PR TITLE
adding second source for Miami-Dade, FL

### DIFF
--- a/sources/us/fl/miami2.json
+++ b/sources/us/fl/miami2.json
@@ -1,0 +1,39 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "12086",
+            "name": "Miami-Dade County",
+            "state": "Florida"
+        },
+        "country": "us",
+        "state": "fl",
+        "county": "Miami-Dade"
+    },
+    "attribution": "Miami-Dade County",
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/albarrentine/2330c2/MIAMI-DADE_2019-07-01.csv.zip",
+    "website": "https://pointmatch.floridarevenue.com/General/AddressFiles.aspx",
+    "license": {
+        "text": "Public Domain",
+        "attribution": false,
+        "share-alike": false
+    },
+    "protocol": "http",
+    "compression": "zip",
+    "conform": {
+        "format": "csv",
+        "number": "NUMBER",
+        "street": [
+            "PREDIR",
+            "STNAME",
+            "STSUFFIX",
+            "POSTDIR"
+        ],
+        "unit": [
+            "UNITTYPE",
+            "UNITNUM"
+        ],
+        "city": "MAILCITY",
+        "district": "COUNTY",
+        "postcode": "ZIP"
+    }
+}

--- a/sources/us/fl/miami2.json
+++ b/sources/us/fl/miami2.json
@@ -21,6 +21,8 @@
     "compression": "zip",
     "conform": {
         "format": "csv",
+        "lat": "LAT",
+        "lon": "LON",
         "number": "NUMBER",
         "street": [
             "PREDIR",

--- a/sources/us/fl/miami2.json
+++ b/sources/us/fl/miami2.json
@@ -22,7 +22,7 @@
     "conform": {
         "format": "csv",
         "lat": "LAT",
-        "lon": "LON",
+        "lon": "LONG",
         "number": "NUMBER",
         "street": [
             "PREDIR",


### PR DESCRIPTION
New government source for Florida (addresses, not parcels) from the FL Dept of Revenue. Has ZIP code and city for all 67 counties, seems to have better coverage in many counties than what's there currently. Plan is to add county.json for sources not currently in OA and county2.json for sources where a county source already exists.