### PR TITLE
Fix bad postals in us/nh/city_of_hampstead

### DIFF
--- a/sources/us/nh/city_of_hampstead.json
+++ b/sources/us/nh/city_of_hampstead.json
@@ -28,8 +28,6 @@
         "id": "ParcelNumber",
         "number": "LOCNUMB",
         "street": "PropertyStreet",
-        "city": "CITY",
-        "region": "STATE",
-        "postcode": "ZIP"
+        "city": "TOWNNAME"
     }
 }


### PR DESCRIPTION
The CITY/STATE/ZIP fields in this geojson file all appear to match the owner mailing address (see screenshot below).

I removed the STATE/ZIP fields since there were no replacements in the source data and replaced CITY with TOWNNAME, which is the town where the parcel is located.

![image](https://user-images.githubusercontent.com/2924736/89561611-60810080-d7de-11ea-9310-d88e94d6ca08.png)

References #5143
