### PR TITLE
de/he/city_of_frankfurtammain data update

### DIFF
--- a/sources/de/he/city_of_frankfurtammain.json
+++ b/sources/de/he/city_of_frankfurtammain.json
@@ -16,22 +16,25 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://services.arcgis.com/OLiydejKCZTGhvWg/arcgis/rest/services/Frankfurt_am_Main_Hauskoordinaten/FeatureServer/0",
-                "website": "http://www.offenedaten.frankfurt.de/",
+                "data": "https://offenedaten.frankfurt.de/dataset/9c902fd2-dd17-40cc-9fab-52c9c28aea3c/resource/59eae6ec-8788-4347-8760-257f50aaced7/download/adressen.csv",
+                "website": "https://www.offenedaten.frankfurt.de/",
                 "license": {
-                    "url": "http://www.govdata.de/dl-de/by-2-0",
+                    "url": "https://www.govdata.de/dl-de/by-1-0",
                     "text": "Datenlizenz Deutschland Namensnennung",
                     "attribution": true,
                     "share-alike": false,
                     "attribution name": "Stadtvermessungsamt Frankfurt am Main"
                 },
-                "protocol": "ESRI",
                 "conform": {
-                    "format": "geojson",
+                    "format": "csv",
+                    "csvsplit": ";",
+                    "srs": "EPSG:10288",
                     "city": "Field16",
                     "street": "Field14",
                     "number": "Field10",
-                    "postcode": "Field15"
+                    "postcode": "Field15",
+                    "lat": "Field13",
+                    "lon": "Field12"
                 }
             }
         ]

--- a/sources/de/he/city_of_frankfurtammain.json
+++ b/sources/de/he/city_of_frankfurtammain.json
@@ -29,6 +29,7 @@
                 "conform": {
                     "format": "csv",
                     "csvsplit": ";",
+                    "encoding": "latin-1",
                     "srs": "EPSG:10288",
                     "city": "Field16",
                     "street": "Field14",

--- a/sources/de/he/city_of_frankfurtammain.json
+++ b/sources/de/he/city_of_frankfurtammain.json
@@ -28,15 +28,16 @@
                 "protocol": "http",
                 "conform": {
                     "format": "csv",
+                    "headers": -1,
                     "csvsplit": ";",
                     "encoding": "latin-1",
                     "srs": "EPSG:10288",
-                    "city": "Field16",
-                    "street": "Field14",
-                    "number": "Field10",
-                    "postcode": "Field15",
-                    "lat": "Field13",
-                    "lon": "Field12"
+                    "city": "COLUMN16",
+                    "street": "COLUMN14",
+                    "number": "COLUMN10",
+                    "postcode": "COLUMN15",
+                    "lat": "COLUMN13",
+                    "lon": "COLUMN12"
                 }
             }
         ]

--- a/sources/de/he/city_of_frankfurtammain.json
+++ b/sources/de/he/city_of_frankfurtammain.json
@@ -25,6 +25,7 @@
                     "share-alike": false,
                     "attribution name": "Stadtvermessungsamt Frankfurt am Main"
                 },
+                "protocol": "http",
                 "conform": {
                     "format": "csv",
                     "csvsplit": ";",


### PR DESCRIPTION
The arcgis service seems to be dead so I replaced it with the latest csv data from the city website. I also noticed that the license was actually listed as dl-de/by-1-0 rather than 2 so updated that as well.

https://www.offenedaten.frankfurt.de/dataset/hauskoordinaten-franfurt