### PR TITLE
us-id-bonneville fixing server link

### DIFF
--- a/sources/us/id/bonneville.json
+++ b/sources/us/id/bonneville.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://bonneville.esriemcs.com/arcgis/rest/services/BC_Address/MapServer/0",
+                "data": "https://bonneville.esriemcs.com/arcgis/rest/services/BC_Address/FeatureServer/0",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",


### PR DESCRIPTION
Address source currently is mapped to MapServer, changing the same to FeatureServer. No other changes.