### PR TITLE
Switch us/pa/luzerne district to city

### DIFF
--- a/sources/us/pa/luzerne.json
+++ b/sources/us/pa/luzerne.json
@@ -37,7 +37,7 @@
                         "function": "postfixed_unit",
                         "field": "FULL_ADDRE"
                     },
-                    "district": "MCN"
+                    "city": "MCN"
                 }
             }
         ],


### PR DESCRIPTION
I accidentally updated Luzerne County to point the `district` field to what should be `city` in 3ad2b9d74b3a0978301e72ee877c1adffd13d3d7. This fixes it 😄 