### PR TITLE
Initial PR for Belgium

### DIFF
--- a/sources/be/bru/bosa-region-brussels-fr.json
+++ b/sources/be/bru/bosa-region-brussels-fr.json
@@ -1,0 +1,42 @@
+{
+    "data": "https://opendata.bosa.be/download/best/openaddress-bebru.zip",
+    "protocol": "http",
+    "coverage": {
+         "ISO 3166": {
+             "alpha2": "BE-BRU",
+             "state": "Brussels-Capital Region",
+             "country": "Belgium"
+         },
+         "country": "be",
+         "state": "brussels-capital region"
+    },
+    "conform": {
+        "format": "csv",
+        "srs": "EPSG:4326",
+        "encoding": "utf-8",
+        "accuracy": "3",
+        "number": "house_number",
+        "street": "streetname_fr",
+        "city":  "muncipality_name_fr",
+        "postcode": "postcode",
+        "id": {
+            "function": "join",
+            "fields": ["region_code","address_id"],
+            "separator": ":"
+        },
+        "unit": "box_number",
+        "lon": "EPSG:4326_lon",
+        "lat": "EPSG:4326_lat"
+    },
+    "compression": "zip",
+    "language": "fr",
+    "website": "https://opendata.bosa.be",
+    "license": {
+        "url": "https://cirb.brussels/fr/nos-solutions/urbis-solutions/licence-urbis-open-data"
+    },
+    "contact": {
+        "name": "Federal Public Service Policy and Support" ,
+        "email": "opendata@belgium.be",
+        "address": "Simon Bolivarlaan 30, WTC III, 1000 Brussels, Belgium"
+    }
+}

--- a/sources/be/bru/bosa-region-brussels-fr.json
+++ b/sources/be/bru/bosa-region-brussels-fr.json
@@ -14,7 +14,7 @@
         "format": "csv",
         "srs": "EPSG:4326",
         "encoding": "utf-8",
-        "accuracy": "3",
+        "accuracy": 3,
         "number": "house_number",
         "street": "streetname_fr",
         "city":  "muncipality_name_fr",

