### PR TITLE
Update sources/us/tx/brazoria.json website URL to fix a 404 error and data URL to use a current mirror

### DIFF
--- a/sources/us/tx/brazoria.json
+++ b/sources/us/tx/brazoria.json
@@ -10,7 +10,7 @@
         "county": "Brazoria"
     },
     "website": "http://www.brazoriacad.org/tax-roll--gis-downloads.html",
-    "data": "https://data.openaddresses.io/cache/uploads/migurski/PARCELS_W_OWNER.zip",
+    "data": "https://rootfiles.org/pub/mirror/gis/us/tx/brazoriacounty/PARCELS.zip",
     "protocol": "http",
     "compression": "zip",
     "conform": {

--- a/sources/us/tx/brazoria.json
+++ b/sources/us/tx/brazoria.json
@@ -9,7 +9,7 @@
         "state": "tx",
         "county": "Brazoria"
     },
-    "website": "http://www.brazoriacad.org/gis-downloads.html",
+    "website": "http://www.brazoriacad.org/tax-roll--gis-downloads.html",
     "data": "https://data.openaddresses.io/cache/uploads/migurski/PARCELS_W_OWNER.zip",
     "protocol": "http",
     "compression": "zip",


### PR DESCRIPTION
Update the website URL, for Brazoria County, Texas, US, in sources/us/tx/brazoria.json.  The prior Brazoria County Appraisal District URL is no longer valid, resulting in a 404 Not Found error.
Update the data URL, for Brazoria County, Texas, US, in sources/us/tx/brazoria.json, to use a current mirror.  The prior cached copy on data.openaddresses.io fails CI tests.