### PR TITLE
Update us/co/rio_blanco

### DIFF
--- a/sources/us/co/rio_blanco.json
+++ b/sources/us/co/rio_blanco.json
@@ -21,7 +21,6 @@
             "ROADPOSTDIR"
         ],
         "unit": "APARTMENT",
-        "city": "MUNICIPALITY",
-        "postcode": "ZIP"
+        "city": "MUNICIPALITY"
     }
 }


### PR DESCRIPTION
Removed ZIP since it references the parcel owner's mailing zip code and not the zip code of the property.
The other fields MUNICIPALITY, etc all refer to the property location.

References #5143 