### PR TITLE
Update web service for Cumberland County, PA

### DIFF
--- a/sources/us/pa/cumberland.json
+++ b/sources/us/pa/cumberland.json
@@ -14,11 +14,11 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://gis.ccpa.net/arcgiswebadaptor/rest/services/Open_Data/Address_Points/MapServer/0",
+                "data": "https://services1.arcgis.com/1Cfo0re3un0w6a30/arcgis/rest/services/Address_Points/FeatureServer/0",
                 "website": "https://www.ccpa.net/116/Geographic-Information-Systems-GIS",
                 "contact": {
-                    "name": "Patrick McKinney",
-                    "title": "GIS Analyst",
+                    "name": "Justin Smith",
+                    "title": "GIS Manager",
                     "phone": "717-240-7842",
                     "email": "gis@ccpa.net",
                     "address": "1 Courthouse Square, Carlisle, PA  17013"


### PR DESCRIPTION
Previous service no longer exists.  New service is reference to open data site.
Updated County contact.  Previous contact no longer works for County.