### PR TITLE
using NLextract as source for countrywide NL

### DIFF
--- a/sources/nl/countrywide.json
+++ b/sources/nl/countrywide.json
@@ -12,6 +12,8 @@
 	"conform": {
 		"format": "csv",
 		"csvsplit": ";",
+		"lon": "lon",
+		"lat": "lat",
 		"number": {
 			"function": "format",
 			"fields": ["huisnummer", "huisletter", "huisnummertoevoeging"],

--- a/sources/nl/countrywide.json
+++ b/sources/nl/countrywide.json
@@ -11,6 +11,7 @@
         "compression": "zip",
 	"conform": {
 		"format": "csv",
+		"csvsplit": ";",
 		"number": {
 			"function": "format",
 			"fields": ["huisnummer", "huisletter", "huisnummertoevoeging"],

--- a/sources/nl/countrywide.json
+++ b/sources/nl/countrywide.json
@@ -19,8 +19,9 @@
 			"fields": ["huisnummer", "huisletter", "huisnummertoevoeging"],
 			"format": "$1$2-$3"
 		},
-		"street": "openbareruimtenaam",
+		"street": "openbareruimte",
 		"postcode": "postcode",
-		"city": "woonplaatsnaam"
+		"city": "woonplaats",
+		"region": "provincie"
 	}
 }

--- a/sources/nl/countrywide.json
+++ b/sources/nl/countrywide.json
@@ -6,10 +6,11 @@
 		},
 		"country": "nl"
 	},
-	"data": "https://basisregistraties.arcgisonline.nl/arcgis/rest/services/BAG/BAG/MapServer/0",
-	"protocol": "ESRI",
+	"data": "https://data.nlextract.nl/bag/csv/bag-adressen-laatst.csv.zip",
+	"protocol": "http",
+        "compression": "zip",
 	"conform": {
-		"format": "geojson",
+		"format": "csv",
 		"number": {
 			"function": "format",
 			"fields": ["huisnummer", "huisletter", "huisnummertoevoeging"],


### PR DESCRIPTION
As described in #4572 the current import is broken. I've rewritten the json to use the NLextract source. It is based on the Norway CSV import, however I do not know how to configure a semicolon as the delimiter in stead of a comma.
Also I haven't tested it, so take the PR with an abundance of skepsis

closes #4572