### PR TITLE
Fix typo

### DIFF
--- a/sources/us/ca/plumas.json
+++ b/sources/us/ca/plumas.json
@@ -6,7 +6,7 @@
             "state": "California"
         },
         "country": "us",
-        "state": "ga",
+        "state": "ca",
         "county": "Plumas"
     },
     "schema": 2,


### PR DESCRIPTION
It looks like the data being used for Plumas County is from 2016. This should be updated using the KMZ on [their website](https://plumascounty.us/2199/Interactive-GIS-Data-to-Download-Page)