--- a/sources/be/bru/bosa-region-brussels-fr.json
+++ b/sources/be/bru/bosa-region-brussels-fr.json
@@ -32,7 +32,10 @@
     "language": "fr",
     "website": "https://opendata.bosa.be",
     "license": {
-        "url": "https://cirb.brussels/fr/nos-solutions/urbis-solutions/licence-urbis-open-data"
+        "url": "https://cirb.brussels/fr/nos-solutions/urbis-solutions/licence-urbis-open-data",
+        "text": "CIRB licence ouverte",
+        "attribution": true,
+        "attribution name": "CIRB / SPRB"
     },
     "contact": {
         "name": "Federal Public Service Policy and Support" ,

--- a/sources/be/bru/bosa-region-brussels-nl.json
+++ b/sources/be/bru/bosa-region-brussels-nl.json
@@ -14,7 +14,7 @@
         "format": "csv",
         "srs": "EPSG:4326",
         "encoding": "utf-8",
-        "accuracy": "3",
+        "accuracy": 3,
         "number": "house_number",
         "street": "streetname_nl",
         "city":  "muncipality_name_nl",

--- a/sources/be/bru/bosa-region-brussels-nl.json
+++ b/sources/be/bru/bosa-region-brussels-nl.json
@@ -32,7 +32,10 @@
     "language": "nl",
     "website": "https://opendata.bosa.be",
     "license": {
-        "url": "https://cirb.brussels/fr/nos-solutions/urbis-solutions/licence-urbis-open-data"
+        "url": "https://cibg.brussels/nl/onze-oplossingen/urbis-solutions/urbis-open-data-licentie",
+        "text": "CIBG open licentie",
+        "attribution": true,
+        "attribution name": "CIBG / GOB"
     },
     "contact": {
         "name": "Federal Public Service Policy and Support" ,

--- a/sources/be/bru/bosa-region-brussels-nl.json
+++ b/sources/be/bru/bosa-region-brussels-nl.json
@@ -1,0 +1,42 @@
+{
+    "data": "https://opendata.bosa.be/download/best/openaddress-bebru.zip",
+    "protocol": "http",
+    "coverage": {
+         "ISO 3166": {
+             "alpha2": "BE-BRU",
+             "state": "Brussels-Capital Region",
+             "country": "Belgium"
+         },
+         "country": "be",
+         "state": "brussels-capital region"
+    },
+    "conform": {
+        "format": "csv",
+        "srs": "EPSG:4326",
+        "encoding": "utf-8",
+        "accuracy": "3",
+        "number": "house_number",
+        "street": "streetname_nl",
+        "city":  "muncipality_name_nl",
+        "postcode": "postcode",
+        "id": {
+            "function": "join",
+            "fields": ["region_code","address_id"],
+            "separator": ":"
+        },
+        "unit": "box_number",
+        "lon": "EPSG:4326_lon",
+        "lat": "EPSG:4326_lat"
+    },
+    "compression": "zip",
+    "language": "nl",
+    "website": "https://opendata.bosa.be",
+    "license": {
+        "url": "https://cirb.brussels/fr/nos-solutions/urbis-solutions/licence-urbis-open-data"
+    },
+    "contact": {
+        "name": "Federal Public Service Policy and Support" ,
+        "email": "opendata@belgium.be",
+        "address": "Simon Bolivarlaan 30, WTC III, 1000 Brussels, Belgium"
+    }
+}

--- a/sources/be/vlg/bosa-region-flanders-nl.json
+++ b/sources/be/vlg/bosa-region-flanders-nl.json
@@ -14,7 +14,7 @@
         "format": "csv",
         "srs": "EPSG:4326",
         "encoding": "utf-8",
-        "accuracy": "3",
+        "accuracy": 3,
         "number": "house_number",
         "street": "streetname_nl",
         "city":  "muncipality_name_nl",

--- a/sources/be/vlg/bosa-region-flanders-nl.json
+++ b/sources/be/vlg/bosa-region-flanders-nl.json
@@ -32,7 +32,10 @@
     "language": "nl",
     "website": "https://opendata.bosa.be",
     "license": {
-        "url":"https://overheid.vlaanderen.be/sites/default/files/documenten/ict-egov/licenties/hergebruik/modellicentie_gratis_hergebruik_v1_0.html"
+        "url": "https://overheid.vlaanderen.be/sites/default/files/documenten/ict-egov/licenties/hergebruik/modellicentie_gratis_hergebruik_v1_0.html",
+        "text": "Modellicentie gratis hergebruik",
+        "attribution": true,
+        "attribution name": "Informatie Vlaanderen"
     },
     "contact": {
         "name": "Federal Public Service Policy and Support" ,

--- a/sources/be/vlg/bosa-region-flanders-nl.json
+++ b/sources/be/vlg/bosa-region-flanders-nl.json
@@ -1,0 +1,42 @@
+{
+    "data": "https://opendata.bosa.be/download/best/openaddress-bevlg.zip",
+    "protocol": "http",
+    "coverage": {
+         "ISO 3166": {
+             "alpha2": "BE-VLG",
+             "state": "Flemish Region",
+             "country": "Belgium"
+         },
+         "country": "be",
+         "state": "flemish region"
+    },
+    "conform": {
+        "format": "csv",
+        "srs": "EPSG:4326",
+        "encoding": "utf-8",
+        "accuracy": "3",
+        "number": "house_number",
+        "street": "streetname_nl",
+        "city":  "muncipality_name_nl",
+        "postcode": "postcode",
+        "id": {
+            "function": "join",
+            "fields": ["region_code","address_id"],
+            "separator": ":"
+        },
+        "unit": "box_number",
+        "lon": "EPSG:4326_lon",
+        "lat": "EPSG:4326_lat"
+    },
+    "compression": "zip",
+    "language": "nl",
+    "website": "https://opendata.bosa.be",
+    "license": {
+        "url":"https://overheid.vlaanderen.be/sites/default/files/documenten/ict-egov/licenties/hergebruik/modellicentie_gratis_hergebruik_v1_0.html"
+    },
+    "contact": {
+        "name": "Federal Public Service Policy and Support" ,
+        "email": "opendata@belgium.be",
+        "address": "Simon Bolivarlaan 30, WTC III, 1000 Brussels, Belgium"
+    }
+}

--- a/sources/be/wal/bosa-region-wallonia-fr.json
+++ b/sources/be/wal/bosa-region-wallonia-fr.json
@@ -14,7 +14,7 @@
         "format": "csv",
         "srs": "EPSG:4326",
         "encoding": "utf-8",
-        "accuracy": "3",
+        "accuracy": 3,
         "number": "house_number",
         "street": "streetname_fr",
         "city":  "muncipality_name_fr",

--- a/sources/be/wal/bosa-region-wallonia-fr.json
+++ b/sources/be/wal/bosa-region-wallonia-fr.json
@@ -1,0 +1,42 @@
+{
+    "data": "https://opendata.bosa.be/download/best/openaddress-bewal.zip",
+    "protocol": "http",
+    "coverage": {
+         "ISO 3166": {
+             "alpha2": "BE-WAL",
+             "state": "Walloon Region",
+             "country": "Belgium"
+         },
+         "country": "be",
+         "state": "walloon region"
+    },
+    "conform": {
+        "format": "csv",
+        "srs": "EPSG:4326",
+        "encoding": "utf-8",
+        "accuracy": "3",
+        "number": "house_number",
+        "street": "streetname_fr",
+        "city":  "muncipality_name_fr",
+        "postcode": "postcode",
+        "id": {
+            "function": "join",
+            "fields": ["region_code","address_id"],
+            "separator": ":"
+        },
+        "unit": "box_number",
+        "lon": "EPSG:4326_lon",
+        "lat": "EPSG:4326_lat"
+    },
+    "compression": "zip",
+    "language": "fr",
+    "website": "https://opendata.bosa.be",
+    "license": {
+        "url": "https://creativecommons.org/licenses/by/4.0"
+    },
+    "contact": {
+        "name": "Federal Public Service Policy and Support" ,
+        "email": "opendata@belgium.be",
+        "address": "Simon Bolivarlaan 30, WTC III, 1000 Brussels, Belgium"
+    }
+}

--- a/sources/be/wal/bosa-region-wallonia-fr.json
+++ b/sources/be/wal/bosa-region-wallonia-fr.json
@@ -32,7 +32,10 @@
     "language": "fr",
     "website": "https://opendata.bosa.be",
     "license": {
-        "url": "https://creativecommons.org/licenses/by/4.0"
+        "url": "https://creativecommons.org/licenses/by/4.0",
+        "text": "CC BY 4.0",
+        "attribution": true,
+        "attribution name": "Service public de Wallonie"
     },
     "contact": {
         "name": "Federal Public Service Policy and Support" ,


### PR DESCRIPTION
Initial PR for Belgium from official federal source, with address datasets from the 3 regions (Walloon, Flemish, Brussels-Capital Region). 

We will probably need to add some more (meta)data files for translating names in "facility municipalities" (see also https://en.wikipedia.org/wiki/Municipalities_with_language_facilities), but this would probably be a good start

See also #4560