### PR TITLE
updated url, added streetdir prefix field

### DIFF
--- a/sources/us/wy/sublette.json
+++ b/sources/us/wy/sublette.json
@@ -15,13 +15,14 @@
             {
                 "name": "county",
                 "compression": "zip",
-                "data": "http://sublette.greenwoodmap.com/download/ownership_shp.zip",
+                "data": "https://greenwoodmap.com/sublette/mapserver/download/ownership_shp.zip",
                 "protocol": "http",
                 "conform": {
                     "format": "shapefile",
                     "file": "address.shp",
                     "number": "streetnum",
                     "street": [
+                        "streetdir",
                         "streetname",
                         "streetsuf"
                     ],
@@ -33,7 +34,7 @@
             {
                 "name": "county",
                 "compression": "zip",
-                "data": "http://sublette.greenwoodmap.com/download/ownership_shp.zip",
+                "data": "https://greenwoodmap.com/sublette/mapserver/download/ownership_shp.zip",
                 "protocol": "http",
                 "conform": {
                     "format": "shapefile",


### PR DESCRIPTION
This PR updates the .zip file URL for Sublette County, WY and adds the `streetdir` prefix field.  