### PR TITLE
New & updated data in ca/on/Peel

### DIFF
--- a/sources/ca/on/city_of_mississauga.json
+++ b/sources/ca/on/city_of_mississauga.json
@@ -1,0 +1,50 @@
+{
+    "coverage": {
+        "country": "ca",
+        "province": "on",
+        "city": "Mississauga",
+        "geometry": {
+            "type": "Point",
+            "coordinates": [
+                -79.643,
+                43.593
+            ]
+        }
+    },
+    "schema": 2,
+    "layers": {
+        "buildings": [
+            {
+                "name": "city",
+                "data": "https://services6.arcgis.com/hM5ymMLbxIyWTjn2/arcgis/rest/services/BldgRoof/FeatureServer/0/",
+                "protocol": "ESRI",
+                "website": "https://data.mississauga.ca/",
+                "license": {
+                    "url": "https://mississauga.maps.arcgis.com/sharing/rest/content/items/961c790805c14d8da258ec91bf4117e3/data",
+                    "attribution": false,
+                    "share-alike": false
+                },
+                "conform": {
+                    "format": "geojson"
+                }
+            }
+        ],
+        "parcels": [
+            {
+                "name": "city",
+                "protocol": "ESRI",
+                "data": "https://services6.arcgis.com/hM5ymMLbxIyWTjn2/arcgis/rest/services/Parcel/FeatureServer/0/",
+                "website": "https://data.mississauga.ca",
+                "license": {
+                    "url": "https://mississauga.maps.arcgis.com/sharing/rest/content/items/961c790805c14d8da258ec91bf4117e3/data",
+                    "attribution": false,
+                    "share-alike": false
+                },
+                "conform": {
+                    "format": "geojson",
+                    "pid": "CITY_PIN"
+                }
+            }
+        ]
+    }
+}

--- a/sources/ca/on/peel-region.json
+++ b/sources/ca/on/peel-region.json
@@ -37,6 +37,7 @@
                         "STREETDIRECTION"
                     ],
                     "city": "MUNICIPALITY",
+                    "addrtype": "LANDUSE",
                     "lat": "LATITUDE",
                     "lon": "LONGITUDE",
                     "accuracy": 1


### PR DESCRIPTION
Two changes were made for this request.

**ca/on/peel-region.json**
We've added a landuse column into our data and I've added the relevant tag within the JSON to allow OpenAddresses to parse it.

**ca/on/city_of_mississauga.json**
The City has released building footprints and parcels to their open data over the past couple of months.  I have added both to the JSON.  They have not released addresses; however, the peel-region addresses cover the city.