### PR TITLE
Update Map Service URL for Cumberland County, PA, USA

### DIFF
--- a/sources/us/pa/cumberland.json
+++ b/sources/us/pa/cumberland.json
@@ -9,8 +9,8 @@
         "state": "pa",
         "county": "Cumberland"
     },
-    "data": "http://gis.ccpa.net/arcgiswebadaptor/rest/services/SCTF/AddressPoints/MapServer/0",
-    "website": "http://www.ccpa.net/index.aspx?NID=2080",
+    "data": "https://gis.ccpa.net/arcgiswebadaptor/rest/services/Open_Data/Address_Points/MapServer/0",
+    "website": "https://www.ccpa.net/116/Geographic-Information-Systems-GIS",
     "contact": {
         "name": "Patrick McKinney",
         "title": "GIS Analyst",


### PR DESCRIPTION
We installed a new server site for our web map services.  The existing map service no longer exist.

I've provided the new Esri REST URL.