### PR TITLE
Fix Sumter formatting

### DIFF
--- a/sources/us/fl/sumter.json
+++ b/sources/us/fl/sumter.json
@@ -1,38 +1,42 @@
-{
-    "coverage": {
-        "US Census": {
-            "geoid": "12119",
-            "name": "Sumter County",
-            "state": "Florida"
-        },
-        "country": "us",
-        "state": "fl",
-        "county": "Sumter"
-    },
-    "schema": 2,
-    "layers": {
-        "addresses": [
-            {
-                "name": "county",
-                "data": "https://gis.sumtercountyfl.gov/sumtergis/rest/services/Interactive/Address2/MapServer/0",
-                "protocol": "ESRI",
-                "conform": {
-                    "format": "geojson",
-                    "number": "ADD_NUM",
-                    "unit": [
-                        "UNITTYPE",
-                        "UNITNUM"
-                    ],
-                    "street": [
-                        "ST_PREDIR",
-                        "ST_NAME",
-                        "ST_POSTYP",
-                        "ST_POSDIR"
-                    ],
-                    "city": "CITY",
-                    "postcode": "POST_CODE"
-                }
-            }
-        ]
-    }
-}
+{                                                                                                                   
+    "coverage": {                                                                                                   
+        "US Census": {                                                                                              
+            "geoid": "12119",                                                                                       
+            "name": "Sumter County",                                                                                
+            "state": "Florida"                                                                                      
+        },                                                                                                          
+        "country": "us",                                                                                            
+        "state": "fl",                                                                                              
+        "county": "Sumter"                                                                                          
+    },                                                                                                              
+    "schema": 2,                                                                                                    
+    "layers": {                                                                                                     
+        "addresses": [                                                                                              
+            {                                                                                                       
+                "name": "county",                                                                                   
+                "data": "https://gis.sumtercountyfl.gov/sumtergis/rest/services/Interactive/Address2/MapServer/0",  
+                "website": "https://sumtercountyfl.gov/105/GIS",                                                    
+                "license": {"url": "https://www.arcgis.com/apps/webappviewer/index.html?id=0f1f020d62c242bcaeb868987"},
+                "protocol": "ESRI",                                                                                 
+                "conform": {                                                                                        
+                    "accuracy": 1,                                                                                  
+                    "format": "geojson",                                                                            
+                    "number": {                                                                                     
+                        "function": "prefixed_number",                                                              
+                        "field": "SADD"                                                                             
+                    },                                                                                              
+                    "unit": [                                                                                       
+                        "UNITTYPE",                                                                                 
+                        "UNIT"                                                                                      
+                    ],                                                                                              
+                    "street": {                                                                                     
+                        "function": "postfixed_street",                                                             
+                        "field": "SADD"                                                                             
+                    },                                                                                              
+                    "city": "CITY",                                                                                 
+                    "postcode": "POST_CODE"                                                                         
+                }                                                                                                   
+            }                                                                                                       
+        ]                                                                                                           
+    }                                                                                                               
+}  


### PR DESCRIPTION
Remove excess whitespace in street names and fix erroneous unit numbers.

Spot checks:

```
-POINT (-82.0655901 28.6968403),21c550859c6cd509,2367,CR 546   N,0.0,BUSHNELL,,,33513,.
+POINT (-82.0655901 28.6968403),52f058b1dd2b3f4f,2367,CR 546 N,,BUSHNELL,,,33513,.
-POINT (-82.0188624 28.8597998),05ca1cfa4d22d901,7056,HOMESTEAD LOOP,UNIT 0.0,WILDWOOD,,,34785,.
+POINT (-82.0188624 28.8597998),076cc6c357f720bd,7056,HOMESTEAD LOOP,UNIT 108,WILDWOOD,,,34785,.
```