### PR TITLE
Switch city field and remove zip/region which appear to be owner mail…

### DIFF
--- a/sources/us/nh/city_of_auburn.json
+++ b/sources/us/nh/city_of_auburn.json
@@ -25,10 +25,12 @@
         "format": "geojson",
         "accuracy": 2,
         "id": "PID",
-        "number": "LOCNUMB",
+        "number": {
+            "function": "regexp",
+            "field": "LOCNUMB",
+            "pattern": "^0*(\\d+)"
+        },
         "street": "LOCNAME",
-        "city": "CITY",
-        "region": "STATE",
-        "postcode": "ZIP"
+        "city": "TOWNNAME"
     }
 }


### PR DESCRIPTION
The CITY/STATE/ZIP fields in this geojson file all appear to match the owner mailing address (see screenshot below).

I removed the STATE/ZIP fields since there were no replacements in the source data and replaced CITY with TOWNNAME, which is the town where the parcel is located.

I also added some regex to remove leading zeroes on the house number.

![image](https://user-images.githubusercontent.com/2924736/89560505-b5237c00-d7dc-11ea-8180-d3f3a6eb6fb0.png)

#5143 
