### PR TITLE
Use region instead of district for Colombia

### DIFF
--- a/sources/co/countrywide.json
+++ b/sources/co/countrywide.json
@@ -30,7 +30,7 @@
                     "number": "number",
                     "street": "street",
                     "city": "city",
-                    "district": "district",
+                    "region": "region",
                     "lat": "lat",
                     "lon": "lon"
                 }


### PR DESCRIPTION
Colombia addresses populate the district field which is currently empty. We need to use the region field instead. I downloaded the source data and used duckdb to show the numbers here.

```
D select district, count(1) from read_csv('co202307_ghs.csv') group by district;
┌──────────┬──────────┐
│ district │ count(1) │
│ varchar  │  int64   │
├──────────┼──────────┤
│          │  7786046 │
└──────────┴──────────┘
D select region, count(1) from read_csv('co202307_ghs.csv') group by region;
┌─────────┬──────────┐
│ region  │ count(1) │
│ varchar │  int64   │
├─────────┼──────────┤
│ BOY     │   265942 │
│ MAG     │   241558 │
│ VAU     │     2288 │
│ CHO     │    35225 │
│ GUA     │     4873 │
│ PUT     │    37384 │
│ QUI     │    64120 │
│ ATL     │   469842 │
│ COR     │   288252 │
│ SAN     │   331767 │
│ CES     │   236908 │
│ CAS     │   100994 │
│ TOL     │   248773 │
│ CUN     │   383876 │
│ RIS     │   145137 │
│ CO      │  1075087 │
│ ANT     │   875404 │
│ HUI     │   225458 │
│ BOL     │   355728 │
│ AMA     │     8961 │
│ LAG     │   149193 │
│ NSA     │   285324 │
│ ARA     │    65644 │
│ SUC     │   218699 │
│ VAC     │   819351 │
│ NAR     │   117521 │
│ VID     │    10240 │
│ GUV     │    17813 │
│ MET     │   241998 │
│ CAU     │   180134 │
│ CAL     │   181496 │
│ CAQ     │   101056 │
├─────────┴──────────┤
│ 32 rows  2 columns │
└────────────────────┘
```