### PR TITLE
Fix us/pa/fayette SRS and add parcels

### DIFF
--- a/sources/us/pa/fayette.json
+++ b/sources/us/pa/fayette.json
@@ -14,18 +14,18 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "http://fayettemaps.rba.com:8080/geoserver/fayette/ows?service=WFS&version=1.1.1&request=GetFeature&typename=fayette:ParcelsPolygon&outputFormat=json",
+                "data": "http://fayettemaps.rba.com:8080/geoserver/fayette/ows?service=WFS&version=1.1.1&request=GetFeature&typename=fayette:ParcelsPolygon&outputFormat=shape-zip",
                 "protocol": "http",
+                "compression": "zip",
                 "conform": {
-                    "format": "geojson",
+                    "format": "shapefile",
                     "accuracy": 2,
                     "number": "ADDR_PHYSI",
                     "street": [
                         "ADDR_PHY_1",
                         "ADDR_PHY_2"
                     ],
-                    "postcode": "ZIP1",
-                    "srs": "EPSG:3857"
+                    "postcode": "ZIP1"
                 }
             }
         ]

--- a/sources/us/pa/fayette.json
+++ b/sources/us/pa/fayette.json
@@ -28,6 +28,18 @@
                     "postcode": "ZIP1"
                 }
             }
+        ],
+        "parcels": [
+            {
+                "name": "county",
+                "data": "http://fayettemaps.rba.com:8080/geoserver/fayette/ows?service=WFS&version=1.1.1&request=GetFeature&typename=fayette:ParcelsPolygon&outputFormat=shape-zip",
+                "protocol": "http",
+                "compression": "zip",
+                "conform": {
+                    "format": "shapefile",
+                    "pid": "taxidnum"
+                }
+            }
         ]
     }
 }

--- a/sources/us/pa/fayette.json
+++ b/sources/us/pa/fayette.json
@@ -24,7 +24,8 @@
                         "ADDR_PHY_1",
                         "ADDR_PHY_2"
                     ],
-                    "postcode": "ZIP1"
+                    "postcode": "ZIP1",
+                    "srs": "EPSG:3857"
                 }
             }
         ]


### PR DESCRIPTION
Closes #4261

Summary: the lat/longs for Fayette are currently Web Mercator, not WGS84. This updates the `srs`.