### PR TITLE
Update San Francisco source

### DIFF
--- a/sources/us/ca/san_francisco.json
+++ b/sources/us/ca/san_francisco.json
@@ -31,8 +31,6 @@
           "street_name",
           "street_type"
       ],
-      "city": "San Francisco",
-      "region": "California",
       "unit": "unit_number",
       "postcode": "zip_code",
       "id": "eas_fullid"

--- a/sources/us/ca/san_francisco.json
+++ b/sources/us/ca/san_francisco.json
@@ -9,28 +9,32 @@
         "state": "ca",
         "county": "san francisco"
     },
-    "attribution": "City and County of San Francisco",
-    "data": "http://apps.sfgov.org/datafiles/view.php?file=sfgis/eas_addresses_with_units.zip",
+    "attribution": "City and County of San Francisco, Enterprise Addressing System",
+    "data": "https://data.sfgov.org/api/geospatial/ramy-di5m?method=export&format=GeoJSON",
     "license": {
-        "text": "Public Domain",
+        "url": "https://www.opendatacommons.org/licenses/pddl/1-0/index.html",
+        "text": "Open Data Commons Public Domain Dedication and License",
         "attribution": false,
         "share-alike": false
     },
-    "website": "http://www.sfgov.org",
+    "website": "https://data.sfgov.org",
     "protocol": "http",
-    "compression": "zip",
     "conform": {
-      "format": "shapefile",
+      "format": "geojson",
+      "accuracy": 2,
       "number": {
         "function": "join",
-        "fields": ["ADDR_NUM", "ADDR_N_SFX"],
+        "fields": ["address_number", "address_number_suffix"],
         "separator": ""
       },
       "street": [
-          "ST_NAME",
-          "ST_TYPE"
+          "street_name",
+          "street_type"
       ],
-      "unit": "UNIT_NUM",
-      "postcode": "zipcode"
+      "city": "San Francisco",
+      "region": "California",
+      "unit": "unit_number",
+      "postcode": "zip_code",
+      "id": "eas_fullid"
     }
 }

--- a/sources/us/ca/san_francisco.json
+++ b/sources/us/ca/san_francisco.json
@@ -10,7 +10,7 @@
         "county": "san francisco"
     },
     "attribution": "City and County of San Francisco, Enterprise Addressing System",
-    "data": "https://data.sfgov.org/api/geospatial/ramy-di5m?method=export&format=GeoJSON",
+    "data": "https://data.sfgov.org/api/geospatial/ramy-di5m?method=export&format=Shapefile",
     "license": {
         "url": "https://www.opendatacommons.org/licenses/pddl/1-0/index.html",
         "text": "Open Data Commons Public Domain Dedication and License",
@@ -19,20 +19,20 @@
     },
     "website": "https://data.sfgov.org",
     "protocol": "http",
-    "compression": "gz",
+    "compression": "zip",
     "conform": {
       "format": "geojson",
       "accuracy": 2,
       "number": {
         "function": "join",
-        "fields": ["address_number", "address_number_suffix"],
+        "fields": ["address_nu", "address__2"],
         "separator": ""
       },
       "street": [
-          "street_name",
-          "street_type"
+          "street_nam",
+          "street_typ"
       ],
-      "unit": "unit_number",
+      "unit": "unit_numbe",
       "postcode": "zip_code",
       "id": "eas_fullid"
     }

--- a/sources/us/ca/san_francisco.json
+++ b/sources/us/ca/san_francisco.json
@@ -21,7 +21,7 @@
     "protocol": "http",
     "compression": "zip",
     "conform": {
-      "format": "geojson",
+      "format": "shapefile",
       "accuracy": 2,
       "number": {
         "function": "join",

--- a/sources/us/ca/san_francisco.json
+++ b/sources/us/ca/san_francisco.json
@@ -19,6 +19,7 @@
     },
     "website": "https://data.sfgov.org",
     "protocol": "http",
+    "compression": "gz",
     "conform": {
       "format": "geojson",
       "accuracy": 2,


### PR DESCRIPTION
This change updates the source for San Francisco addresses. Previously it was updating against a shapefile, but this file is deprecated in favor of a nightly updated dataset at https://data.sfgov.org/Geographic-Locations-and-Boundaries/Addresses-with-Units-Enterprise-Addressing-System/ramy-di5m

The endpoint to the data is a bulk geojson dataset of all the addresses published from San Francisco's Enterprise Address System. Added the Enterprise Address System in the attribution source for clarity in case additional sources of address data are added for San Francisco.

Also updated the license to Open Data Commons Public Domain Dedication and License (which is the license applied to all of San Francisco's open data).

Addresses: #4060 