### PR TITLE
update: us_wa_city_of_seattle.json

### DIFF
--- a/sources/us/wa/city_of_seattle.json
+++ b/sources/us/wa/city_of_seattle.json
@@ -22,8 +22,8 @@
             {
                 "name": "city",
                 "protocol": "ESRI",
-                "data": "https://services.arcgis.com/ZOyb2t4B0UYuYNYH/arcgis/rest/services/TRANSPO_MAFDAP_PV/FeatureServer/1",
-                "website": "https://data.seattle.gov/dataset/Addresses-MAF-/y8kz-x5b5",
+                "data": "https://services.arcgis.com/ZOyb2t4B0UYuYNYH/arcgis/rest/services/TRANSPO_MAFDAP_PV/FeatureServer/0",
+                "website": "https://data.seattle.gov/dataset/Addresses-MAF-/9drs-d4jm/about_data",
                 "conform": {
                     "format": "geojson",
                     "id": "MAF_ID",


### PR DESCRIPTION
Updating the Seattle MAF address URLs. Both source and about/website was outdated and was no longer available. Updated to the most recent ones. Everything else remains the same.

Closes #7309 