### PR TITLE
au/countrywide include lot number as number

### DIFF
--- a/scripts/au/gnaf.sh
+++ b/scripts/au/gnaf.sh
@@ -47,7 +47,7 @@ SELECT
         CASE WHEN number_first IS NOT NULL THEN number_first ||
             CASE WHEN number_last IS NOT NULL THEN '-' || number_last || ' ' ELSE ' ' END
         ELSE
-            CASE WHEN lot_number IS NOT NULL THEN lot_number ELSE NULL END
+            CASE WHEN lot_number IS NOT NULL THEN 'LOT ' || lot_number ELSE NULL END
         END
     )
         AS number,

--- a/scripts/au/gnaf.sh
+++ b/scripts/au/gnaf.sh
@@ -47,7 +47,7 @@ SELECT
         CASE WHEN number_first IS NOT NULL THEN number_first ||
             CASE WHEN number_last IS NOT NULL THEN '-' || number_last || ' ' ELSE ' ' END
         ELSE
-            NULL
+            CASE WHEN lot_number IS NOT NULL THEN lot_number ELSE NULL END
         END
     )
         AS number,

--- a/sources/au/countrywide.json
+++ b/sources/au/countrywide.json
@@ -1,6 +1,6 @@
 {
     "protocol": "http",
-    "data": "https://data.openaddresses.io/cache/uploads/andrewharvey-openaddr/7c9f61/au-aug2019.zip",
+    "data": "https://data.openaddresses.io/cache/uploads/andrewharvey-openaddr/9e55fd/au-aug2019.zip",
     "website": "http://data.gov.au/dataset/geocoded-national-address-file-g-naf",
     "compression": "zip",
     "coverage": {

--- a/sources/au/countrywide.json
+++ b/sources/au/countrywide.json
@@ -1,6 +1,6 @@
 {
     "protocol": "http",
-    "data": "https://data.openaddresses.io/cache/uploads/andrewharvey-openaddr/9e55fd/au-aug2019.zip",
+    "data": "https://data.openaddresses.io/cache/uploads/andrewharvey-openaddr/b4268a/au-aug2019.zip",
     "website": "http://data.gov.au/dataset/geocoded-national-address-file-g-naf",
     "compression": "zip",
     "coverage": {


### PR DESCRIPTION
closes #4616 

The justification here is that in these cases where there is a lot number only that number is being used for addressing. Ideally we'd have a different field for lot number, but until then I think this is the best interim solution.