### PR TITLE
MapServerify Sources

### DIFF
--- a/sources/ca/ab/city_of_cochrane.json
+++ b/sources/ca/ab/city_of_cochrane.json
@@ -1,4 +1,5 @@
 {
+    "schema": 2,
     "coverage": {
         "country": "ca",
         "state": "ab",
@@ -11,7 +12,6 @@
             ]
         }
     },
-    "schema": 2,
     "layers": {
         "addresses": [
             {

--- a/sources/ca/ab/city_of_cochrane.json
+++ b/sources/ca/ab/city_of_cochrane.json
@@ -16,7 +16,7 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://opendata.arcgis.com/datasets/a44b78d73ea748ea85425469700bcb31_0.zip",
+                "data": "https://services5.arcgis.com/M1SNYuFIW9v2gSO7/arcgis/rest/services/Cochrane_Addresses/FeatureServer/0",
                 "website": "https://data-cochranegis.opendata.arcgis.com/datasets/cochrane-addresses",
                 "license": {
                     "url": "https://www.cochrane.ca/947/Open-Data-Licence",
@@ -26,14 +26,13 @@
                     "share-alike": false
                 },
                 "attribution": "Contains information licensed under the Open Data Licence – Town of Cochrane.",
-                "protocol": "http",
-                "compression": "zip",
+                "protocol": "ESRI",
                 "conform": {
-                    "format": "shapefile",
+                    "format": "geojson",
                     "id": "AID",
-                    "number": "Building_No",
+                    "number": "Building_N",
                     "unit": "Unit_No",
-                    "street": "Street_Name"
+                    "street": "Street_Nam"
                 }
             }
         ]

--- a/sources/ca/ab/city_of_lethbridge.json
+++ b/sources/ca/ab/city_of_lethbridge.json
@@ -16,15 +16,15 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://opendata.arcgis.com/datasets/16e189882ac94a5091618ee0e0f74ce7_0.zip",
+                "data": "https://gis.lethbridge.ca/lethwebgisarcgis/rest/services/OpenData/odl_parcels/MapServer/0",
+                "website": "https://hub.arcgis.com/datasets/16e189882ac94a5091618ee0e0f74ce7_0",
                 "license": {
                     "url": "https://www.lethbridge.ca/Pages/OpenDataLicense.aspx",
                     "attribution": false
                 },
-                "protocol": "http",
-                "compression": "zip",
+                "protocol": "ESRI",
                 "conform": {
-                    "format": "shapefile",
+                    "format": "geojson",
                     "accuracy": 2,
                     "number": {
                         "function": "prefixed_number",

--- a/sources/ca/ab/city_of_lethbridge.json
+++ b/sources/ca/ab/city_of_lethbridge.json
@@ -1,4 +1,5 @@
 {
+    "schema": 2,
     "coverage": {
         "country": "ca",
         "state": "ab",
@@ -11,7 +12,6 @@
             ]
         }
     },
-    "schema": 2,
     "layers": {
         "addresses": [
             {

--- a/sources/ca/ab/grande_prairie.json
+++ b/sources/ca/ab/grande_prairie.json
@@ -16,7 +16,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://opendataservices.countygp.ab.ca/arcgis/rest/services/site_addresses/FeatureServer/0",
+                "data": "https://opendata.arcgis.com/datasets/3e2fdcaebb9340c7922942a631e1dd63_0.zip",
                 "website": "http://opendata.countygp.ab.ca/datasets/site-addresses-od?geometry=-122.481%2C54.697%2C-115.664%2C55.793",
                 "license": {
                     "url": "http://www.countygp.ab.ca/EN/main/community/maps-gis/open-data/open-data-licence.html",
@@ -25,6 +25,7 @@
                     "share-alike": false
                 },
                 "protocol": "http",
+                "compression": "zip",
                 "conform": {
                     "format": "shapefile",
                     "number": [

--- a/sources/ca/ab/grande_prairie.json
+++ b/sources/ca/ab/grande_prairie.json
@@ -16,7 +16,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://opendata.arcgis.com/datasets/3e2fdcaebb9340c7922942a631e1dd63_0.zip",
+                "data": "https://opendataservices.countygp.ab.ca/arcgis/rest/services/site_addresses/FeatureServer/0",
                 "website": "http://opendata.countygp.ab.ca/datasets/site-addresses-od?geometry=-122.481%2C54.697%2C-115.664%2C55.793",
                 "license": {
                     "url": "http://www.countygp.ab.ca/EN/main/community/maps-gis/open-data/open-data-licence.html",

--- a/sources/ca/bc/city_of_courtenay.json
+++ b/sources/ca/bc/city_of_courtenay.json
@@ -16,7 +16,7 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://opendata.arcgis.com/datasets/3009dc39fb33478986736627a1a525e1_0.zip",
+                "data": "https://services3.arcgis.com/PwS5hVLYsEN2U36s/arcgis/rest/services/AddressPoints/FeatureServer/0",
                 "website": "http://data-courtenay.opendata.arcgis.com/datasets/addresspoints",
                 "license": {
                     "url": "https://data-courtenay.opendata.arcgis.com/pages/city-of-courtenay-open-data-licence",
@@ -25,10 +25,9 @@
                     "attribution": true,
                     "share-alike": false
                 },
-                "protocol": "http",
-                "compression": "zip",
+                "protocol": "ESRI",
                 "conform": {
-                    "format": "shapefile",
+                    "format": "geojson",
                     "number": "TEXTSTRING",
                     "street": "StreetName"
                 }

--- a/sources/ca/bc/port_moody.json
+++ b/sources/ca/bc/port_moody.json
@@ -16,7 +16,7 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://opendata.arcgis.com/datasets/7bc8ca82182141d2b3f0452fe593d528_0.zip",
+                "data": "https://services9.arcgis.com/XMHGoEc3tdJ8TphG/arcgis/rest/services/Parcel_Information/FeatureServer/0",
                 "website": "https://data.portmoody.ca/datasets/7bc8ca82182141d2b3f0452fe593d528_0/data",
                 "license": {
                     "url": "https://www.portmoody.ca/en/city-hall/open-data-terms-of-use.aspx",
@@ -24,10 +24,9 @@
                     "attribution": true,
                     "share-alike": false
                 },
-                "protocol": "http",
-                "compression": "zip",
+                "protocol": "ESRI",
                 "conform": {
-                    "format": "shapefile",
+                    "format": "geojson",
                     "number": "House",
                     "street": "Street",
                     "unit": "Unit"

--- a/sources/ca/nb/city_of_fredericton.json
+++ b/sources/ca/nb/city_of_fredericton.json
@@ -16,17 +16,13 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://opendata.arcgis.com/datasets/c81dabf64d18479bb8e5253f2dfcf308_0.zip",
+                "data": "https://services2.arcgis.com/iLWAxhpxafhOza2U/arcgis/rest/services/Geocoded_Civics/FeatureServer/0",
                 "website": "https://data-fredericton.opendata.arcgis.com/datasets/geocoded-civics",
                 "note": "prefixed_number is used for number since the Nbr and Frac_Nbr fields cannot be combined correctly with a single format function (123A vs 123 1/2)",
-                "protocol": "http",
-                "compression": "zip",
+                "protocol": "ESRI",
                 "conform": {
-                    "format": "shapefile",
-                    "number": {
-                        "function": "prefixed_number",
-                        "field": "Address"
-                    },
+                    "format": "geojson",
+                    "number": "Nbr",
                     "street": [
                         "Street_Nam",
                         "St_Type"

--- a/sources/ca/nl/happy-valley-goose-bay.json
+++ b/sources/ca/nl/happy-valley-goose-bay.json
@@ -16,12 +16,11 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://opendata.arcgis.com/datasets/a843f572632d45cc96e14e17265b9822_0.zip",
+                "data": "https://services9.arcgis.com/lK1pL02NmD23fAgi/arcgis/rest/services/Address_Pts/FeatureServer/0",
                 "website": "https://portal-townhvgb.opendata.arcgis.com/datasets/a843f572632d45cc96e14e17265b9822_0",
-                "protocol": "http",
-                "compression": "zip",
+                "protocol": "ESRI",
                 "conform": {
-                    "format": "shapefile",
+                    "format": "geojson",
                     "number": "CIVIC_NUM",
                     "street": "STREET"
                 }

--- a/sources/ca/on/brantford.json
+++ b/sources/ca/on/brantford.json
@@ -16,12 +16,11 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://opendata.arcgis.com/datasets/8fa270cb0c174bd99b52a11260f60f15_0.zip?outSR=%7B%22latestWkid%22%3A2958%2C%22wkid%22%3A2150%7D",
+                "data": "https://services.arcgis.com/aji2lCmjXt0KpGzI/arcgis/rest/services/OP_Site_Addresses2/FeatureServer/0",
                 "website": "https://data-brantford.opendata.arcgis.com/datasets/8fa270cb0c174bd99b52a11260f60f15_0?geometry=-80.790%2C43.063%2C-79.747%2C43.238",
-                "protocol": "http",
-                "compression": "zip",
+                "protocol": "ESRI",
                 "conform": {
-                    "format": "shapefile",
+                    "format": "geojson",
                     "number": "STREETNUM",
                     "street": [
                         "STREETNAME",


### PR DESCRIPTION
@KHobbs3 @JosephKuchar I've switched this selection of sources from the ESRI provided zip file to the MapServer API. The zip files often cause problems in the long run around updates and not randomly breaking. These are all from the exact same open data sites from which the zip was pulled - so the license will be the same.