### PR TITLE
Update data and licence Kreis Viersen, NW, DE

### DIFF
--- a/sources/de/nw/kreis_viersen.json
+++ b/sources/de/nw/kreis_viersen.json
@@ -5,21 +5,20 @@
 		"county": "Viersen",
 		"geometry": { "type": "Point", "coordinates": [6.40, 51.26] }
 	},
-	"data": "https://www.offenesdatenportal.de/dataset/cd06d2ff-e0cd-42aa-bfd2-a83b09324a58/resource/4a1c942c-6d44-4cc6-9408-c70bb2f6c280/download/2017-12-01-hausnummernkml.zip",
+	"data": "http://geoportal-niederrhein.de/files/opendatagis/Kreis_Viersen/Navi_Geb/Adressen_Kreis_Viersen_KML.zip",
 	"website": "https://www.offenesdatenportal.de/dataset/hausnummern-im-kreis-viersen",
 	"license": {
-		"text": "CC BY 4.0",
-		"url": "http://creativecommons.org/licenses/by/4.0/",
+		"text": "Data licence Germany – attribution – version 2.0",
+		"url": "https://www.govdata.de/dl-de/by-2-0",
 		"attribution": true,
-		"share-alike": false,
-		"attribution name": "Kreis Viersen"
+		"share-alike": false
 	},
 	"compression": "zip",
 	"protocol": "http",
 	"conform": {
 		"format": "xml",
-		"file": "2017-12-01 Hausnummern.kml",
-		"layer": "NAVI_GEB_ohne_0000",
+		"file": "Adressen_Kreis_Viersen_KML.kml",
+		"layer": "KRZN_NAVI_GEB",
 		"postcode": "POSTLEITZAHL",
 		"street": "STRASSENNAME",
 		"number": ["HAUS_NR", "HAUS_NR_ZUSATZ"],


### PR DESCRIPTION
Update data URL and licence to fix `SourceProblem.download_source_failed` (http://results.openaddresses.io/sources/de/nw/kreis_viersen)