### PR TITLE
Changed source URL slightly for us/ny/city_of_new_york

### DIFF
--- a/sources/us/ny/city_of_new_york.json
+++ b/sources/us/ny/city_of_new_york.json
@@ -16,7 +16,7 @@
             ]
         }
     },
-    "data": "https://data.cityofnewyork.us/api/geospatial/g6pj-hd8k?method=export&format=Shapefile",
+    "data": "https://data.cityofnewyork.us/api/geospatial/g6pj-hd8k?method=export&format=Original",
     "website": "https://data.cityofnewyork.us/City-Government/NYC-Address-Points/g6pj-hd8k",
     "protocol": "http",
     "compression": "zip",


### PR DESCRIPTION
Using the "original" format instead of "shapefile" as shapefile appears to synchronously convert the data before it can be downloaded. I suspect that this leads to data corruption and/or timeouts.

The "original" format is already a shape file so the extra data conversion is completely unnecessary.

> Note: This change was prompted by the fact that this source started outputting significantly less addresses even though the source data does not have less records 

https://results.openaddresses.io/sources/us/ny/city_of_new_york
![Screen Shot 2019-06-20 at 12 26 54 PM](https://user-images.githubusercontent.com/220535/59865327-c1d5de00-9356-11e9-8f62-291000118cf0.png)
