### PR TITLE
Normalize Country Coverage Tags

### DIFF
--- a/sources/au/act/statewide.json
+++ b/sources/au/act/statewide.json
@@ -4,7 +4,7 @@
             "alpha2": "AU-ACT"
         },
         "country": "au",
-        "state": "Australian Capital Territory"
+        "state": "act"
     },
     "data": "http://actmapi.act.gov.au/datadownload/Shapefile/MGA94_55/ACT_data.zip",
     "website": "http://app.actmapi.act.gov.au/download.html",

--- a/sources/au/nsw/statewide.json
+++ b/sources/au/nsw/statewide.json
@@ -6,7 +6,7 @@
             "country": "Australia"
         },
         "country": "au",
-        "state": "New South Wales"
+        "state": "nsw"
     },
     "data": "https://tianjara.net/data/NSW_Property_20191214.zip",
     "note": "see https://github.com/openaddresses/openaddresses/blob/master/sources/au/nsw/README.md",

--- a/sources/au/qld/brisbane_city_council.json
+++ b/sources/au/qld/brisbane_city_council.json
@@ -5,8 +5,8 @@
     "website": "https://www.data.brisbane.qld.gov.au/data/dataset/property-address-data",
     "language": "en",
     "coverage": {
-        "country": "Australia",
-        "state": "Queensland",
+        "country": "au",
+        "state": "qld",
         "city": "Brisbane City Council"
     },
     "license": {

--- a/sources/au/qld/city_of_gold_coast.json
+++ b/sources/au/qld/city_of_gold_coast.json
@@ -4,8 +4,8 @@
     "website": "http://data-goldcoast.opendata.arcgis.com/datasets/cadastre",
     "language": "en",
     "coverage": {
-        "country": "Australia",
-        "state": "Queensland",
+        "country": "au",
+        "state": "qld",
         "city": "City of Gold Coast"
     },
     "license": {

--- a/sources/au/qld/logan_city.json
+++ b/sources/au/qld/logan_city.json
@@ -1,7 +1,7 @@
 {
     "coverage": {
-        "country": "AU",
-        "state": "QLD",
+        "country": "au",
+        "state": "qld",
         "county": "Logan City Council"
     },
     "language": "en",

--- a/sources/au/qld/statewide.json
+++ b/sources/au/qld/statewide.json
@@ -5,7 +5,7 @@
             "state": "Queensland",
             "country": "Australia"
         },
-        "state": "queensland",
+        "state": "qld",
         "country": "au"
     },
     "protocol": "http",

--- a/sources/au/qld/sunshine_coast_council.json
+++ b/sources/au/qld/sunshine_coast_council.json
@@ -4,8 +4,8 @@
     "website": "https://data.sunshinecoast.qld.gov.au/Planning-and-Cadastre/Land-Parcel-Information/wbdm-vdqs",
     "language": "en",
     "coverage": {
-        "country": "Australia",
-        "state": "Queensland",
+        "country": "qu",
+        "state": "qld",
         "city": "Sunshine Coast Council"
     },
     "license": {

--- a/sources/au/qld/townsville_city_council.json
+++ b/sources/au/qld/townsville_city_council.json
@@ -4,8 +4,8 @@
     "website": "https://data.gov.au/dataset/d1e688f4-9203-4a98-bb2f-3b3aebbbc1ee",
     "language": "en",
     "coverage": {
-        "country": "Australia",
-        "state": "Queensland",
+        "country": "au",
+        "state": "qld",
         "city": "Townsville City Council"
     },
     "license": {

--- a/sources/au/tas/statewide.json
+++ b/sources/au/tas/statewide.json
@@ -38,7 +38,7 @@
             "state": "Tasmania",
             "country": "Australia"
         },
-        "state": "tasmania",
+        "state": "tas",
         "country": "au"
     },
     "compression": "zip"

--- a/sources/au/vic/city_of_greater_geelong.json
+++ b/sources/au/vic/city_of_greater_geelong.json
@@ -5,8 +5,8 @@
     "compression": "zip",
     "language": "en",
     "coverage": {
-        "country": "Australia",
-        "state": "Victoria",
+        "country": "au",
+        "state": "vic",
         "city": "City of Greater Geelong"
     },
     "license": {

--- a/sources/au/vic/city_of_melbourne.json
+++ b/sources/au/vic/city_of_melbourne.json
@@ -5,8 +5,8 @@
     "compression": "zip",
     "language": "en",
     "coverage": {
-        "country": "Australia",
-        "state": "Victoria",
+        "country": "au",
+        "state": "vic",
         "city": "City of Melbourne"
     },
     "license": {

--- a/sources/au/vic/statewide.json
+++ b/sources/au/vic/statewide.json
@@ -10,7 +10,7 @@
             "country": "Australia"
         },
         "country": "au",
-        "state": "victoria"
+        "state": "vic"
     },
     "note": "data URL expires; must use web interface & email workflow to download fresh data. See README.statewide.md",
     "license": {

--- a/sources/fi/ahvenanmaa-fi.json
+++ b/sources/fi/ahvenanmaa-fi.json
@@ -5,7 +5,7 @@
     "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/2e212776-5151-443a-91eb-1fdd02d77642/download/19_osoitteet_2018-05-15.opt",
     "coverage": {
         "state": "Ahvenanmaa",
-        "country": "FI",
+        "country": "fi",
         "ISO 3166": {
             "alpha2": "FI-01",
             "country": "Finland",

--- a/sources/fi/ahvenanmaa-sv.json
+++ b/sources/fi/ahvenanmaa-sv.json
@@ -5,7 +5,7 @@
     "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/2e212776-5151-443a-91eb-1fdd02d77642/download/19_osoitteet_2018-05-15.opt",
     "coverage": {
         "state": "Ahvenanmaa",
-        "country": "FI",
+        "country": "fi",
         "ISO 3166": {
             "alpha2": "FI-01",
             "country": "Finland",

--- a/sources/fi/countrywide-fi.json
+++ b/sources/fi/countrywide-fi.json
@@ -4,7 +4,7 @@
     "note": "URL of the data changes quarterly and needs to be adjusted, and data converted to .zip form. Find the link to Suomi_osoitteet*.zip on https://www.avoindata.fi/data/dataset/rakennusten-osoitetiedot-koko-suomi",
     "data": "https://geocoding.blob.core.windows.net/vrk/fi_vrk_addresses.zip",
     "coverage": {
-        "country": "FI",
+        "country": "fi",
         "ISO 3166": {
             "alpha2": "FI",
             "country": "Finland"

--- a/sources/fi/countrywide-sv.json
+++ b/sources/fi/countrywide-sv.json
@@ -4,7 +4,7 @@
     "note": "URL of the data changes quarterly and needs to be adjusted, and data converted to .zip form. Find the link to Suomi_osoitteet*.zip on https://www.avoindata.fi/data/dataset/rakennusten-osoitetiedot-koko-suomi",
     "data": "https://geocoding.blob.core.windows.net/vrk/fi_vrk_addresses.zip",
     "coverage": {
-        "country": "FI",
+        "country": "fi",
         "ISO 3166": {
             "alpha2": "FI",
             "country": "Finland"

--- a/sources/fi/etelä-karjala-fi.json
+++ b/sources/fi/etelä-karjala-fi.json
@@ -5,7 +5,7 @@
     "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/b5853ae5-3426-404e-83cc-574d0f7af79b/download/08_osoitteet_2018-05-15.opt",
     "coverage": {
         "state": "Etelä-Karjala",
-        "country": "FI",
+        "country": "fi",
         "ISO 3166": {
             "alpha2": "FI-02",
             "country": "Finland",

--- a/sources/fi/etelä-karjala-sv.json
+++ b/sources/fi/etelä-karjala-sv.json
@@ -5,7 +5,7 @@
     "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/b5853ae5-3426-404e-83cc-574d0f7af79b/download/08_osoitteet_2018-05-15.opt",
     "coverage": {
         "state": "Södra Karelen",
-        "country": "FI",
+        "country": "fi",
         "ISO 3166": {
             "alpha2": "FI-02",
             "country": "Finland",

--- a/sources/fi/etelä-pohjanmaa-fi.json
+++ b/sources/fi/etelä-pohjanmaa-fi.json
@@ -5,7 +5,7 @@
     "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/57ec927d-575e-42d6-acd2-f841d6158757/download/13_osoitteet_2018-05-15.opt",
     "coverage": {
         "state": "Etelä-Pohjanmaa",
-        "country": "FI",
+        "country": "fi",
         "ISO 3166": {
             "alpha2": "FI-03",
             "country": "Finland",

--- a/sources/fi/etelä-pohjanmaa-sv.json
+++ b/sources/fi/etelä-pohjanmaa-sv.json
@@ -5,7 +5,7 @@
     "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/57ec927d-575e-42d6-acd2-f841d6158757/download/13_osoitteet_2018-05-15.opt",
     "coverage": {
         "state": "Södra Österbotten",
-        "country": "FI",
+        "country": "fi",
         "ISO 3166": {
             "alpha2": "FI-03",
             "country": "Finland",

--- a/sources/fi/etelä-savo-fi.json
+++ b/sources/fi/etelä-savo-fi.json
@@ -5,7 +5,7 @@
     "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/34b9ad64-ac93-4a1e-890f-b14acb8e27cf/download/09_osoitteet_2018-05-15.opt",
     "coverage": {
         "state": "Etelä-Savo",
-        "country": "FI",
+        "country": "fi",
         "ISO 3166": {
             "alpha2": "FI-04",
             "country": "Finland",

--- a/sources/fi/etelä-savo-sv.json
+++ b/sources/fi/etelä-savo-sv.json
@@ -5,7 +5,7 @@
     "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/34b9ad64-ac93-4a1e-890f-b14acb8e27cf/download/09_osoitteet_2018-05-15.opt",
     "coverage": {
         "state": "Södra Savolax",
-        "country": "FI",
+        "country": "fi",
         "ISO 3166": {
             "alpha2": "FI-04",
             "country": "Finland",

--- a/sources/fi/kainuu-fi.json
+++ b/sources/fi/kainuu-fi.json
@@ -5,7 +5,7 @@
     "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/b101ccbd-4154-4b7b-951e-02920e2e7785/download/17_osoitteet_2018-05-15.opt",
     "coverage": {
         "state": "Kainuu",
-        "country": "FI",
+        "country": "fi",
         "ISO 3166": {
             "alpha2": "FI-05",
             "country": "Finland",

--- a/sources/fi/kainuu-sv.json
+++ b/sources/fi/kainuu-sv.json
@@ -5,7 +5,7 @@
     "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/b101ccbd-4154-4b7b-951e-02920e2e7785/download/17_osoitteet_2018-05-15.opt",
     "coverage": {
         "state": "Kajanaland",
-        "country": "FI",
+        "country": "fi",
         "ISO 3166": {
             "alpha2": "FI-05",
             "country": "Finland",

--- a/sources/fi/kanta-häme-fi.json
+++ b/sources/fi/kanta-häme-fi.json
@@ -5,7 +5,7 @@
     "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/66a7ed8a-1cce-4a69-b7dd-265a52298e63/download/04_osoitteet_2018-05-15.opt",
     "coverage": {
         "state": "Kanta-Häme",
-        "country": "FI",
+        "country": "fi",
         "ISO 3166": {
             "alpha2": "FI-06",
             "country": "Finland",

--- a/sources/fi/kanta-häme-sv.json
+++ b/sources/fi/kanta-häme-sv.json
@@ -5,7 +5,7 @@
     "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/66a7ed8a-1cce-4a69-b7dd-265a52298e63/download/04_osoitteet_2018-05-15.opt",
     "coverage": {
         "state": "Egentliga Tavastland",
-        "country": "FI",
+        "country": "fi",
         "ISO 3166": {
             "alpha2": "FI-06",
             "country": "Finland",

--- a/sources/fi/keski-pohjanmaa-fi.json
+++ b/sources/fi/keski-pohjanmaa-fi.json
@@ -5,7 +5,7 @@
     "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/f0d28faf-cc4f-4bd3-beba-be97fed4e4dd/download/15_osoitteet_2018-05-15.opt",
     "coverage": {
         "state": "Keski-Pohjanmaa",
-        "country": "FI",
+        "country": "fi",
         "ISO 3166": {
             "alpha2": "FI-07",
             "country": "Finland",

--- a/sources/fi/keski-pohjanmaa-sv.json
+++ b/sources/fi/keski-pohjanmaa-sv.json
@@ -5,7 +5,7 @@
     "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/f0d28faf-cc4f-4bd3-beba-be97fed4e4dd/download/15_osoitteet_2018-05-15.opt",
     "coverage": {
         "state": "Mellersta Österbotten",
-        "country": "FI",
+        "country": "fi",
         "ISO 3166": {
             "alpha2": "FI-07",
             "country": "Finland",

--- a/sources/fi/keski-suomi-fi.json
+++ b/sources/fi/keski-suomi-fi.json
@@ -5,7 +5,7 @@
     "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/e5bef516-1c17-4fce-8df7-a8cc759dda4c/download/12_osoitteet_2018-05-15.opt",
     "coverage": {
         "state": "Keski-Suomi",
-        "country": "FI",
+        "country": "fi",
         "ISO 3166": {
             "alpha2": "FI-08",
             "country": "Finland",

--- a/sources/fi/keski-suomi-sv.json
+++ b/sources/fi/keski-suomi-sv.json
@@ -5,7 +5,7 @@
     "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/e5bef516-1c17-4fce-8df7-a8cc759dda4c/download/12_osoitteet_2018-05-15.opt",
     "coverage": {
         "state": "Mellersta Finland",
-        "country": "FI",
+        "country": "fi",
         "ISO 3166": {
             "alpha2": "FI-08",
             "country": "Finland",

--- a/sources/fi/kymeenlaakso-fi.json
+++ b/sources/fi/kymeenlaakso-fi.json
@@ -5,7 +5,7 @@
     "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/77ed5851-1967-4bb6-8c5c-bbcbd006847e/download/07_osoitteet_2018-05-15.opt",
     "coverage": {
         "state": "Kymeenlaakso",
-        "country": "FI",
+        "country": "fi",
         "ISO 3166": {
             "alpha2": "FI-09",
             "country": "Finland",

--- a/sources/fi/kymeenlaakso-sv.json
+++ b/sources/fi/kymeenlaakso-sv.json
@@ -5,7 +5,7 @@
     "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/77ed5851-1967-4bb6-8c5c-bbcbd006847e/download/07_osoitteet_2018-05-15.opt",
     "coverage": {
         "state": "Kymeenlaakso",
-        "country": "FI",
+        "country": "fi",
         "ISO 3166": {
             "alpha2": "FI-09",
             "country": "Finland",

--- a/sources/fi/lappi-fi.json
+++ b/sources/fi/lappi-fi.json
@@ -5,7 +5,7 @@
     "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/7a38e16a-8720-4b44-8f44-cfbf7a6a8e7e/download/18_osoitteet_2018-05-15.opt",
     "coverage": {
         "state": "Lappi",
-        "country": "FI",
+        "country": "fi",
         "ISO 3166": {
             "alpha2": "FI-10",
             "country": "Finland",

--- a/sources/fi/lappi-sv.json
+++ b/sources/fi/lappi-sv.json
@@ -5,7 +5,7 @@
     "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/7a38e16a-8720-4b44-8f44-cfbf7a6a8e7e/download/18_osoitteet_2018-05-15.opt",
     "coverage": {
         "state": "Lappland",
-        "country": "FI",
+        "country": "fi",
         "ISO 3166": {
             "alpha2": "FI-10",
             "country": "Finland",

--- a/sources/fi/pirkanmaa-fi.json
+++ b/sources/fi/pirkanmaa-fi.json
@@ -5,7 +5,7 @@
     "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/8d8a412c-956d-480b-b3c6-2c3c7f3fa649/download/05_osoitteet_2018-05-15.opt",
     "coverage": {
         "state": "Pirkanmaa",
-        "country": "FI",
+        "country": "fi",
         "ISO 3166": {
             "alpha2": "FI-11",
             "country": "Finland",

--- a/sources/fi/pirkanmaa-sv.json
+++ b/sources/fi/pirkanmaa-sv.json
@@ -5,7 +5,7 @@
     "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/8d8a412c-956d-480b-b3c6-2c3c7f3fa649/download/05_osoitteet_2018-05-15.opt",
     "coverage": {
         "state": "Birkaland",
-        "country": "FI",
+        "country": "fi",
         "ISO 3166": {
             "alpha2": "FI-11",
             "country": "Finland",

--- a/sources/fi/pohjanmaa-fi.json
+++ b/sources/fi/pohjanmaa-fi.json
@@ -5,7 +5,7 @@
     "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/018416ba-a175-4478-be8f-8d06e22daa43/download/14_osoitteet_2018-05-15.opt",
     "coverage": {
         "state": "Pohjanmaa",
-        "country": "FI",
+        "country": "fi",
         "ISO 3166": {
             "alpha2": "FI-12",
             "country": "Finland",

--- a/sources/fi/pohjanmaa-sv.json
+++ b/sources/fi/pohjanmaa-sv.json
@@ -5,7 +5,7 @@
     "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/018416ba-a175-4478-be8f-8d06e22daa43/download/14_osoitteet_2018-05-15.opt",
     "coverage": {
         "state": "Österbotten",
-        "country": "FI",
+        "country": "fi",
         "ISO 3166": {
             "alpha2": "FI-12",
             "country": "Finland",

--- a/sources/fi/pohjois-karjala-fi.json
+++ b/sources/fi/pohjois-karjala-fi.json
@@ -5,7 +5,7 @@
     "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/cdfa7f78-1110-4beb-bfc4-2ad543cb2a5d/download/11_osoitteet_2018-05-15.opt",
     "coverage": {
         "state": "Pohjois-Karjala",
-        "country": "FI",
+        "country": "fi",
         "ISO 3166": {
             "alpha2": "FI-13",
             "country": "Finland",

--- a/sources/fi/pohjois-karjala-sv.json
+++ b/sources/fi/pohjois-karjala-sv.json
@@ -5,7 +5,7 @@
     "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/cdfa7f78-1110-4beb-bfc4-2ad543cb2a5d/download/11_osoitteet_2018-05-15.opt",
     "coverage": {
         "state": "Norra Karelen",
-        "country": "FI",
+        "country": "fi",
         "ISO 3166": {
             "alpha2": "FI-13",
             "country": "Finland",

--- a/sources/fi/pohjois-pohjanmaa-fi.json
+++ b/sources/fi/pohjois-pohjanmaa-fi.json
@@ -5,7 +5,7 @@
     "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/9d944bfc-1a56-48da-8ba4-f697e2bc33f3/download/16_osoitteet_2018-05-15.opt",
     "coverage": {
         "state": "Pohjois-Pohjanmaa",
-        "country": "FI",
+        "country": "fi",
         "ISO 3166": {
             "alpha2": "FI-14",
             "country": "Finland",

--- a/sources/fi/pohjois-pohjanmaa-sv.json
+++ b/sources/fi/pohjois-pohjanmaa-sv.json
@@ -5,7 +5,7 @@
     "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/9d944bfc-1a56-48da-8ba4-f697e2bc33f3/download/16_osoitteet_2018-05-15.opt",
     "coverage": {
         "state": "Norra Österbotten",
-        "country": "FI",
+        "country": "fi",
         "ISO 3166": {
             "alpha2": "FI-14",
             "country": "Finland",

--- a/sources/fi/pohjois-savo-fi.json
+++ b/sources/fi/pohjois-savo-fi.json
@@ -5,7 +5,7 @@
     "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/fbca190f-01e6-408f-b5bb-58b38be790ac/download/10_osoitteet_2018-05-15.opt",
     "coverage": {
         "state": "Pohjois-Savo",
-        "country": "FI",
+        "country": "fi",
         "ISO 3166": {
             "alpha2": "FI-15",
             "country": "Finland",

--- a/sources/fi/pohjois-savo-sv.json
+++ b/sources/fi/pohjois-savo-sv.json
@@ -5,7 +5,7 @@
     "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/fbca190f-01e6-408f-b5bb-58b38be790ac/download/10_osoitteet_2018-05-15.opt",
     "coverage": {
         "state": "Norra Savolax",
-        "country": "FI",
+        "country": "fi",
         "ISO 3166": {
             "alpha2": "FI-15",
             "country": "Finland",

--- a/sources/fi/päijät-häme-fi.json
+++ b/sources/fi/päijät-häme-fi.json
@@ -5,7 +5,7 @@
     "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/785ce0a8-af6c-4f12-ba8c-0762296285f5/download/06_osoitteet_2018-05-15.opt",
     "coverage": {
         "state": "Päijät-Häme",
-        "country": "FI",
+        "country": "fi",
         "ISO 3166": {
             "alpha2": "FI-16",
             "country": "Finland",

--- a/sources/fi/päijät-häme-sv.json
+++ b/sources/fi/päijät-häme-sv.json
@@ -5,7 +5,7 @@
     "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/785ce0a8-af6c-4f12-ba8c-0762296285f5/download/06_osoitteet_2018-05-15.opt",
     "coverage": {
         "state": "Päijänne-Tavastland",
-        "country": "FI",
+        "country": "fi",
         "ISO 3166": {
             "alpha2": "FI-16",
             "country": "Finland",

--- a/sources/fi/satakunta-fi.json
+++ b/sources/fi/satakunta-fi.json
@@ -5,7 +5,7 @@
     "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/d6bf2869-f708-4948-bc02-71f3027eeacd/download/03_osoitteet_2018-05-15.opt",
     "coverage": {
         "state": "Satakunta",
-        "country": "FI",
+        "country": "fi",
         "ISO 3166": {
             "alpha2": "FI-17",
             "country": "Finland",

--- a/sources/fi/satakunta-sv.json
+++ b/sources/fi/satakunta-sv.json
@@ -5,7 +5,7 @@
     "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/d6bf2869-f708-4948-bc02-71f3027eeacd/download/03_osoitteet_2018-05-15.opt",
     "coverage": {
         "state": "Satakunda",
-        "country": "FI",
+        "country": "fi",
         "ISO 3166": {
             "alpha2": "FI-17",
             "country": "Finland",

--- a/sources/fi/uusimaa-fi.json
+++ b/sources/fi/uusimaa-fi.json
@@ -5,7 +5,7 @@
     "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/c87f669c-bcca-44c9-ad91-94c7983519a7/download/01_osoitteet_2018-05-15.opt",
     "coverage": {
         "state": "Uusimaa",
-        "country": "FI",
+        "country": "fi",
         "ISO 3166": {
             "alpha2": "FI-18",
             "country": "Finland",

--- a/sources/fi/uusimaa-sv.json
+++ b/sources/fi/uusimaa-sv.json
@@ -5,7 +5,7 @@
     "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/c87f669c-bcca-44c9-ad91-94c7983519a7/download/01_osoitteet_2018-05-15.opt",
     "coverage": {
         "state": "Nyland",
-        "country": "FI",
+        "country": "fi",
         "ISO 3166": {
             "alpha2": "FI-18",
             "country": "Finland",

--- a/sources/fi/varsinais-suomi-fi.json
+++ b/sources/fi/varsinais-suomi-fi.json
@@ -5,7 +5,7 @@
     "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/ae513be7-6ffa-4acc-a351-f1ccee4d6486/download/02_osoitteet_2018-05-15.opt",
     "coverage": {
         "state": "Varsinais-Suomi",
-        "country": "FI",
+        "country": "fi",
         "ISO 3166": {
             "alpha2": "FI-19",
             "country": "Finland",

--- a/sources/fi/varsinais-suomi-sv.json
+++ b/sources/fi/varsinais-suomi-sv.json
@@ -5,7 +5,7 @@
     "data": "https://www.avoindata.fi/data/dataset/cf9208dc-63a9-44a2-9312-bbd2c3952596/resource/ae513be7-6ffa-4acc-a351-f1ccee4d6486/download/02_osoitteet_2018-05-15.opt",
     "coverage": {
         "state": "Egentliga Finland",
-        "country": "FI",
+        "country": "fi",
         "ISO 3166": {
             "alpha2": "FI-19",
             "country": "Finland",

--- a/sources/jm/august_town.json
+++ b/sources/jm/august_town.json
@@ -2,7 +2,7 @@
     "data": "https://s3.amazonaws.com/data.openaddresses.io/cache/jm/august_town.geojson",
     "protocol": "http",
     "coverage": {
-        "country": "Jamaica",
+        "country": "jm",
         "city": "August Town",
         "geometry": {"type": "Point", "coordinates": [-76.73, 18.01]}
     },

--- a/sources/sk/countrywide.json
+++ b/sources/sk/countrywide.json
@@ -4,7 +4,7 @@
             "alpha2": "SK",
             "country": "Slovakia"
         },
-        "country": "Slovakia"
+        "country": "sk"
     },
     "data": "http://epsilon.sk/sk-countrywide.zip",
     "attribution": "Ministerstvo vnútra Slovenskej republiky / Ministry of Interior of the Slovak Republic",

--- a/sources/ua/12/city_of_dnipropetrovsk.json
+++ b/sources/ua/12/city_of_dnipropetrovsk.json
@@ -7,8 +7,8 @@
                 48.462
             ]
         },
-        "country": "UA",
-        "state": "UA-12",
+        "country": "ua",
+        "state": "ua-12",
         "city": "Dnipropetrovsk"
     },
     "data": "https://data.openaddresses.io/cache/uploads/migurski/d3c8f6/dnipro_addr_bld.shp.zip",

--- a/sources/ua/63/city_of_kharkiv.json
+++ b/sources/ua/63/city_of_kharkiv.json
@@ -7,8 +7,8 @@
                 49.994
             ]
         },
-        "country": "UA",
-        "state": "UA-63",
+        "country": "ua",
+        "state": "ua-63",
         "city": "Kharkiv"
     },
     "data": "http://cdr.citynet.kharkov.ua/arcgis/rest/services/gis_ort_stat_general/MapServer/1",

--- a/sources/us/ca/city_of_newport_beach.json
+++ b/sources/us/ca/city_of_newport_beach.json
@@ -1,8 +1,9 @@
 {
     "coverage": {
+        "US Census": {"geoid": "06059", "name": "Orange County", "state": "California"},
         "country": "us",
         "state": "ca",
-        "country": "Orange",
+        "county": "Orange",
         "city": "Newport Beach"
     },
     "data": "http://nbgis.newportbeachca.gov/gispub/GISDataDownload/Address%20Points/shapefile/Address%20Points.zip",

--- a/sources/us/de/city_of_dover.json
+++ b/sources/us/de/city_of_dover.json
@@ -12,8 +12,8 @@
             "name": "City of Dover",
             "state": "Delaware"
         },
-        "country": "US",
-        "state": "DE",
+        "country": "us",
+        "state": "de",
         "city": "Dover"
     },
     "data": "https://gis.dover.de.us/arcgis/rest/services/Address_Labels/MapServer/2",

--- a/sources/us/de/city_of_newark.json
+++ b/sources/us/de/city_of_newark.json
@@ -12,8 +12,8 @@
             "name": "City of Newark",
             "state": "Delaware"
         },
-        "country": "US",
-        "state": "DE",
+        "country": "us",
+        "state": "de",
         "city": "Dover"
     },
     "data": "https://giswa.cityofnewarkde.us/arcgis_public/rest/services/TaxParcels/Newark_Parcels/MapServer/0",

--- a/sources/us/mo/taney.json
+++ b/sources/us/mo/taney.json
@@ -2,8 +2,8 @@
     "coverage":
     {
         "county": "Taney County",
-        "state": "Missouri",
-        "country": "US",
+        "state": "mo",
+        "country": "us",
         "US Census": {
             "geoid": "29213"
         },

--- a/sources/xk/countrywide.json
+++ b/sources/xk/countrywide.json
@@ -4,7 +4,7 @@
             "alpha2": "XK",
             "country": "Kosovo"
         },
-        "country": "Kosovo"
+        "country": "xk"
     },
     "data": "https://www.dropbox.com/s/3vgtlgkkiadkt7d/xk_addr.csv?dl=1",
     "protocol": "http",


### PR DESCRIPTION
There were several tags that didn't follow our convention of lowercased ISO codes, this normalizes these sources to follow convention.

Ref: https://github.com/openaddresses/batch/issues/5