### PR TITLE
Fix ftp source for us/ca/san_bernardino

### DIFF
--- a/sources/us/ca/san_bernardino.json
+++ b/sources/us/ca/san_bernardino.json
@@ -23,7 +23,7 @@
         "region": "STATE"
     },
     "attribution": "San Bernardino County",
-    "data": "ftp://gims_public:gims4all!@gis1.sbcounty.gov/Temp%20Parcel%20Basemap/countywide_parcels_07_20_2020.zip",
+    "data": "ftp://gims_public:gims4all!@gis1.sbcounty.gov/Temp Parcel Basemap/countywide_parcels_07_20_2020.zip",
     "website": "http://cms.sbcounty.gov/gis/FTPServices.aspx",
     "protocol": "http",
     "compression": "zip"

--- a/sources/us/ca/san_bernardino.json
+++ b/sources/us/ca/san_bernardino.json
@@ -13,7 +13,6 @@
         "id": "APN",
         "format": "shapefile-polygon",
         "number": "NUMBER",
-        "unit": "UNIT_NO",
         "street": [
             "PREDIR",
             "STREETNAME",

--- a/sources/us/ca/san_bernardino.json
+++ b/sources/us/ca/san_bernardino.json
@@ -23,7 +23,7 @@
         "region": "STATE"
     },
     "attribution": "San Bernardino County",
-    "data": "ftp://gisftp:1sbcftp1@gis1.sbcounty.gov/gims/parcel_basemap_data/countywide_parcels_03_04_2020.zip",
+    "data": "ftp://gims_public:gims4all!@gis1.sbcounty.gov/Temp%20Parcel%20Basemap/countywide_parcels_07_20_2020.zip",
     "website": "http://cms.sbcounty.gov/gis/FTPServices.aspx",
     "protocol": "http",
     "compression": "zip"

--- a/sources/us/ca/san_bernardino.json
+++ b/sources/us/ca/san_bernardino.json
@@ -13,6 +13,7 @@
         "id": "APN",
         "format": "shapefile-polygon",
         "number": "NUMBER",
+        "unit": "UNIT_NO",
         "street": [
             "PREDIR",
             "STREETNAME",


### PR DESCRIPTION
Builds of us/ca/san_bernardino have been failing with FTP errors since 2020/06/22 (see #5115). It turns out that San Bernadino County is having some issues with their FTP server and moved the parcel data to a new location. I reached out to them they provided new credentials and the updated path to the parcel data.