### PR TITLE
Update license for Portland Metro, Oregon

### DIFF
--- a/sources/us/or/portland_metro.json
+++ b/sources/us/or/portland_metro.json
@@ -29,8 +29,8 @@
                     "email": "alicia.wood@oregonmetro.gov"
                 },
                 "license": {
-                    "url": "https://www.oregonmetro.gov/sites/default/files/2014/08/01/Open_Database_and_Content_Licenses.pdf",
-                    "text": "Open Database License (ODbL) v1.0",
+                    "url": "https://rlisdiscovery.oregonmetro.gov/pages/open-database-license",
+                    "text": "RLIS Open Database End User License",
                     "attribution": true,
                     "attribution name": "Oregon Metro",
                     "share-alike": true
@@ -67,8 +67,8 @@
                     "email": "christine.rutan@oregonmetro.gov"
                 },
                 "license": {
-                    "url": "https://www.oregonmetro.gov/sites/default/files/2014/08/01/Open_Database_and_Content_Licenses.pdf",
-                    "text": "Open Database License (ODbL) v1.0",
+                    "url": "https://rlisdiscovery.oregonmetro.gov/pages/open-database-license",
+                    "text": "RLIS Open Database End User License",
                     "attribution": true,
                     "attribution name": "Oregon Metro",
                     "share-alike": true
@@ -87,8 +87,8 @@
                 "data": "https://services2.arcgis.com/McQ0OlIABe29rJJy/ArcGIS/rest/services/Building_Footprint_Database/FeatureServer/0",
                 "website": "https://rlisdiscovery.oregonmetro.gov/datasets/drcMetro::building-footprint-database-1/about",
                 "license": {
-                    "url": "https://www.oregonmetro.gov/sites/default/files/2014/08/01/Open_Database_and_Content_Licenses.pdf",
-                    "text": "Open Database License (ODbL) v1.0",
+                    "url": "https://rlisdiscovery.oregonmetro.gov/pages/open-database-license",
+                    "text": "RLIS Open Database End User License",
                     "attribution": true,
                     "attribution name": "Oregon Metro",
                     "share-alike": true


### PR DESCRIPTION
Oregon Metro is now using their own license for their addresses/parcels/buildings