### PR TITLE
Add Peel Region building footprints

### DIFF
--- a/sources/ca/on/city_of_brampton.json
+++ b/sources/ca/on/city_of_brampton.json
@@ -36,6 +36,22 @@
                     "city": "CITY"
                 }
             }
+        ],
+        "buildings": [
+            {
+                "name": "city",
+                "data": "https://services3.arcgis.com/rl7ACuZkiFsmDA2g/arcgis/rest/services/Building_Footprints/FeatureServer/0/",
+                "protocol": "ESRI",
+                "website": "https://geohub.brampton.ca/datasets/building-footprints",
+                "license": {
+                    "url": "https://creativecommons.org/licenses/by/4.0/",
+                    "text": "CC-BY 4.0",
+                    "attribution name": "City of Brampton"
+                },
+                "conform": {
+                    "format": "geojson"
+                }
+            }
         ]
     }
 }

--- a/sources/ca/on/peel-region.json
+++ b/sources/ca/on/peel-region.json
@@ -42,6 +42,22 @@
                     "accuracy": 1
                 }
             }
+        ],
+        "buildings": [
+            {
+                "name": "region",
+                "data": "https://services6.arcgis.com/ONZht79c8QWuX759/arcgis/rest/services/Building_Footprints_Caledon/FeatureServer/0/",
+                "protocol": "ESRI",
+                "website": "https://data.peelregion.ca/",
+                "license": {
+                    "url": "https://data.peelregion.ca/pages/license",
+                    "attribution": false,
+                    "share-alike": false
+                },
+                "conform": {
+                    "format": "geojson"
+                }
+            }
         ]
     }
 }


### PR DESCRIPTION
Two new additions:
1. Added building footprints for the City of Brampton into city_of_brampton.json
2. Added building footprints for the Town of Caledon - these were added into the peel-region.json file because they are created, maintained, and released by the Region, not the Town.  Please tell me if I should create a new source file for the Town in this case.