### PR TITLE
updated url, moved STREET_DIR_SUFFIX to unit in conform

### DIFF
--- a/sources/ca/bc/city_of_vernon.json
+++ b/sources/ca/bc/city_of_vernon.json
@@ -16,7 +16,7 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://services1.arcgis.com/HypAr72I39xWsrNH/arcgis/rest/services/Vernon_Civic_Address_Points/FeatureServer/4",
+                "data": "https://services1.arcgis.com/HypAr72I39xWsrNH/ArcGIS/rest/services/Vernon_Civic_Address_Points/FeatureServer/1",
                 "website": "https://cov-open-data-vernon.hub.arcgis.com/datasets/vernon::vernon-civic-address-points/about",
                 "license": {
                     "url": "https://www.vernon.ca/government-services/maps-gis/open-data-catalogue",
@@ -25,7 +25,6 @@
                 "protocol": "ESRI",
                 "conform": {
                     "number": [
-                        "STREET_NUMBER_PREFIX",
                         "STREET_NUMBER",
                         "STREET_NUMBER_SUFFIX"
                     ],
@@ -35,6 +34,7 @@
                         "STREET_TYPE",
                         "STREET_DIR_SUFFIX"
                     ],
+                    "unit": "STREET_NUMBER_PREFIX",
                     "format": "geojson"
                 }
             }


### PR DESCRIPTION
This PR updates the data URL to the correct layer and moves the `STREET_NUMBER_PREFIX` field from `number`->`unit` after spot checking a number of addresses.  