### PR TITLE
adding FL statewide government address source from the Dept of Revenue

### DIFF
--- a/sources/us/fl/statewide2.json
+++ b/sources/us/fl/statewide2.json
@@ -1,0 +1,33 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "12",
+            "state": "Florida"
+        },
+        "country": "us",
+        "state": "fl"
+    },
+    "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/uploads/albarrentine/464e13/FL_STATEWIDE_2019-07-01.csv.zip",
+    "website": "https://pointmatch.floridarevenue.com/General/AddressFiles.aspx",
+    "protocol": "http",
+    "compression": "zip",
+    "conform": {
+        "format": "csv",
+        "lat": "LAT",
+        "lon": "LONG",
+        "number": "NUMBER",
+        "street": [
+            "PREDIR",
+            "STNAME",
+            "STSUFFIX",
+            "POSTDIR"
+        ],
+        "unit": [
+            "UNITTYPE",
+            "UNITNUM"
+        ],
+        "city": "MAILCITY",
+        "district": "COUNTY",
+        "postcode": "ZIP"
+    }
+}


### PR DESCRIPTION
Statewide government source from https://pointmatch.floridarevenue.com/General/AddressFiles.aspx, updated semi-annually it looks like, though requires a download. Appears to have better coverage in some areas (Gadsden, Miami), possibly less in others, unclear if that's because of duplicates in the existing sources and/or apartment addresses vs. building-level for geocoding. In any case, it's a supplemental source with a postal code and city for 9.1M addresses in all 67 counties.