### PR TITLE
Update license for City of Portland, Oregon

### DIFF
--- a/sources/us/or/city_of_portland.json
+++ b/sources/us/or/city_of_portland.json
@@ -24,9 +24,8 @@
                 "data": "https://www.portlandmaps.com/arcgis/rest/services/Public/COP_OpenData_Property/MapServer/47",
                 "website": "https://gis-pdx.opendata.arcgis.com/datasets/PDX::address/about",
                 "license": {
-                    "attribution": true,
-                    "attribution text": "City of Portland, Oregon",
-                    "presumed": true
+                    "url": "https://opendatacommons.org/licenses/pddl/1-0/",
+                    "text": "Public Domain Dedication and License (PDDL) v1.0"
                 },
                 "protocol": "ESRI",
                 "conform": {
@@ -52,9 +51,8 @@
                 "data": "https://www.portlandmaps.com/arcgis/rest/services/Public/Taxlots/MapServer/0",
                 "website": "https://www.portlandmaps.com/metadata/index.cfm?action=DisplayServiceLayer&ServerLayerID=1778",
                 "license": {
-                    "attribution": true,
-                    "attribution text": "City of Portland, Oregon",
-                    "presumed": true
+                    "url": "https://opendatacommons.org/licenses/pddl/1-0/",
+                    "text": "Public Domain Dedication and License (PDDL) v1.0"
                 },
                 "protocol": "ESRI",
                 "conform": {
@@ -69,9 +67,8 @@
                 "data": "https://www.portlandmaps.com/arcgis/rest/services/Public/COP_OpenData_Property/MapServer/48",
                 "website": "https://gis-pdx.opendata.arcgis.com/datasets/building-footprints/about",
                 "license": {
-                    "attribution": true,
-                    "attribution text": "City of Portland, Oregon",
-                    "presumed": true
+                    "url": "https://opendatacommons.org/licenses/pddl/1-0/",
+                    "text": "Public Domain Dedication and License (PDDL) v1.0"
                 },
                 "protocol": "ESRI",
                 "conform": {


### PR DESCRIPTION
According to the [terms of service](https://www.portlandmaps.com/documents/terms-of-service/), data on the City of Portland's Open Data Portal are licensed under the Public Domain Dedication and License (PDDL) v1.0