### PR TITLE
Wrong tag used to extract cities in us/me/statewide.json

### DIFF
--- a/sources/us/me/statewide.json
+++ b/sources/us/me/statewide.json
@@ -28,7 +28,7 @@
                         "POSTDIR"
                     ],
                     "unit": "UNIT",
-                    "city": "MUNICIPALITY",
+                    "city": "TOWN",
                     "district": "COUNTY",
                     "region": "STATE",
                     "postcode": "ZIPCODE"


### PR DESCRIPTION
The city field in this file is alway [empty](https://batch.openaddresses.io/data/1300/history). After taking a look at the [source data](https://maine.hub.arcgis.com/datasets/c1de8b6877114e109980972b4250a883_0/explore?showTable=true) it seems like the wrong name was used to extract cities:
```
                "conform": {
                    "format": "geojson",
                    "number": [
                        "ADDRESS_NUMBER",
                        "ADDNUMSUF"
                    ],
                    "street": [
                        "PREDIR",
                        "STREETNAME",
                        "SUFFIX",
                        "POSTDIR"
                    ],
                    "unit": "UNIT",
                    "city": "MUNICIPALITY",
                    "district": "COUNTY",
                    "region": "STATE",
                    "postcode": "ZIPCODE"
                }
```
There is no MUNICIPALITY field but there is a TOWN field containing the city info. I'm not sure how I can test my change locally to check it fixes the issue though.