### PR TITLE
Fix housenumber for us/ca/el_dorado source

### DIFF
--- a/sources/us/ca/el_dorado.json
+++ b/sources/us/ca/el_dorado.json
@@ -22,7 +22,10 @@
                     "id": "PRCL_ID",
                     "format": "geojson",
                     "city": "CITY",
-                    "number": "ADDR_NBR",
+                    "number": {
+                        "function": "prefixed_number",
+                        "field": "PRCL_ADDR"
+                    },
                     "street": [
                         "ADDR_STR_NAME",
                         "ADDR_STR_TYPE"


### PR DESCRIPTION
House numbers are incorrect for this source.   236791/253992 features where ADDR_NBR='1'
Object from esri service looks like:

```
POLY_ID: 41
PRCL_ID: 015034021
ADDR_STR_NAME: PINE
PRCL_ADDR: 247 PINE ST
ADDR_STR_TYPE: ST
ADDR_UNIT_TYPE:
ADDR_UNIT_NBR:
ADDR_FLOOR:
ADDR_NBR: 1
```
Number should be 247, not 1.
