### PR TITLE
Add US National Address Database source

### DIFF
--- a/sources/us/countrywide.json
+++ b/sources/us/countrywide.json
@@ -1,0 +1,39 @@
+{
+    "coverage": {
+        "ISO 3166": {
+            "alpha2": "US",
+            "country": "United States"
+        },
+        "country": "us"
+    },
+    "schema": 2,
+    "layers": {
+        "addresses": [
+            {
+                "name": "country",
+                "protocol": "http",
+                "data": "NAD Release 16, comma delimited ASCII",
+                "website": "https://www.transportation.gov/gis/national-address-database",
+                "compression": "zip",
+                "language": "en",
+                "license": {
+                    "url": "https://www.transportation.gov/mission/open/gis/national-address-database/national-address-database-nad-disclaimer",
+                    "attribution": false,
+                    "share-alike": false
+                },
+                "conform": {
+                    "format": "csv",
+                    "number": "AddNo_Full",
+                    "unit": "Unit",
+                    "street": "StNam_Full",
+                    "city": "Inc_Muni",
+                    "district": "County",
+                    "region": "State",
+                    "postcode": "Zip_Code",
+                    "lat": "Latitude",
+                    "lon": "Longitude"
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Adds the US NAD (https://www.transportation.gov/gis/national-address-database) source file