### PR TITLE
au/vic/statewide change order URLs as existing ones aren't being updated

### DIFF
--- a/sources/au/vic/statewide.json
+++ b/sources/au/vic/statewide.json
@@ -14,7 +14,7 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://s3-ap-southeast-2.amazonaws.com/cl-isd-prd-datashare-s3-delivery/Order_BGJ5MV.zip",
+                "data": "https://s3.ap-southeast-2.amazonaws.com/cl-isd-prd-datashare-s3-delivery/Order_FDBZT5.zip",
                 "note": "data URL provided by a weekly recurring order placed at https://datashare.maps.vic.gov.au/",
                 "website": "https://discover.data.vic.gov.au/dataset/vicmap-address",
                 "compression": "zip",
@@ -26,7 +26,7 @@
                     "share-alike": false
                 },
                 "conform": {
-                    "file": "ll_gda2020/filegdb/whole_of_dataset/victoria/VICMAP_ADDRESS.gdb",
+                    "file": "ll_gda2020/filegdb/whole_of_dataset/victoria/VMADD.gdb",
                     "format": "gdb",
                     "layer": "ADDRESS",
                     "id": "PFI",
@@ -46,7 +46,7 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://s3-ap-southeast-2.amazonaws.com/cl-isd-prd-datashare-s3-delivery/Order_OTL5B2.zip",
+                "data": "https://s3.ap-southeast-2.amazonaws.com/cl-isd-prd-datashare-s3-delivery/Order_EUKSRV.zip",
                 "note": "data URL provided by a weekly recurring order placed at https://datashare.maps.vic.gov.au/",
                 "website": "https://discover.data.vic.gov.au/dataset/property-view-vicmap-property",
                 "conform": {


### PR DESCRIPTION
The existing order URLs though they are are set as weekly recurring orders, don't have any recent data. While these new URLs contain the latest data, it's unclear if they will be updated in place.