### PR TITLE
Add source for Floyd County, GA

### DIFF
--- a/sources/us/ga/floyd.json
+++ b/sources/us/ga/floyd.json
@@ -1,0 +1,19 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "13115",
+            "name": "Floyd County",
+            "state": "Georgia"
+        },
+        "country": "us",
+        "state": "ga",
+        "county": "Floyd"
+    },
+    "protocol": "ESRI",
+    "data": "https://romefloyd.agdmaps.com/arcgis/rest/services/AddressPoints/FeatureServer/0",
+    "conform": {
+        "format": "geojson",
+        "number": "st_number",
+        "street": "road_name"
+    }
+}


### PR DESCRIPTION
Skipping the city/state/zipcode attributes from the source since they are referencing the owner mailing address, not necessarily the property address.