### PR TITLE
fixed URLs to new host

### DIFF
--- a/sources/us/wa/cowlitz.json
+++ b/sources/us/wa/cowlitz.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://www.cowlitzinfo.net/arcgis/rest/services/WSPublic/WSAddressPoints/MapServer/0",
+                "data": "https://cowlitzgis.net/ccserver/rest/services/Cadastral/WSAddressPoints/MapServer/0",
                 "website": "http://www.co.cowlitz.wa.us/index.aspx?nid=201",
                 "protocol": "ESRI",
                 "conform": {
@@ -23,16 +23,14 @@
                     "unit": "UNIT",
                     "street": "SITE_ALL",
                     "postcode": "Post_Code",
-                    "city": "CITY",
-                    "district": "County",
-                    "region": "State"
+                    "city": "CITY"
                 }
             }
         ],
         "parcels": [
             {
                 "name": "county",
-                "data": "https://www.cowlitzinfo.net/arcgis/rest/services/WSPublic/ParcelsDark/MapServer/0",
+                "data": "https://cowlitzgis.net/ccserver/rest/services/Cadastral/Parcels/MapServer/0",
                 "website": "http://www.co.cowlitz.wa.us/index.aspx?nid=201",
                 "protocol": "ESRI",
                 "conform": {


### PR DESCRIPTION
This PR updates us/wa/cowlitz to point to the new URL.  The addresses conform has been updated to remove district and region which are no longer available. 