### PR TITLE
Add Black Hawk County, IA

### DIFF
--- a/sources/us/ia/black_hawk.json
+++ b/sources/us/ia/black_hawk.json
@@ -1,0 +1,79 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "19013",
+            "name": "Black Hawk County",
+            "state": "Iowa"
+        },
+        "country": "us",
+        "state": "ia",
+        "county": "Black Hawk"
+    },
+    "schema": 2,
+    "layers": {
+        "addresses": [
+            {
+                "name": "county",
+                "data": "https://github.com/user-attachments/files/16609191/BlackHawkIAParcelPts.gdb.zip",
+                "license": {
+                    "text": "Public Domain",
+                    "attribution": false,
+                    "share-alike": false
+                },
+                "year": "2024",
+                "protocol": "http",
+                "compression": "zip",
+                "conform": {
+                    "number": {
+                        "function": "prefixed_number",
+                        "field": "propertyad"
+                    },
+                    "street": {
+                        "function": "postfixed_street",
+                        "field": "propertyad"
+                    },
+                    "unit": "Unit",
+                    "city": {
+                        "function": "regexp",
+                        "field": "property_2",
+                        "pattern": "^(.+)(?:,\\sIA\\s\\d{5})$",
+                        "replace": "$1"
+                    },
+                    "region": {
+                        "function": "regexp",
+                        "field": "property_2",
+                        "pattern": "^(?:.+,\\s)(IA)(?:\\s\\d{5})$",
+                        "replace": "$1"
+                    },
+                    "postcode": {
+                        "function": "regexp",
+                        "field": "property_2",
+                        "pattern": "^(?:.+,\\sIA\\s)(\\d{5})$",
+                        "replace": "$1"
+                    },
+                    "format": "gdb",
+                    "layer": "parcelpts"
+                }
+            }
+        ],
+        "parcels": [
+            {
+                "name": "county",
+                "data": "https://github.com/user-attachments/files/16609407/BlackHawkIAParcels.gdb.zip",
+                "license": {
+                    "text": "Public Domain",
+                    "attribution": false,
+                    "share-alike": false
+                },
+                "year": "2024",
+                "protocol": "http",
+                "compression": "zip",
+                "conform": {
+                    "pid": "PIN",
+                    "format": "gdb",
+                    "layer": "parcel"
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Shapefiles exported from the [Iowa GIS Data Repository](https://iowagisdata.org/) (data uploaded directly from Black Hawk County)
[BlackHawkIAParcels.gdb.zip](https://github.com/user-attachments/files/16609407/BlackHawkIAParcels.gdb.zip)
[BlackHawkIAParcelPts.gdb.zip](https://github.com/user-attachments/files/16609191/BlackHawkIAParcelPts.gdb.zip)