### PR TITLE
Erie County NY: use 'LOCALZIP' field instead of 'ZIP'

### DIFF
--- a/sources/us/ny/erie.json
+++ b/sources/us/ny/erie.json
@@ -16,7 +16,7 @@
         "street": "ADDNAME",
         "number": "ADDNUM",
         "city": "CITYTOWN",
-        "postcode": ["ZIP", "ZIP4"],
+        "postcode": ["LOCALZIP"],
         "accuracy":2
     }
 }

--- a/sources/us/ny/erie.json
+++ b/sources/us/ny/erie.json
@@ -16,7 +16,7 @@
         "street": "ADDNAME",
         "number": "ADDNUM",
         "city": "CITYTOWN",
-        "postcode": ["LOCALZIP"],
-        "accuracy":2
+        "postcode": "LOCALZIP",
+        "accuracy": 2
     }
 }


### PR DESCRIPTION
Heya,

Following on from the discussion in https://github.com/openaddresses/openaddresses/issues/5063 this PR changes the ZIP field from `ZIP` to `LOCALZIP`, the former seems to apply to the address of the owner rather than that of the parcel.

Resolves https://github.com/openaddresses/openaddresses/issues/5063