### PR TITLE
update nz/countrywide source

### DIFF
--- a/sources/nz/countrywide.json
+++ b/sources/nz/countrywide.json
@@ -11,8 +11,8 @@
         "addresses": [
             {
                 "name": "country",
-                "data": "https://data.linz.govt.nz/services;key=441c0097257f45ab84d5ea4d24723f23/wfs?service=WFS&request=GetFeature&outputformat=CSV&typeNames=layer-53353",
-                "website": "https://data.linz.govt.nz/layer/53353-nz-street-address/",
+                "data": "https://data.linz.govt.nz/services;key=441c0097257f45ab84d5ea4d24723f23/wfs?service=WFS&request=GetFeature&outputformat=CSV&typeNames=layer-105689",
+                "website": "https://data.linz.govt.nz/layer/105689-nz-addresses/",
                 "license": {
                     "url": "http://creativecommons.org/licenses/by/4.0/",
                     "text": "CC BY 4.0",

--- a/sources/nz/countrywide.json
+++ b/sources/nz/countrywide.json
@@ -31,13 +31,9 @@
                     "id": "address_id",
                     "unit": "unit_value",
                     "number": {
-                        "function": "format",
-                        "fields": [
-                            "address_number",
-                            "address_number_suffix",
-                            "address_number_high"
-                        ],
-                        "format": "$1$2-$3"
+                        "function": "remove_prefix",
+                        "field": "full_address_number",
+                        "field_to_remove": "unit_value"
                     },
                     "street": "full_road_name",
                     "city": "suburb_locality",

--- a/sources/nz/countrywide.json
+++ b/sources/nz/countrywide.json
@@ -33,11 +33,12 @@
                     "number": {
                         "function": "format",
                         "fields": [
+                            "address_number_prefix",
                             "address_number",
                             "address_number_suffix",
                             "address_number_high"
                         ],
-                        "format": "$1$2-$3"
+                        "format": "$1$2$3-$4"
                     },
                     "street": "full_road_name",
                     "city": "suburb_locality",

--- a/sources/nz/countrywide.json
+++ b/sources/nz/countrywide.json
@@ -31,10 +31,13 @@
                     "id": "address_id",
                     "unit": "unit_value",
                     "number": {
-                        "function": "regexp",
-                        "field": "full_address_number",
-                        "pattern": "^(?:.*/)(.*)",
-                        "replace": "$1"
+                        "function": "format",
+                        "fields": [
+                            "address_number",
+                            "address_number_suffix",
+                            "address_number_high"
+                        ],
+                        "format": "$1$2-$3"
                     },
                     "street": "full_road_name",
                     "city": "suburb_locality",

--- a/sources/nz/countrywide.json
+++ b/sources/nz/countrywide.json
@@ -31,9 +31,10 @@
                     "id": "address_id",
                     "unit": "unit_value",
                     "number": {
-                        "function": "remove_prefix",
+                        "function": "regexp",
                         "field": "full_address_number",
-                        "field_to_remove": "unit_value"
+                        "pattern": "^(?:.*/)(.*)",
+                        "replace": "$1"
                     },
                     "street": "full_road_name",
                     "city": "suburb_locality",


### PR DESCRIPTION
1. Updates the source URL per https://github.com/openaddresses/openaddresses/issues/7257#issuecomment-2171881758

> the "NZ Street Address" dataset, which was superceded in Jan 2023 by the "NZ Addresses" data available at https://data.linz.govt.nz/layer/105689-nz-addresses/

2. Fixes a small number of number formatting edge cases where there was both an `address number_suffix` and a `address_number_high`. For example "1A-7A Puka Place, Inglewood" which shows the suffix applying to both the low and high number parts, which is something the current mapping we use gets wrong as OA will format it as "1A-7"
