### PR TITLE
Switzerland: ch/contrywide fix missing postcodes and city names

### DIFF
--- a/sources/ch/countrywide.json
+++ b/sources/ch/countrywide.json
@@ -37,8 +37,8 @@
                     "street": "STRNAME",
                     "lon": "GKODE",
                     "lat": "GKODN",
-                    "city": "PLZNAME",
-                    "postcode": "PLZ4",
+                    "city": "DPLZNAME",
+                    "postcode": "DPLZ4",
                     "region": "GDEKT"
                 }
             }


### PR DESCRIPTION
The latest [ch/countrywide](http://results.openaddresses.io/sources/ch/countrywide) data was having blank `POSTCODE` and `CITY` columns.

There was a mismatch with the column names of the [source data](https://data.geo.admin.ch/ch.bfs.gebaeude_wohnungs_register/CSV/CH/CH.zip), so this PR fixes it.