### PR TITLE
au/qld/statewide change buildings source to generated dataset

### DIFF
--- a/sources/au/qld/README.statewide.md
+++ b/sources/au/qld/README.statewide.md
@@ -13,6 +13,6 @@ You will then receive an email with the download link.
 
 [Building areas - Queensland](http://qldspatial.information.qld.gov.au/catalogue/custom/detail.page?fid={BC24B68C-50D2-41E8-B0AE-FF4EB2913FDA})
 
-    curl 'https://spatial.information.qld.gov.au/arcgis/sharing/servers/0c54a850c61240c284e7a0651766a46f/rest/services/QSC/ClipZipShip/GPServer/ClipZipShip/submitJob?f=json&env%3AoutSR=102100&Layers_to_Clip=%5B%22Building%20areas%22%5D&Feature_Format=File%20Geodatabase%20-%20GDB%20-%20.gdb&Spatial_Reference=Same%20As%20Input&To_Email=USER%40EXAMPLE.COM&Prepackaged_Data_URLs=&Output_Title=Extract'
+    curl 'https://spatial.information.qld.gov.au/arcgis/sharing/servers/0c54a850c61240c284e7a0651766a46f/rest/services/QSC/ClipZipShip/GPServer/ClipZipShip/submitJob?f=json&env%3AoutSR=102100&Layers_to_Clip=%5B%22Generated%20building%20outlines%22%5D&Feature_Format=File%20Geodatabase%20-%20GDB%20-%20.gdb&Spatial_Reference=Same%20As%20Input&To_Email=USER%40EXAMPLE.COM&Prepackaged_Data_URLs=&Output_Title=Extract'
 
 You will then receive an email with the download link.

--- a/sources/au/qld/README.statewide.md
+++ b/sources/au/qld/README.statewide.md
@@ -11,7 +11,7 @@ You will then receive an email with the download link.
 
 ## Buildings
 
-[Building areas - Queensland](http://qldspatial.information.qld.gov.au/catalogue/custom/detail.page?fid={BC24B68C-50D2-41E8-B0AE-FF4EB2913FDA})
+There are two building datasets available from the Queensland Government, [Building areas - Queensland](http://qldspatial.information.qld.gov.au/catalogue/custom/detail.page?fid={BC24B68C-50D2-41E8-B0AE-FF4EB2913FDA}) which only includes large footprint buildings but has accurate geometries, and [Generated building outlines - Queensland](http://qldspatial.information.qld.gov.au/catalogue/custom/search.page?q=%22Generated%20building%20outlines%20-%20Queensland%22) which includes all buildings but has less accurate geometries. We have selected the latter to provide better coverage.
 
     curl 'https://spatial.information.qld.gov.au/arcgis/sharing/servers/0c54a850c61240c284e7a0651766a46f/rest/services/QSC/ClipZipShip/GPServer/ClipZipShip/submitJob?f=json&env%3AoutSR=102100&Layers_to_Clip=%5B%22Generated%20building%20outlines%22%5D&Feature_Format=File%20Geodatabase%20-%20GDB%20-%20.gdb&Spatial_Reference=Same%20As%20Input&To_Email=USER%40EXAMPLE.COM&Prepackaged_Data_URLs=&Output_Title=Extract'
 

--- a/sources/au/qld/statewide.json
+++ b/sources/au/qld/statewide.json
@@ -72,10 +72,12 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/uploads/andrewharvey-openaddr/562a23/DP_QLD_BUILDING_AREAS.zip",
-                "website": "http://qldspatial.information.qld.gov.au/catalogue/custom/detail.page?fid={BC24B68C-50D2-41E8-B0AE-FF4EB2913FDA}",
+                "data": "https://www.alantgeo.com.au/share/DP_QLD_BUILDING_AREAS.zip",
+                "website": "http://qldspatial.information.qld.gov.au/catalogue/custom/search.page?q=%22Generated%20building%20outlines%20-%20Queensland%22",
                 "conform": {
-                    "format": "shapefile"
+                    "format": "gdb",
+                    "file": "DP_QLD_BUILDING_AREAS.gdb",
+                    "layer": "Generated_building_outlines"
                 },
                 "compression": "zip",
                 "license": {

--- a/sources/au/qld/statewide.json
+++ b/sources/au/qld/statewide.json
@@ -76,7 +76,7 @@
                 "website": "http://qldspatial.information.qld.gov.au/catalogue/custom/search.page?q=%22Generated%20building%20outlines%20-%20Queensland%22",
                 "conform": {
                     "format": "gdb",
-                    "file": "DP_QLD_BUILDING_AREAS.gdb",
+                    "file": "data.gdb",
                     "layer": "Generated_building_outlines"
                 },
                 "compression": "zip",

--- a/sources/au/qld/statewide.json
+++ b/sources/au/qld/statewide.json
@@ -76,7 +76,6 @@
                 "website": "http://qldspatial.information.qld.gov.au/catalogue/custom/search.page?q=%22Generated%20building%20outlines%20-%20Queensland%22",
                 "conform": {
                     "format": "gdb",
-                    "file": "data.gdb",
                     "layer": "Generated_building_outlines"
                 },
                 "compression": "zip",


### PR DESCRIPTION
This change swaps out one dataset for another. The previous dataset only included a small subset of buildings with large footprints. The new dataset includes all buildings, although has less accurate geometries. Since we can only select one, I've opted for the complete coverage dataset.