### PR TITLE
Improve Florida Loveland dataset parsing for invalid addresses

### DIFF
--- a/sources/us/fl/_loveland.json
+++ b/sources/us/fl/_loveland.json
@@ -22,7 +22,7 @@
                     "street": {
                         "function": "regexp",
                         "field": "phy_addr1",
-                        "pattern": "^(?:[0-9]+ )(.*)",
+                        "pattern": "^(?:[0-9]+)\\w+(.*)",
                         "replace": "$1"
                     },
                     "city": "city",


### PR DESCRIPTION
As mentioned in https://github.com/openaddresses/openaddresses/issues/5694 there is some invalid data in the Loveland Florida dataset.

From my examination, about 35,000 of the 9 million addresses are coming through with a housenumber and streetname that are identical.

Looking at the source data, this is coming from records where the address field contains only a number, something like `"325"`.

The regular expression we are currently using to parse the data will cause both the housenumber _and_ street to use that single number in this case.

This PR attempts to improve the regex so that the street column is empty instead.