### PR TITLE
Update Verona Source

### DIFF
--- a/sources/it/34/city_of_verona.json
+++ b/sources/it/34/city_of_verona.json
@@ -16,7 +16,7 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "http://file.comune.verona.it/opendata/territorio/2014/SHP_NUMERAZIONE_CIVICA_point%2026-02-21014.zip",
+                "data": "http://file.comune.verona.it/opendata/territorio/2018/CS_OPENDATA_NUMERAZIONE_CIVICA_point.zip",
                 "website": "http://www.comune.verona.it/nqcontent.cfm?a_id=41435",
                 "attribution": "Comune di Verona",
                 "conform": {

--- a/sources/it/34/city_of_verona.json
+++ b/sources/it/34/city_of_verona.json
@@ -22,7 +22,11 @@
                 "conform": {
                     "format": "shapefile",
                     "srs": "EPSG:26591",
-                    "number": "NUM_CIV",
+                    "number": {
+                        "function": "format",
+                        "fields": ["NUM_CIV", "ESP"],
+                        "format": "$1/$2"
+                    },
                     "street": "NOME_VIA",
                     "postcode": "CAP",
                     "accuracy": 3,


### PR DESCRIPTION
Changes:
- Updated file link (update 13/07/2018)
- Added "exponent" to street number (example 1/A, A is the exponent)

Some questions:

- This file isn't updated regularly and every time it updates its url changes. Is there any option in the json to prevent it from being reprocessed every time? (It's kind of a waste of resources)
- Is it useful to have city, district and region hardcoded in conform? Or is it just ignored?
- It looks like that the "validity check" considers street numbers with "exponent" invalid, why?

