### PR TITLE
Use new ESRI source for Clark County, WA

### DIFF
--- a/sources/us/wa/clark.json
+++ b/sources/us/wa/clark.json
@@ -9,11 +9,10 @@
         "state": "wa",
         "county": "Clark"
     },
-    "data": "https://data.openaddresses.io/cache/uploads/nvkelso/2806bc/clark_county_vancouver_wa_tax_parcels.zip",
-    "protocol": "http",
-    "compression": "zip",
+    "data": "https://services2.arcgis.com/ylxwjFBdCPBzP16d/arcgis/rest/services/SitusAddress/FeatureServer/0",
+    "protocol": "ESRI",
     "conform": {
-        "format": "shapefile-polygon",
+        "format": "geojson",
         "number": "HSNBR",
         "street": [
             "STDIR",

--- a/sources/us/wa/clark.json
+++ b/sources/us/wa/clark.json
@@ -13,13 +13,12 @@
     "protocol": "ESRI",
     "conform": {
         "format": "geojson",
-        "number": "HSNBR",
+        "number": "HsNbr",
         "street": [
-            "STDIR",
-            "STNAME",
-            "STYPE"
+            "StDir",
+            "StName",
+            "Stype"
         ],
-        "postcode": "ZP1",
-        "city": "STCITY"
+        "postcode": "Zp1"
     }
 }


### PR DESCRIPTION
Thanks to some discussion with the team at TriMet, we learned that there is now a web portal for data from Clark County, WA.

So, unlike in the past, we won't need @nvkelso to [order a DVD to his address](https://github.com/openaddresses/openaddresses/issues/1948) to get the most up to date data.

More details can be found at the following places:
https://hub-clarkcountywa.opendata.arcgis.com/datasets/7ee0659e52a14986b1958df0499fd456_0
https://gis.clark.wa.gov/gishome/metadata/#/layer/6279
https://services2.arcgis.com/ylxwjFBdCPBzP16d/arcgis/rest/services/SitusAddress/FeatureServer/0/query?outFields=*&where=1%3D1
https://gis.clark.wa.gov/mapsonline/index.cfm?
https://gis.clark.wa.gov/gishome/