### PR TITLE
Add Oregon statewide buildings

### DIFF
--- a/ci/run_changed_sources.py
+++ b/ci/run_changed_sources.py
@@ -125,7 +125,6 @@ def main():
             layer=source.layer,
             layersource=source.name,
             do_preview=True,
-            do_mbtiles=True,
             do_pmtiles=True,
             mapbox_key=os.environ.get('MAPBOX_KEY'),
         )

--- a/sources/us/or/statewide.json
+++ b/sources/us/or/statewide.json
@@ -47,6 +47,17 @@
                     "format": "geojson"
                 }
             }
+        ],
+        "buildings": [
+            {
+                "name": "state",
+                "data": "https://services8.arcgis.com/8PAo5HGmvRMlF2eU/arcgis/rest/services/Building_Footprints/FeatureServer/0",
+                "website": "https://geohub.oregon.gov/datasets/5dfc198ecaf64711a9e77057de2b6af1_0/about",
+                "protocol": "ESRI",
+                "conform": {
+                    "format": "geojson"
+                }
+            }
         ]
     }
 }


### PR DESCRIPTION
@iandees would you be able to upload [this gdb](https://drive.proton.me/urls/EXP268C6D4#NTeKoIRR1bud) to data.openaddresses.io? This gdb contains statewide address data from NAD r8. The current source we're using is missing address data from some counties.