### PR TITLE
Update fi countrywise data

### DIFF
--- a/sources/fi/countrywide-fi.json
+++ b/sources/fi/countrywide-fi.json
@@ -1,7 +1,7 @@
 {
     "protocol": "http",
-    "compression": "zip",
-    "note": "URL of the .zip changes quarterly and needs to be adjusted. Find the link to Suomi_osoitteet*.zip on https://www.avoindata.fi/data/dataset/rakennusten-osoitetiedot-koko-suomi",
+    "compression": "7z",
+    "note": "URL of the .7z changes quarterly and needs to be adjusted. Find the link to Suomi_osoitteet*.zip on https://www.avoindata.fi/data/dataset/rakennusten-osoitetiedot-koko-suomi",
     "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/ae13f168-e835-4412-8661-355ea6c4c468/download/suomi_osoitteet_2019-11-14.7z",
     "coverage": {
         "country": "FI",

--- a/sources/fi/countrywide-fi.json
+++ b/sources/fi/countrywide-fi.json
@@ -1,8 +1,8 @@
 {
     "protocol": "http",
     "compression": "zip",
-    "note": "URL of the .zip changes quarterly and needs to be adjusted. Find the link to Suomi_osoitteet*.zip on https://www.avoindata.fi/data/dataset/rakennusten-osoitetiedot-koko-suomi",
-    "data": "https://drive.google.com/open?id=1EYi2rUiaNYQqq5Qruea71K9VMI81b5ow",
+    "note": "URL of the data changes quarterly and needs to be adjusted, and data converted to .zip form. Find the link to Suomi_osoitteet*.zip on https://www.avoindata.fi/data/dataset/rakennusten-osoitetiedot-koko-suomi",
+    "data": "https://geocoding.blob.core.windows.net/vrk/fi_vrk_addresses.zip",
     "coverage": {
         "country": "FI",
         "ISO 3166": {

--- a/sources/fi/countrywide-fi.json
+++ b/sources/fi/countrywide-fi.json
@@ -1,8 +1,8 @@
 {
     "protocol": "http",
-    "compression": "7z",
-    "note": "URL of the .7z changes quarterly and needs to be adjusted. Find the link to Suomi_osoitteet*.zip on https://www.avoindata.fi/data/dataset/rakennusten-osoitetiedot-koko-suomi",
-    "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/ae13f168-e835-4412-8661-355ea6c4c468/download/suomi_osoitteet_2019-11-14.7z",
+    "compression": "zip",
+    "note": "URL of the .zip changes quarterly and needs to be adjusted. Find the link to Suomi_osoitteet*.zip on https://www.avoindata.fi/data/dataset/rakennusten-osoitetiedot-koko-suomi",
+    "data": "https://drive.google.com/open?id=1EYi2rUiaNYQqq5Qruea71K9VMI81b5ow",
     "coverage": {
         "country": "FI",
         "ISO 3166": {

--- a/sources/fi/countrywide-fi.json
+++ b/sources/fi/countrywide-fi.json
@@ -2,14 +2,13 @@
     "protocol": "http",
     "compression": "zip",
     "note": "URL of the .zip changes quarterly and needs to be adjusted. Find the link to Suomi_osoitteet*.zip on https://www.avoindata.fi/data/dataset/rakennusten-osoitetiedot-koko-suomi",
-    "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/ae13f168-e835-4412-8661-355ea6c4c468/download/suomi_osoitteet_2019-08-15.zip",
+    "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/ae13f168-e835-4412-8661-355ea6c4c468/download/suomi_osoitteet_2019-11-14.7z",
     "coverage": {
         "country": "FI",
         "ISO 3166": {
             "alpha2": "FI",
             "country": "Finland"
         }
-
     },
     "license": {
         "url": "https://creativecommons.org/licences/by/4.0/deed.fi",

--- a/sources/fi/countrywide-sv.json
+++ b/sources/fi/countrywide-sv.json
@@ -1,7 +1,7 @@
 {
     "protocol": "http",
-    "compression": "zip",
-    "note": "URL of the .zip changes quarterly and needs to be adjusted. Find the link to Suomi_osoitteet*.zip on https://www.avoindata.fi/data/dataset/rakennusten-osoitetiedot-koko-suomi",
+    "compression": "7z",
+    "note": "URL of the .7z changes quarterly and needs to be adjusted. Find the link to Suomi_osoitteet*.zip on https://www.avoindata.fi/data/dataset/rakennusten-osoitetiedot-koko-suomi",
     "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/ae13f168-e835-4412-8661-355ea6c4c468/download/suomi_osoitteet_2019-11-14.7z",
     "coverage": {
         "country": "FI",

--- a/sources/fi/countrywide-sv.json
+++ b/sources/fi/countrywide-sv.json
@@ -1,8 +1,8 @@
 {
     "protocol": "http",
     "compression": "zip",
-    "note": "URL of the .zip changes quarterly and needs to be adjusted. Find the link to Suomi_osoitteet*.zip on https://www.avoindata.fi/data/dataset/rakennusten-osoitetiedot-koko-suomi",
-    "data": "https://drive.google.com/open?id=1EYi2rUiaNYQqq5Qruea71K9VMI81b5ow",
+    "note": "URL of the data changes quarterly and needs to be adjusted, and data converted to .zip form. Find the link to Suomi_osoitteet*.zip on https://www.avoindata.fi/data/dataset/rakennusten-osoitetiedot-koko-suomi",
+    "data": "https://geocoding.blob.core.windows.net/vrk/fi_vrk_addresses.zip",
     "coverage": {
         "country": "FI",
         "ISO 3166": {

--- a/sources/fi/countrywide-sv.json
+++ b/sources/fi/countrywide-sv.json
@@ -1,8 +1,8 @@
 {
     "protocol": "http",
-    "compression": "7z",
-    "note": "URL of the .7z changes quarterly and needs to be adjusted. Find the link to Suomi_osoitteet*.zip on https://www.avoindata.fi/data/dataset/rakennusten-osoitetiedot-koko-suomi",
-    "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/ae13f168-e835-4412-8661-355ea6c4c468/download/suomi_osoitteet_2019-11-14.7z",
+    "compression": "zip",
+    "note": "URL of the .zip changes quarterly and needs to be adjusted. Find the link to Suomi_osoitteet*.zip on https://www.avoindata.fi/data/dataset/rakennusten-osoitetiedot-koko-suomi",
+    "data": "https://drive.google.com/open?id=1EYi2rUiaNYQqq5Qruea71K9VMI81b5ow",
     "coverage": {
         "country": "FI",
         "ISO 3166": {

--- a/sources/fi/countrywide-sv.json
+++ b/sources/fi/countrywide-sv.json
@@ -2,14 +2,13 @@
     "protocol": "http",
     "compression": "zip",
     "note": "URL of the .zip changes quarterly and needs to be adjusted. Find the link to Suomi_osoitteet*.zip on https://www.avoindata.fi/data/dataset/rakennusten-osoitetiedot-koko-suomi",
-    "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/ae13f168-e835-4412-8661-355ea6c4c468/download/suomi_osoitteet_2019-08-15.zip",
+    "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/ae13f168-e835-4412-8661-355ea6c4c468/download/suomi_osoitteet_2019-11-14.7z",
     "coverage": {
         "country": "FI",
         "ISO 3166": {
             "alpha2": "FI",
             "country": "Finland"
         }
-
     },
     "license": {
         "url": "https://creativecommons.org/licences/by/4.0/deed.fi",


### PR DESCRIPTION
- Compression changed, so we need to host an intermediate data package in zip form
- As a bonus, the package name is now fixed, so dataloading will not break any more
- We started a scheduled process to keep the data updated as a part of national digitransit service