### PR TITLE
City of Alpharetta, GA, USA: updated addresses layer conform to current available fields

### DIFF
--- a/sources/us/ga/city_of_alpharetta.json
+++ b/sources/us/ga/city_of_alpharetta.json
@@ -28,13 +28,10 @@
                     "format": "geojson",
                     "number": "StNumber",
                     "street": [
-                        "PreMod",
                         "PreDir",
-                        "PreType",
                         "Name",
                         "PostType",
-                        "PostDir",
-                        "PostMod"
+                        "PostDir"
                     ],
                     "unit": "UnitActual",
                     "city": "City",


### PR DESCRIPTION
Source data no longer has various fields for street conform