### PR TITLE
Add Jackson County, IA

### DIFF
--- a/sources/us/ia/jackson.json
+++ b/sources/us/ia/jackson.json
@@ -1,0 +1,69 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "19097",
+            "name": "Jackson County",
+            "state": "Iowa"
+        },
+        "country": "us",
+        "state": "ia",
+        "county": "Jackson"
+    },
+    "schema": 2,
+    "layers": {
+        "addresses": [
+            {
+                "name": "county",
+                "data": "https://github.com/user-attachments/files/16620006/Site_structure_points_1222.zip",
+                "license": {
+                    "text": "Public Domain",
+                    "attribution": false,
+                    "share-alike": false
+                },
+                "year": "2022",
+                "protocol": "http",
+                "compression": "zip",
+                "conform": {
+                    "number": [
+                        "AddNum_Pre",
+                        "Add_Number",
+                        "AddNum_Suf"
+                    ],
+                    "street": [
+                        "StN_PreMod",
+                        "StN_PreDir",
+                        "StN_PreTyp",
+                        "StreetName",
+                        "StN_PosTyp",
+                        "StN_PosDir",
+                        "StN_PosMod"
+                    ],
+                    "unit": "Unit",
+                    "city": "Post_Comm",
+                    "district": "County",
+                    "region": "State",
+                    "postcode": "Post_Code",
+                    "format": "shapefile"
+                }
+            }
+        ],
+        "parcels": [
+            {
+                "name": "county",
+                "data": "https://github.com/user-attachments/files/16619955/parcels_0724.zip",
+                "license": {
+                    "text": "Public Domain",
+                    "attribution": false,
+                    "share-alike": false
+                },
+                "year": "2024",
+                "protocol": "http",
+                "compression": "zip",
+                "conform": {
+                    "pid": "PIN",
+                    "format": "shapefile"
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Shapefiles exported from the [Iowa GIS Data Repository](https://iowagisdata.org/) (data uploaded directly from Jackson County)
[parcels_0724.zip](https://github.com/user-attachments/files/16619955/parcels_0724.zip)
[Site_structure_points_1222.zip](https://github.com/user-attachments/files/16620006/Site_structure_points_1222.zip)