### PR TITLE
Added missing part of street in us/co/statewide

### DIFF
--- a/sources/us/co/statewide.json
+++ b/sources/us/co/statewide.json
@@ -19,6 +19,7 @@
         ],
         "street": [
             "PreDir",
+            "PreType",
             "StreetName",
             "PostType",
             "PostDir"


### PR DESCRIPTION
`PreType` was missing causing things like "County Road 100" (Cr 100) to be added as just "100"