### PR TITLE
Update source for Dauphin County, Pennsylvania.

### DIFF
--- a/sources/us/pa/dauphin.json
+++ b/sources/us/pa/dauphin.json
@@ -17,20 +17,17 @@
         "address": "2 South Second Street, Harrisburg, PA  17101-1295"
     },
     "website": "https://data-dauphinco.opendata.arcgis.com/",
-    "data": "https://gis.dauphincounty.org/arcgis/rest/services/Municipal/Muni_Basemap/MapServer/0",
+    "data": "https://gis.dauphincounty.org/arcgis/rest/services/Parcels/MapServer/1",
     "protocol": "ESRI",
     "conform": {
         "format": "geojson",
-        "number": "ST_NUM",
+        "number": "house_number",
         "street": [
-            "DIRPRE",
-            "FEANME",
-            "FEATYP",
-            "DIRSUF"
+            "prefix_directional",
+            "street_name",
+            "street_suffix"
         ],
-        "city": "MUN",
-        "unit": "LV_APT",
-        "postcode": "ZIP",
-        "addrtype": "FCODE"
+        "city": "MUNICIPALITY",
+        "id": "PID"
     }
 }


### PR DESCRIPTION
Switch from non-existent Address Points service to Tax Parcels service.

fixes #5161