### PR TITLE
Add support for first_non_empty in the JSONSchema

### DIFF
--- a/ATTRIBUTE_FUNCTIONS.md
+++ b/ATTRIBUTE_FUNCTIONS.md
@@ -18,6 +18,22 @@ One note, however, is that functions cannot be combined at this time.  That is, 
 
 ## Formatting Functions
 
+## Index
+
+* [`join`](#join)
+* [`format`](#format)
+* [`prefixed_number`](#prefixed_number-postfixed_street-and-postfixed_unit)
+* [`postfixed_street`](#prefixed_number-postfixed_street-and-postfixed_unit)
+* [`postfixed_unit`](#prefixed_number-postfixed_street-and-postfixed_unit)
+* [`remove_prefix`](#remove_prefix-and-remove_postfix)
+* [`remove_postfix`](#remove_prefix-and-remove_postfix)
+* [`regexp`](#regexp)
+* [`first_non_empty`](#first_non_empty)
+* [`get`](#get)
+* [`chain`](#chain)
+
+## Combining Functions
+
 There are two functions that are specifically designed to combine two or more fields into one.
 
 ### `join`
@@ -267,6 +283,10 @@ While virtually all modern regular expression flavors share identical basic beha
 | `field` | string | any field name in the data source | none (required)
 | `pattern` | string | a compilable regular expression | none (required)
 | `replace` | string | a string referencing 0 or more captured groups in `pattern` | none (optional)
+
+### `first_non_empty`
+
+The `first_non_empty` function is used to extract the first non-empty value from a list of fields. This function is particularly useful when a single record contains multiple columns for a particular output column.
 
 ### `get`
 The `get` function is particularly useful in a situation when a single address record may contain multiple nodes having the same field name.

--- a/schema/layers/address_conform.json
+++ b/schema/layers/address_conform.json
@@ -66,6 +66,8 @@
             },{
                 "$ref": "../util/functions/regexp.json"
             },{
+                "$ref": "../util/functions/first_non_empty.json"
+            },{
                 "$ref": "../util/functions/remove_prefix.json"
             },{
                 "$ref": "../util/functions/remove_postfix.json"
@@ -87,6 +89,8 @@
                 "$ref": "../util/functions/base.json"
             },{
                 "$ref": "../util/functions/regexp.json"
+            },{
+                "$ref": "../util/functions/first_non_empty.json"
             },{
                 "$ref": "../util/functions/prefixed_number.json"
             },{
@@ -111,6 +115,8 @@
                 "$ref": "../util/functions/base.json"
             },{
                 "$ref": "../util/functions/regexp.json"
+            },{
+                "$ref": "../util/functions/first_non_empty.json"
             },{
                 "$ref": "../util/functions/postfixed_street.json"
             },{
@@ -138,6 +144,8 @@
             },{
                 "$ref": "../util/functions/regexp.json"
             },{
+                "$ref": "../util/functions/first_non_empty.json"
+            },{
                 "$ref": "../util/functions/remove_prefix.json"
             },{
                 "$ref": "../util/functions/remove_postfix.json"
@@ -159,6 +167,8 @@
                 "$ref": "../util/functions/base.json"
             },{
                 "$ref": "../util/functions/regexp.json"
+            },{
+                "$ref": "../util/functions/first_non_empty.json"
             },{
                 "$ref": "../util/functions/remove_prefix.json"
             },{
@@ -182,6 +192,8 @@
             },{
                 "$ref": "../util/functions/regexp.json"
             },{
+                "$ref": "../util/functions/first_non_empty.json"
+            },{
                 "$ref": "../util/functions/remove_prefix.json"
             },{
                 "$ref": "../util/functions/remove_postfix.json"
@@ -204,6 +216,8 @@
             },{
                 "$ref": "../util/functions/regexp.json"
             },{
+                "$ref": "../util/functions/first_non_empty.json"
+            },{
                 "$ref": "../util/functions/remove_prefix.json"
             },{
                 "$ref": "../util/functions/remove_postfix.json"
@@ -225,6 +239,8 @@
                 "$ref": "../util/functions/base.json"
             },{
                 "$ref": "../util/functions/regexp.json"
+            },{
+                "$ref": "../util/functions/first_non_empty.json"
             },{
                 "$ref": "../util/functions/remove_prefix.json"
             },{

--- a/schema/util/functions/first_non_empty.json
+++ b/schema/util/functions/first_non_empty.json
@@ -1,0 +1,24 @@
+{
+    "description": "first_non_empty function definition",
+    "type": "object",
+    "required": [
+        "function",
+        "fields"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "function": {
+            "type": "string",
+            "enum": [
+                "first_non_empty"
+            ]
+        },
+        "fields": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "string"
+            }
+        }
+    }
+}

--- a/sources/si/countrywide.json
+++ b/sources/si/countrywide.json
@@ -36,10 +36,7 @@
                         "fields": ["HS_STEVILKA", "HS_DODATEK"],
                         "separator": ""
                     },
-                    "street": {
-                        "function": "first_non_empty",
-                        "fields": ["ULICA_NAZIV", "NASELJE_NAZIV"]
-                    },
+                    "street": "ULICA_NAZIV",
                     "city": "NASELJE_NAZIV",
                     "district": "OBCINA_NAZIV",
                     "region": "STATISTICNA_REGIJA_NAZIV",

--- a/sources/si/countrywide.json
+++ b/sources/si/countrywide.json
@@ -36,7 +36,10 @@
                         "fields": ["HS_STEVILKA", "HS_DODATEK"],
                         "separator": ""
                     },
-                    "street": "ULICA_NAZIV",
+                    "street": {
+                        "function": "first_non_empty",
+                        "fields": ["ULICA_NAZIV", "NASELJE_NAZIV"]
+                    },
                     "city": "NASELJE_NAZIV",
                     "district": "OBCINA_NAZIV",
                     "region": "STATISTICNA_REGIJA_NAZIV",


### PR DESCRIPTION
Fixes #6425 

This adds support and documentation for the existing [`first_non_empty`](https://github.com/openaddresses/batch-machine/blob/7903a812b9aecd5da168e54fcc1bc7eedf5a678a/openaddr/conform.py#L1033) function to the JSONSchema.