### PR TITLE
add warren county, pa, usa

### DIFF
--- a/sources/us/pa/warren.json
+++ b/sources/us/pa/warren.json
@@ -1,0 +1,46 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "42123",
+            "name": "Warren County",
+            "state": "Pennsylvania"
+        },
+        "country": "us",
+        "state": "pa",
+        "county": "Warren"
+    },
+    "schema": 2,
+    "layers": {
+        "addresses": [
+            {
+                "name": "county",
+                "data": "http://arcgis.vgsi.com/arcgis/rest/services/Waren_PA/WarenCountyPAWebMap/MapServer/1",
+                "website": "https://warrencopa.com/",
+                "contact": {
+                    "phone": "814-728-3400",
+                    "email": "info@warren-county.net",
+                    "address": "Warren County Courthouse, 204 4th Avenue, Warren, PA 16365"
+                },
+                "protocol": "ESRI",
+                "conform": {
+                    "format": "geojson",
+                    "id": "PIN",
+                    "number": "Add_Number",
+                    "street": [
+                        "St_PreMod",
+                        "St_PreDir",
+                        "St_PreTyp",
+                        "St_Name",
+                        "St_PosTyp",
+                        "St_PosDir",
+                        "St_PosMod"
+                    ],
+                    "unit": "Unit",
+                    "city": "Inc_Muni",
+                    "district": "County",
+                    "region": "State"
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Esri REST service does not support https

fields for postal community and zip code, but no data populated