### PR TITLE
Update remote data URL for es/nc

### DIFF
--- a/sources/es/nc/statewide.json
+++ b/sources/es/nc/statewide.json
@@ -11,7 +11,7 @@
         "addresses": [
             {
                 "name": "state",
-                "data": "http://www.navarra.es/appsext/DescargarFichero/default.aspx?codigoAcceso=OpenData&fichero=GestorDireccionesPostales\\OpenAddresses.zip",
+                "data": "https://administracionelectronica.navarra.es/AccesoFicheros/DownloadFile.aspx?codigoAcceso=OpenData&fichero=GestorDireccionesPostales%5COpenAddresses.zip",
                 "protocol": "http",
                 "compression": "zip",
                 "license": {


### PR DESCRIPTION
The old URL return 301, and OpenAddresses does not follow the redirection (as expected).

So I update the URL + spiking a JS browser redirection.
