### PR TITLE
Updated field references due to a schema change

### DIFF
--- a/sources/us/pa/cumberland.json
+++ b/sources/us/pa/cumberland.json
@@ -11,17 +11,31 @@
     },
     "data": "http://gis.ccpa.net/arcgiswebadaptor/rest/services/SCTF/AddressPoints/MapServer/0",
     "website": "http://www.ccpa.net/index.aspx?NID=2080",
+    "contact": {
+        "name": "Patrick McKinney",
+        "title": "GIS Analyst",
+        "phone": "717-240-7842",
+        "email": "gis@ccpa.net",
+        "address": "1 Courthouse Square, Carlisle, PA  17013"
+    },
     "protocol": "ESRI",
     "conform": {
         "format": "geojson",
-        "number": "SAN",
+        "id": "ID",
+        "number": "Add_Number",
         "street": [
-            "PRD",
-            "STN",
-            "STS",
-            "POD"
+            "St_PreMod",
+            "St_PreDir",
+            "St_PreTyp",
+            "St_Name",
+            "St_PosTyp",
+            "St_PosDir",
+            "St_PosMod"            
         ],
-        "unit": "APTNUM",
-        "city": "CITY"
+        "unit": "Unit",
+        "city": "Post_Comm",
+        "district": "County",
+        "region": "State",
+        "postcode": "Post_Code"        
     }
 }


### PR DESCRIPTION
Cumberland County, PA, changed the schema for their address points layer this week.  This PR updates the fields to the new fields in the dataset.

I've also added contact information and additional fields that now exist in the dataset.