### PR TITLE
Try adding quoting around the run-one args.

### DIFF
--- a/ci/run_changed_sources.py
+++ b/ci/run_changed_sources.py
@@ -123,8 +123,8 @@ def main():
         output_dir = os.path.join("output", path_to_source)
         mkdir_p(output_dir)
         os.system(f"openaddr-process-one {source[0]} {output_dir} "
-                  f"--layer {source[1]} "
-                  f"--layersource {source[2]} "
+                  f"--layer \"{source[1]}\" "
+                  f"--layersource \"{source[2]}\" "
                   f"--render-preview "
                   f"--mapbox-key {os.environ.get('MAPBOX_KEY')}")
 


### PR DESCRIPTION
For #6912 