### PR TITLE
Update statewide.json

### DIFF
--- a/sources/us/co/statewide.json
+++ b/sources/us/co/statewide.json
@@ -12,7 +12,7 @@
         "addresses": [
             {
                 "name": "state",
-                "data": "https://gisftp.colorado.gov/State%20Data/OIT-GIS/ColoradoData/Cadastral/2023/PublicAddresses2023/CSAD_Public.zip",
+                "data": "https://gisftp.colorado.gov/State%20Data/OIT-GIS/ColoradoData/Cadastral/2023/PublicAddresses2023/Master_Address_Public.zip",
                 "website": "https://data.colorado.gov/Local-Aggregation/Statewide-Aggregate-Addresses-in-Colorado-2023-Pub/5bh8-d7bc",
                 "license": {
                     "text": "Public Domain",
@@ -23,7 +23,7 @@
                 "compression": "zip",
                 "conform": {
                     "format": "gdb",
-                    "file": "CSAD_Public/CSADPublic.gdb",
+                    "file": "Master_Address_Public.gdb",
                     "number": [
                         "AddrNum",
                         "NumSuf"

--- a/sources/us/co/statewide.json
+++ b/sources/us/co/statewide.json
@@ -24,6 +24,7 @@
                 "conform": {
                     "format": "gdb",
                     "file": "Master_Address_Public.gdb",
+                    "layer": "Colorado_Public_Address_Composite",
                     "number": [
                         "AddrNum",
                         "NumSuf"


### PR DESCRIPTION
(re-done to update FILE attribute as requested) The path to the CO Statewide address point file has been updated. There are issues with the old file that have been corrected in this file. These issues go upstream to Geocode.Earth, for example, and are used by our District's School Finder. I hope I have changed the FILE attribute correctly - it seems to unzip directly to the GDB intstead of a sub-folder as with the previous version.