### PR TITLE
Update us/in/statewide

### DIFF
--- a/sources/us/in/statewide.json
+++ b/sources/us/in/statewide.json
@@ -12,17 +12,12 @@
         "addresses": [
             {
                 "name": "state",
-                "website": "https://www.indianamap.org/datasets/address-points-of-indiana-current/about",
-                "data": "https://opendata.arcgis.com/api/v3/datasets/9b222d07cc164eb384a24742cbf1d274_62/downloads/data?format=geojson&spatialRefId=4326&where=1%3D1",
-                "protocol": "http",
-                "compression": "zip",
+                "website": "https://www.indianamap.org/datasets/9b222d07cc164eb384a24742cbf1d274_0/explore",
+                "data": "https://gisdata.in.gov/server/rest/services/Hosted/Address_Points_of_Indiana_Current/FeatureServer/0",
+                "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
-                    "number": [
-                        "addnum_pre",
-                        "add_number",
-                        "addnum_suf"
-                    ],
+                    "number": "geohousenum",
                     "street": [
                         "st_premod",
                         "st_predir",
@@ -44,9 +39,9 @@
         "parcels": [
             {
                 "name": "state",
-                "website": "https://www.indianamap.org/datasets/INMap::parcel-boundaries-of-indiana-current/about",
-                "data": "https://opendata.arcgis.com/api/v3/datasets/70565d886f1e4528a43a86be6ce5c2f3_0/downloads/data?format=geojson&spatialRefId=4326&where=1%3D1",
-                "protocol": "http",
+                "website": "https://www.indianamap.org/datasets/ce78e8017fcb479c81a06a6255cfcfa6_0/explore",
+                "data": "https://gisdata.in.gov/server/rest/services/Hosted/Parcel_Boundaries_of_Indiana_Current/FeatureServer/0",
+                "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
                     "pid": "STATE_PARCEL_ID"
@@ -56,12 +51,11 @@
         "buildings": [
             {
                 "name": "state",
-                "website": "https://www.indianamap.org/maps/384f2d5041a14c34bd9e807c568784da/about",
-                "data": "https://opendata.arcgis.com/api/v3/datasets/384f2d5041a14c34bd9e807c568784da_0/downloads/data?format=fgdb&spatialRefId=4326&where=1%3D1",
-                "protocol": "http",
-                "compression": "zip",
+                "website": "https://www.indianamap.org/datasets/384f2d5041a14c34bd9e807c568784da_0/explore",
+                "data": "https://gisdata.in.gov/server/rest/services/Hosted/Building_Footprints/FeatureServer/0",
+                "protocol": "ESRI",
                 "conform": {
-                    "format": "gdb"
+                    "format": "geojson"
                 }
             }
         ]


### PR DESCRIPTION
It looks like the Indiana statewide sources haven't updated since 2020. In fact I'm only seeing addresses and parcels, but it looks like the building [source](https://github.com/openaddresses/openaddresses/blob/master/sources/us/in/statewide.json#L56) hasn't made it into `/data` at all.

This PR updates the sources to use a public ArcGIS Online endpoint underlying the State's open data offerings. In my experience the open data endpoints are very slow to generate a download, and based on #7034 it sounds like there's been some trial and error getting them to work.

Please let me know though if there's a preference towards using ArcGIS Open Data endpoints over ArcGIS Online endpoints when available.