### PR TITLE
Update ch/zurich source

### DIFF
--- a/sources/ch/zurich.json
+++ b/sources/ch/zurich.json
@@ -8,21 +8,20 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://data.stadt-zuerich.ch/dataset/adressen/resource/2f3e80d8-646d-4247-8542-37837b6ed3db/download/adressen.zip",
-                "website": "https://data.stadt-zuerich.ch/dataset/adressen",
+                "data": "https://www.ogd.stadt-zuerich.ch/wfs/geoportal/Adressen_Stadt_Zuerich?SERVICE=WFS&VERSION=1.1.0&request=GetFeature&typeName=adrstzh_adressen_stzh_p&outputFormat=application%2Fjson&srsName=EPSG:4326",
+                "website": "https://data.stadt-zuerich.ch/dataset/geo_adressen_stadt_zuerich",
                 "license": {
                     "text": "CC 0",
                     "attribution": false,
                     "share-alike": false
                 },
                 "protocol": "http",
-                "compression": "zip",
                 "conform": {
-                    "format": "shapefile",
+                    "format": "geojson",
                     "encoding": "utf-8",
-                    "number": "HAUSNUMMER",
-                    "street": "LOKALISATI",
-                    "postcode": "PLZ"
+                    "number": "hausnummer",
+                    "street": "lokalisationsname",
+                    "postcode": "plz"
                 }
             }
         ]


### PR DESCRIPTION
Current cached data for ch/zurich is not accurate:
![image](https://user-images.githubusercontent.com/2924736/202501026-f3c65c03-ae29-48b2-8bd2-00e35d6233dc.png)

Updating to current source as the data looks much better:
![image](https://user-images.githubusercontent.com/2924736/202501749-24b90a50-0c3a-4ffc-b662-b03042da6698.png)
