### PR TITLE
Update denver.json

### DIFF
--- a/sources/us/co/denver.json
+++ b/sources/us/co/denver.json
@@ -40,35 +40,7 @@
                 "protocol": "http",
                 "compression": "zip"
             }
-        ],
-        "parcels": [
-            {
-                "name": "county",
-                "website": "https://www.denvergov.org/opendata/dataset/city-and-county-of-denver-parcels",
-                "license": "CC BY 3.0",
-                "attribution": "City of Denver Open Data Catalog",
-                "data": "https://www.denvergov.org/media/gis/DataCatalog/parcels/shape/parcels.zip",
-                "protocol": "http",
-                "compression": "zip",
-                "conform": {
-                    "format": "shapefile",
-                    "pid": "SCHEDNUM"
-                }
-            }
-        ],
-        "buildings": [
-            {
-                "name": "county",
-                "website": "https://www.denvergov.org/opendata/dataset/city-and-county-of-denver-building-outlines-2014",
-                "license": "CC BY 3.0",
-                "attribution": "City of Denver Open Data Catalog",
-                "data": "https://www.denvergov.org/media/gis/DataCatalog/building_outlines_2014/shape/building_outlines_2014.zip",
-                "protocol": "http",
-                "compression": "zip",
-                "conform": {
-                    "format": "shapefile"
-                }
-            }
         ]
+        
     }
 }

--- a/sources/us/co/denver.json
+++ b/sources/us/co/denver.json
@@ -41,6 +41,6 @@
                 "compression": "zip"
             }
         ]
-        
+
     }
 }


### PR DESCRIPTION
Removing 2 redundant and error-inducing sources. Please reach out to me if there are any more clarifications needed. As we have been using OA and City of Denver address points (as well as parcels, and many other Denver open data sources), I feel the proposed changes below are justified: 

- Denver Parcels - main reason is there are missing zip codes for all addresses, and otherwise, contains redundant information that is more accurately found in the Denver Addresses file, which is maintained perfectly by the City and County of Denver. The missing zip codes are also causing issue through Geocode.Earth and our Denver Public Schools geocoding system, which pulls Denver and CO through the US_WEST aggregate. 

- building footprints 2014 - in addition to being 10 years out of date, the data within provides no additional geocoding information