### PR TITLE
Adding website and license information to CO statewide

### DIFF
--- a/sources/us/co/statewide.json
+++ b/sources/us/co/statewide.json
@@ -13,6 +13,12 @@
             {
                 "name": "state",
                 "data": "https://data.colorado.gov/api/views/ge5d-pvi7/rows.csv?accessType=DOWNLOAD",
+                "website": "https://data.colorado.gov/State/Statewide-Aggregate-Addresses-in-Colorado-2020-Pub/n7je-akky",
+                "license": {
+                    "text": "Public Domain",
+                    "attribution name": "Governor's Office of Information Technology",
+                    "share-alike": false
+                },
                 "protocol": "http",
                 "conform": {
                     "format": "csv",


### PR DESCRIPTION
As shown in the About tab of [this link](https://data.colorado.gov/State/Statewide-Aggregate-Addresses-in-Colorado-2020-Pub/n7je-akky), the license for this data is `Public Domain`.

I have verified that if you click Export, and choose the CSV file type, the URL is identical to the existing `data` field in the source file. This verifies that the data source is identical to what we are pulling from.

You can also find screenshots of this attached below.

<img width="333" alt="Screen Shot 2021-07-01 at 7 25 03 PM" src="https://user-images.githubusercontent.com/860375/124207442-c6374480-daa2-11eb-9a56-fcfa892705c0.png">

<img width="1851" alt="Screen Shot 2021-07-01 at 7 25 14 PM" src="https://user-images.githubusercontent.com/860375/124207438-c5061780-daa2-11eb-8bd1-51314f739ad5.png">
