### PR TITLE
use correct fields for number

### DIFF
--- a/sources/ca/on/city_of_london.json
+++ b/sources/ca/on/city_of_london.json
@@ -21,7 +21,10 @@
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
-                    "number": "FullNumber",
+                    "number": [
+                        "MunicipalNumber",
+                        "MunicipalNumberQualifier"
+                    ],
                     "street": [
                         "StreetName",
                         "StreetType",


### PR DESCRIPTION
The `FullNumber` field is formatted as `${UnitNumber}-${MunicipalNumber}`, so this PR corrects the conform to use the actual house number + extension (such as 'A', 'B') where extension is not the unit.  