### PR TITLE
Update street column in us/sc/jasper.json

### DIFF
--- a/sources/us/sc/jasper.json
+++ b/sources/us/sc/jasper.json
@@ -20,7 +20,12 @@
                     "format": "geojson",
                     "unit": [ "UNIT_TYPE", "UNIT" ],
                     "number": "STREET_NUM",
-                    "street": "FULL_STREET",
+                    "street": [
+                        "STREET_PRE",
+                        "STREET_NAM",
+                        "STREET_TYP",
+                        "STREET_POS"
+                    ],
                     "city": "COMM",
                     "region": "STATE",
                     "postcode": "ZIP_CODE"


### PR DESCRIPTION
The street labels currently use the FULL_STREET field but this field contains everything including the street number. Change to get only the street label using other fields so the output is consistent with other sources.