### PR TITLE
updated data URL, use non-unit field for number

### DIFF
--- a/sources/us/ct/city_of_manchester.json
+++ b/sources/us/ct/city_of_manchester.json
@@ -23,14 +23,14 @@
                 "name": "city",
                 "conform": {
                     "format": "geojson",
-                    "number": "MAIL_NUM_TXT",
+                    "number": "MAIL_NUM",
                     "street": "FULL_STR",
                     "unit": "UNIT",
                     "postcode": "ZIP_CODE",
                     "id": "PAR_NUM_TXT"
                 },
                 "attribution": "City of Manchester",
-                "data": "http://gis1.townofmanchester.org/arcgis/rest/services/Basemaps/ToMMI_BaseMap/MapServer/4",
+                "data": "https://gis1.townofmanchester.org/arcgis/rest/services/Basemaps/ToMMI3_BaseMap/MapServer/2",
                 "protocol": "ESRI"
             }
         ]


### PR DESCRIPTION
This PR:
- updates the URL to the current one
- use `MAIL_NUM` field for `number` instead of `MAIL_NUM_TXT` since the latter contains unit number