### PR TITLE
US: fix San Francisco postcode

### DIFF
--- a/sources/us/ca/san_francisco.json
+++ b/sources/us/ca/san_francisco.json
@@ -41,7 +41,11 @@
                         "street_typ"
                     ],
                     "unit": "unit_numbe",
-                    "postcode": "zip_code",
+                    "postcode": {
+                        "function": "regexp",
+                        "field": "zip_code",
+                        "pattern": "^([0-9]+)"
+                    },
                     "id": "eas_fullid"
                 }
             }


### PR DESCRIPTION
Hi there, I hope you are doing well !

The `zip_code` field is encoded as a real instead of integer in the Shapefile, this causes extra zeros in the decimal part (e.g. `94102.0`).

![image](https://user-images.githubusercontent.com/5153882/185655438-71c8f790-5ae7-40da-ab9b-fd36b85c3a7e.png)

List of all postcodes from the latest export:
```
94102.0
94103.0
94104.0
94105.0
94107.0
94108.0
94109.0
94110.0
94111.0
94112.0
94114.0
94115.0
94116.0
94117.0
94118.0
94121.0
94122.0
94123.0
94124.0
94127.0
94129.0
94130.0
94131.0
94132.0
94133.0
94134.0
94158.0
```
