### PR TITLE
Adding building unit attributes to us/co/denver

### DIFF
--- a/sources/us/co/denver.json
+++ b/sources/us/co/denver.json
@@ -27,6 +27,8 @@
                         "POSTDIRECT"
                     ],
                     "unit": [
+                        "BUILDING_T",
+                        "BUILDING_I",
                         "COMPOSITE_",
                         "COMPOSIT_U"
                     ]

--- a/sources/us/co/denver.json
+++ b/sources/us/co/denver.json
@@ -29,8 +29,8 @@
                     "unit": [
                         "BUILDING_T",
                         "BUILDING_I",
-                        "COMPOSITE_",
-                        "COMPOSIT_U"
+                        "UNIT_TYPE",
+                        "UNIT_IDENT"
                     ]
                 },
                 "website": "https://www.denvergov.org/opendata/dataset/city-and-county-of-denver-addresses",


### PR DESCRIPTION
Adding building unit attributes to us/co/denver.

Someone with more experience here should probably verify this worked correctly.

Closes #5838