### PR TITLE
Update Denver source to use more recent buildings

### DIFF
--- a/sources/us/co/denver.json
+++ b/sources/us/co/denver.json
@@ -59,10 +59,10 @@
         "buildings": [
             {
                 "name": "county",
-                "website": "https://www.denvergov.org/opendata/dataset/city-and-county-of-denver-building-outlines-2014",
+                "website": "https://www.denvergov.org/opendata/dataset/city-and-county-of-denver-building-outlines-2020",
                 "license": "CC BY 3.0",
                 "attribution": "City of Denver Open Data Catalog",
-                "data": "https://www.denvergov.org/media/gis/DataCatalog/building_outlines_2014/shape/building_outlines_2014.zip",
+                "data": "https://www.denvergov.org/media/gis/DataCatalog/building_outlines_2020/shape/building_outlines_2020.zip",
                 "protocol": "http",
                 "compression": "zip",
                 "conform": {


### PR DESCRIPTION
As pointed out in https://github.com/openaddresses/openaddresses/pull/7035, the buildings dataset for Denver was using older data. This updates to use a more recent (2020) release.