### PR TITLE
Create bogota_addressforall.json

### DIFF
--- a/sources/co/bogota_addressforall.json
+++ b/sources/co/bogota_addressforall.json
@@ -1,0 +1,33 @@
+{
+    "coverage": {
+        "ISO 3166": {
+            "alpha2": "CO-DC",
+            "country": "Colombia",
+            "region": "Distrito Capital de Bogotá"
+        },
+        "country": "co",
+        "state": "dc"
+    },
+    "schema": 2,
+    "layers": {
+        "addresses": [
+            {
+                "name": "state",
+                "data": "https://addressforall-my.sharepoint.com/personal/operacao_addressforall_org/_layouts/15/download.aspx?share=EfECM6Ea5LJDlSWmlVA4l0oBHa_ufTUdHQCoFWws4qZsUA",
+                "website": "https://github.com/digital-guard/preserv-CO/tree/main/data/DC/Bogota/_pk0001.01",
+                "protocol": "http",
+                "license": {
+                    "url": "https://creativecommons.org/licenses/by/4.0/",
+                    "attribution": true,
+                    "attribution name": "CC-BY-4.0",
+                    "share-alike": true
+                },
+                "conform": {
+                    "format": "geojson",
+                    "number": "hnum",
+                    "street": "via"
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Hello,

This is data export from addressforall.org filtred with street and house number.
The data is from https://datosabiertos.bogota.gov.co/dataset

There are another data for export, please let me know if this dataset is correct.
The 
[batch-machine](https://github.com/openaddresses/batch-machine) ask me mapbox key, i do not find where to put it.

Thanks
Carlos Rebollo.
