### PR TITLE
Fixed ES script

### DIFF
--- a/scripts/es/Makefile
+++ b/scripts/es/Makefile
@@ -1,24 +1,25 @@
 xml:
-	curl "http://www.catastro.minhap.es/INSPIRE/Addresses/ES.SDGC.AD.atom.xml" | grep enclosure | sed -e "s/^.*http/http/" -e "s/\" type.*$$//" > xml_urls.txt
-	mkdir xml
-	cd xml && cat ../xml_urls.txt | xargs -I {} curl {} -O
+        curl -L "https://www.catastro.minhap.es/INSPIRE/Addresses/ES.SDGC.AD.atom.xml" | grep enclosure | sed -e "s/^.*http/http/" -e "s/\" type.*$$//" > xml_urls.txt
+        mkdir xml
+        cd xml && cat ../xml_urls.txt | xargs -I {} curl -L {} -O
 
 gml:
-	rm -rf spain_catastre
-	mkdir spain_catastre
-	rm -f gml_urls.txt
-	grep -a zip xml/* | sed -e "s/^.*http/http/" -e "s/\" type=.*$$//" | grep -a -v "</id" | grep -a -v "<inspire" >> spain_catastre/gml_urls.latin1.txt
-	cat spain_catastre/gml_urls.latin1.txt | iconv -f latin1 -t utf8 > spain_catastre/gml_urls.txt
-	rm -f spain_catastre/gm_urls.latin1.txt
-	mkdir spain_catastre/gml
-	python download_gml.py spain_catastre/gml_urls.txt spain_catastre/gml/
+        rm -rf spain_catastre
+        mkdir spain_catastre
+        rm -f gml_urls.txt
+        grep -a zip xml/* | sed -e "s/^.*http/http/" -e "s/\" type=.*$$//" | grep -a -v "</id" | grep -a -v "<inspire" >> spain_catastre/gml_urls.latin1.txt
+        cat spain_catastre/gml_urls.latin1.txt | iconv -f latin1 -t utf8 > spain_catastre/gml_urls.txt
+        rm -f spain_catastre/gm_urls.latin1.txt
+        mkdir spain_catastre/gml
+        python download_gml.py spain_catastre/gml_urls.txt spain_catastre/gml/
 
 convert:
-	rm -f build/es-*.csv
-	find spain_catastre/gml/ | grep zip | grep gml | parallel --no-notice -t -j 1 python gml_to_csv.py {} build/
+        mkdir -p build
+        rm -f build/es-*.csv
+        find spain_catastre/gml/ | grep zip | grep gml | parallel --gnu  --no-notice -t -j 1 python gml_to_csv.py {} build/
 
 combine:
-	bash ./combine.sh
+        bash ./combine.sh
 
 # NOTE: you may also need to run find_missing.py to locate files that don't convert properly 
 

--- a/scripts/es/Makefile
+++ b/scripts/es/Makefile
@@ -16,7 +16,7 @@ gml:
 convert:
         mkdir -p build
         rm -f build/es-*.csv
-        find spain_catastre/gml/ | grep zip | grep gml | parallel --gnu  --no-notice -t -j 1 python gml_to_csv.py {} build/
+        find spain_catastre/gml/ | grep zip | grep gml | parallel --no-notice -t -j 1 python gml_to_csv.py {} build/
 
 combine:
         bash ./combine.sh

--- a/scripts/es/download_gml.py
+++ b/scripts/es/download_gml.py
@@ -6,8 +6,7 @@ with open(sys.argv[1], 'r') as f:
     urls = f.readlines()
     for url in urls:
         url = url.rstrip("\n")
-
-        if len(url) > 0
+        if len(url) > 0:
             filename = sys.argv[2] + url.split('/')[-1]
 
             urllib.urlretrieve(url, filename)


### PR DESCRIPTION
Fixed script to generate ES cached data. 

- URLs are redirected to HTTPS now. Fails if curl `-L` option is missing to follow redirects
- `build` directory is not added so script failed 
-  Syntax error in `scripts/es/download_gml.py`