### PR TITLE
Remove duplicated use of TASE2_NIMETUS_LIIGIGA in both district and city

### DIFF
--- a/sources/ee/countrywide.json
+++ b/sources/ee/countrywide.json
@@ -29,7 +29,6 @@
                     "city": {
                         "function": "join",
                         "fields": [
-                            "TASE2_NIMETUS_LIIGIGA",
                             "TASE3_NIMETUS_LIIGIGA",
                             "TASE4_NIMETUS_LIIGIGA"
                         ],


### PR DESCRIPTION
TASE2_NIMETUS_LIIGIGA currently is used in both the district field and as the first element in the city field (alongside levels 3 and 4). This seems unintentional and it should only appear in the one of those fields.

Given the level descriptions of the Estonian levels from the source (copied below): https://geoportaal.maaamet.ee/eng/spatial-data/address-data-p313.html

it seems that the OA hierarchy of region->district->city should then map to Estonian Level1 -> Level2 -> Level3/4.

Address components

| Level | Name | Probable match in Google component type |
| ----- | ---- | ------ |
| 1. | County | administrative_area_level_1 |
| 2. | Administrative unit (city, rural municipality) | administrative_area_level_2 |
| 3. | Settlement unit (village, borough) or City district | sublocality |
| 4. | Address area (mainly old gardening cooperatives, where houses are numbered randomly) | neighborhood? |
| 5. | Thouroughfare (street, road alley etc) | route |
| 6. | Address object name (place name, name of a cadastral parcel or building – used mainly in rural areas) | premise? |
| 7. | Address number (number of a building or cadastral parcel) | street_number |
| 8. | Building part number (number of apartment or other part of the building) | room? Not used in geocoding or maps |

