### PR TITLE
CH Coordinate Order

### DIFF
--- a/sources/ch/countrywide.json
+++ b/sources/ch/countrywide.json
@@ -35,8 +35,8 @@
                     },
                     "number": "DEINR",
                     "street": "STRNAME",
-                    "lon": "GKODE",
-                    "lat": "GKODN",
+                    "lat": "GKODE",
+                    "lon": "GKODN",
                     "city": "DPLZNAME",
                     "postcode": "DPLZ4",
                     "region": "GDEKT"


### PR DESCRIPTION
### Context

I flipped the coordinates in https://github.com/openaddresses/openaddresses/issues/5465 as a stopgap. The underlying bug is now resolved and these should be restored to their correct order.

Closes: https://github.com/openaddresses/openaddresses/issues/5465