### PR TITLE
Remove bad postal codes /us/al/st_clair

### DIFF
--- a/sources/us/al/st_clair.json
+++ b/sources/us/al/st_clair.json
@@ -14,6 +14,6 @@
     "conform": {
         "format": "geojson",
         "street": "STREET_NAME",
-        "number": "STREET_NUM",
+        "number": "STREET_NUM"
     }
 }

--- a/sources/us/al/st_clair.json
+++ b/sources/us/al/st_clair.json
@@ -15,6 +15,5 @@
         "format": "geojson",
         "street": "STREET_NAME",
         "number": "STREET_NUM",
-        "postcode": "ZIPCODE_1"
     }
 }


### PR DESCRIPTION
Removed the postcode mapping because the ZIPCODE_1 field is the owners mailing address zipcode, not the zipcode of the parcel address. 

#5143
