### PR TITLE
Pulaski, AR

### DIFF
--- a/sources/us/ar/pulaski.json
+++ b/sources/us/ar/pulaski.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://www.pagis.org/arcgis/rest/services/MAPS/BaseMap/MapServer/9",
+                "data": "https://www.pagis.org/arcgis/rest/services/MAPS/BaseMap/MapServer/20",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
@@ -29,6 +29,27 @@
                     "unit": "UNIT",
                     "city": "CITYNAME",
                     "postcode": "ZIP"
+                }
+            }
+        ],
+        "parcels": [
+            {
+                "name": "county",
+                "data": "https://www.pagis.org/arcgis/rest/services/MAPS/BaseMap/MapServer/68",
+                "protocol": "ESRI",
+                "conform": {
+                    "format": "geojson",
+                    "pid": "PARCELID"
+                }
+            }
+        ],
+        "buildings": [
+            {
+                "name": "county",
+                "data": "https://www.pagis.org/arcgis/rest/services/MAPS/BaseMap/MapServer/21",
+                "protocol": "ESRI",
+                "conform": {
+                    "format": "geojson"
                 }
             }
         ]


### PR DESCRIPTION
The upstream source switched around their ESRI layers. We were pulling from a valid layer... for manhole covers, which was previously addresses.

Ref https://github.com/openaddresses/openaddresses/issues/5843