### PR TITLE
Update city_of_burlington.json

### DIFF
--- a/sources/ca/on/city_of_burlington.json
+++ b/sources/ca/on/city_of_burlington.json
@@ -26,7 +26,7 @@
                 },
                 "protocol": "ESRI",
                 "conform": {
-                    "format": "shapefile",
+                    "format": "geojson",
                     "number": "HOUSENUM",
                     "street": [
                         "STREET",

--- a/sources/ca/on/city_of_burlington.json
+++ b/sources/ca/on/city_of_burlington.json
@@ -16,7 +16,7 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://opendata.arcgis.com/datasets/d923cecae518430da70f9a29a0ea9b4d_0.zip?outSR=%7B%22latestWkid%22%3A26917%2C%22wkid%22%3A26917%7D",
+                "data": "https://mapping.burlington.ca/arcgisweb/rest/services/COB/AddressPoints/MapServer/0",
                 "website": "https://navburl-burlington.opendata.arcgis.com/datasets/address-points",
                 "license": {
                     "url": "https://www.burlington.ca/en/services-for-you/resources/Ongoing_Projects/Open_Data/OpenDataBurlingtonTermsOfUseSeptember192011.pdf",
@@ -24,8 +24,7 @@
                     "attibrution name": "City of Burlington",
                     "attribution": true
                 },
-                "protocol": "http",
-                "compression": "zip",
+                "protocol": "ESRI",
                 "conform": {
                     "format": "shapefile",
                     "number": "HOUSENUM",

--- a/sources/ca/on/city_of_burlington.json
+++ b/sources/ca/on/city_of_burlington.json
@@ -16,12 +16,18 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://mapping.burlington.ca/arcgisweb/rest/services/COB/AddressPoints/MapServer/0",
-                "website": "http://cms.burlington.ca/Page12956.aspx",
-                "license": "http://cms.burlington.ca/AssetFactory.aspx?did=18762",
-                "protocol": "ESRI",
+                "data": "https://opendata.arcgis.com/datasets/d923cecae518430da70f9a29a0ea9b4d_0.zip?outSR=%7B%22latestWkid%22%3A26917%2C%22wkid%22%3A26917%7D",
+                "website": "https://navburl-burlington.opendata.arcgis.com/datasets/address-points",
+                "license": {
+                    "url": "https://www.burlington.ca/en/services-for-you/resources/Ongoing_Projects/Open_Data/OpenDataBurlingtonTermsOfUseSeptember192011.pdf",
+                    "text": "Datasets are publicly available from the City under these Terms of Use",
+                    "attibrution name": "City of Burlington",
+                    "attribution": true
+                },
+                "protocol": "http",
+                "compression": "zip",
                 "conform": {
-                    "format": "geojson",
+                    "format": "shapefile",
                     "number": "HOUSENUM",
                     "street": [
                         "STREET",


### PR DESCRIPTION
Updated data links and license information. ESRI endpoint is not found at this `website` and previous web link is broken.