### PR TITLE
Update Webster County, IA

### DIFF
--- a/sources/us/ia/webster.json
+++ b/sources/us/ia/webster.json
@@ -14,37 +14,54 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Webster/Address_94.zip",
+                "data": "https://github.com/user-attachments/files/16607877/shp_Address_Points.zip",
                 "license": {
                     "text": "Public Domain",
                     "attribution": false,
                     "share-alike": false
                 },
-                "year": "2012?",
-                "protocol": "ftp",
+                "year": "2024",
+                "protocol": "http",
                 "compression": "zip",
                 "conform": {
-                    "number": {
-                        "function": "regexp",
-                        "field": "address",
-                        "pattern": "^([0-9]+)"
-                    },
-                    "street": {
-                        "function": "regexp",
-                        "field": "address",
-                        "pattern": "^(?:[0-9]+ )(.*)",
-                        "replace": "$1"
-                    },
-                    "unit": {
-                        "function": "regexp",
-                        "field": "address",
-                        "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
-                        "replace": "$1"
-                    },
-                    "city": "POSTAL_COM",
-                    "district": "COUNTY",
-                    "region": "STATE",
-                    "postcode": "ZIP_CODE",
+                    "number": [
+                        "AddNum_Pre",
+                        "Add_Number",
+                        "AddNum_suf"
+                    ],
+                    "street": [
+                        "StN_PreMod",
+                        "StN_PreDir",
+                        "StN_PreTyp",
+                        "StN_PreSep",
+                        "StreetName",
+                        "StN_PosTyp",
+                        "StN_PosDir",
+                        "StN_PosMod"
+                    ],
+                    "unit": "Unit",
+                    "city": "Post_Comm",
+                    "district": "County",
+                    "region": "State",
+                    "postcode": "Post_Code",
+                    "format": "shapefile"
+                }
+            }
+        ],
+        "parcels": [
+            {
+                "name": "county",
+                "data": "https://github.com/user-attachments/files/16607876/shp_Parcel_Poly.zip",
+                "license": {
+                    "text": "Public Domain",
+                    "attribution": false,
+                    "share-alike": false
+                },
+                "year": "2024",
+                "protocol": "http",
+                "compression": "zip",
+                "conform": {
+                    "pid": "PIN",
                     "format": "shapefile"
                 }
             }


### PR DESCRIPTION
Shapefiles exported from the [Iowa GIS Data Repository](https://iowagisdata.org/) (data uploaded directly from Webster County)
[shp_Parcel_Poly.zip](https://github.com/user-attachments/files/16607876/shp_Parcel_Poly.zip)
[shp_Address_Points.zip](https://github.com/user-attachments/files/16607877/shp_Address_Points.zip)
