### PR TITLE
Add "city" field for CA countrywide data

### DIFF
--- a/sources/ca/countrywide.json
+++ b/sources/ca/countrywide.json
@@ -35,6 +35,7 @@
                         "OFFICIAL_STREET_DIR"
                     ],
                     "region": "MAIL_PROV_ABVN",
+                    "city": "MAIL_MUN_NAME",
                     "postcode": "MAIL_POSTAL_CODE",
                     "lat": "REPPOINT_LATITUDE",
                     "lon": "REPPOINT_LONGITUDE"


### PR DESCRIPTION
Canada NAR data was missing "city" in the conform. It should be populated by MAIL_MUN_NAME
