### PR TITLE
Add Clayton County, IA

### DIFF
--- a/sources/us/ia/clayton.json
+++ b/sources/us/ia/clayton.json
@@ -1,0 +1,64 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "19043",
+            "name": "Clayton County",
+            "state": "Iowa"
+        },
+        "country": "us",
+        "state": "ia",
+        "county": "Clayton"
+    },
+    "schema": 2,
+    "layers": {
+        "addresses": [
+            {
+                "name": "county",
+                "data": "https://github.com/user-attachments/files/16609299/PARCELDATA_04032024.zip",
+                "license": {
+                    "text": "Public Domain",
+                    "attribution": false,
+                    "share-alike": false
+                },
+                "year": "2024",
+                "protocol": "http",
+                "compression": "zip",
+                "conform": {
+                    "number": "SitusStree",
+                    "street": [
+                        "SitusPreDi",
+                        "SitusStr_1",
+                        "SitusStr_2",
+                        "SitusPostD"
+                    ],
+                    "unit": [
+                        "SitusUnitT",
+                        "SitusUnit"
+                    ],
+                    "city": "SitusCityN",
+                    "region": "SitusState",
+                    "postcode": "SitusPosta",
+                    "format": "shapefile"
+                }
+            }
+        ],
+        "parcels": [
+            {
+                "name": "county",
+                "data": "https://github.com/user-attachments/files/16609299/PARCELDATA_04032024.zip",
+                "license": {
+                    "text": "Public Domain",
+                    "attribution": false,
+                    "share-alike": false
+                },
+                "year": "2024",
+                "protocol": "http",
+                "compression": "zip",
+                "conform": {
+                    "pid": "PIN",
+                    "format": "shapefile"
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Shapefiles exported from the [Iowa GIS Data Repository](https://iowagisdata.org/) (data uploaded directly from Clayton County)
[PARCELDATA_04032024.zip](https://github.com/user-attachments/files/16609299/PARCELDATA_04032024.zip)