### PR TITLE
Add Wakulla County, FL

### DIFF
--- a/sources/us/fl/wakulla.json
+++ b/sources/us/fl/wakulla.json
@@ -1,0 +1,59 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "12129",
+            "name": "Wakulla County",
+            "state": "Florida"
+        },
+        "country": "us",
+        "state": "fl",
+        "county": "Wakulla"
+    },
+    "schema": 2,
+    "layers": {
+        "addresses": [
+            {
+                "name": "county",
+                "data": "https://github.com/openaddresses/openaddresses/files/11761597/WAKULLA_2023-07-01.zip",
+                "website": "https://pointmatch.floridarevenue.com/General/AddressFiles.aspx",
+                "year": 2023,
+                "protocol": "http",
+                "compression": "zip",
+                "conform": {
+                    "format": "csv",
+                    "lat": "LAT",
+                    "lon": "LONG",
+                    "number": "NUMBER",
+                    "street": [
+                        "PREDIR",
+                        "STNAME",
+                        "STSUFFIX",
+                        "POSTDIR"
+                    ],
+                    "unit": [
+                        "UNITTYPE",
+                        "UNITNUM"
+                    ],
+                    "city": "MAILCITY",
+                    "district": "COUNTY",
+                    "postcode": "ZIP"
+                }
+            }
+        ],
+        "parcels": [
+            {
+                "name": "county",
+                "attribution": "Wakulla County",
+                "data": "https://floridarevenue.com/property/dataportal/Documents/PTO%20Data%20Portal/Map%20Data/2023F/wakulla_2023pin.zip",
+                "website": "https://floridarevenue.com/property/Pages/DataPortal_RequestAssessmentRollGISData.aspx",
+                "year": 2023,
+                "protocol": "http",
+                "compression": "zip",
+                "conform": {
+                    "format": "shapefile",
+                    "pid": "PARCELNO"
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Source zip (from [FDOR download portal](https://pointmatch.floridarevenue.com/General/AddressFiles.aspx)): [WAKULLA_2023-07-01.zip](https://github.com/openaddresses/openaddresses/files/11761597/WAKULLA_2023-07-01.zip)
