### PR TITLE
Updating Japan Regional Data

### DIFF
--- a/sources/jp/aichi.json
+++ b/sources/jp/aichi.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/aichi.json
+++ b/sources/jp/aichi.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-aichi.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/23000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/aichi.json
+++ b/sources/jp/aichi.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/akita.json
+++ b/sources/jp/akita.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/akita.json
+++ b/sources/jp/akita.json
@@ -14,7 +14,7 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/5000-22.0a.zip",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/05000-22.0a.zip",
                 "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
                 "conform": {

--- a/sources/jp/akita.json
+++ b/sources/jp/akita.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-akita.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/5000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/akita.json
+++ b/sources/jp/akita.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/aomori.json
+++ b/sources/jp/aomori.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/aomori.json
+++ b/sources/jp/aomori.json
@@ -14,7 +14,7 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/2000-22.0a.zip",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/02000-22.0a.zip",
                 "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
                 "conform": {

--- a/sources/jp/aomori.json
+++ b/sources/jp/aomori.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-aomori.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/2000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/aomori.json
+++ b/sources/jp/aomori.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/chiba.json
+++ b/sources/jp/chiba.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/chiba.json
+++ b/sources/jp/chiba.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-chiba.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/12000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/chiba.json
+++ b/sources/jp/chiba.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/ehime.json
+++ b/sources/jp/ehime.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/ehime.json
+++ b/sources/jp/ehime.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/ehime.json
+++ b/sources/jp/ehime.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-ehime.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/38000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/fukui.json
+++ b/sources/jp/fukui.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/fukui.json
+++ b/sources/jp/fukui.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-fukui.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/18000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/fukui.json
+++ b/sources/jp/fukui.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/fukuoka.json
+++ b/sources/jp/fukuoka.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/fukuoka.json
+++ b/sources/jp/fukuoka.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/fukuoka.json
+++ b/sources/jp/fukuoka.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-fukuoka.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/40000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/fukushima.json
+++ b/sources/jp/fukushima.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-fukushima.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/7000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/fukushima.json
+++ b/sources/jp/fukushima.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/fukushima.json
+++ b/sources/jp/fukushima.json
@@ -14,7 +14,7 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/7000-22.0a.zip",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/07000-22.0a.zip",
                 "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
                 "conform": {

--- a/sources/jp/fukushima.json
+++ b/sources/jp/fukushima.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/gifu.json
+++ b/sources/jp/gifu.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/gifu.json
+++ b/sources/jp/gifu.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-gifu.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/21000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/gifu.json
+++ b/sources/jp/gifu.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/gunma.json
+++ b/sources/jp/gunma.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/gunma.json
+++ b/sources/jp/gunma.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/gunma.json
+++ b/sources/jp/gunma.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-gunma.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/10000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/hiroshima.json
+++ b/sources/jp/hiroshima.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/hiroshima.json
+++ b/sources/jp/hiroshima.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-hiroshima.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/34000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/hiroshima.json
+++ b/sources/jp/hiroshima.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/hokkaido.json
+++ b/sources/jp/hokkaido.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/hokkaido.json
+++ b/sources/jp/hokkaido.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-hokkaido.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/1000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/hokkaido.json
+++ b/sources/jp/hokkaido.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/hokkaido.json
+++ b/sources/jp/hokkaido.json
@@ -14,7 +14,7 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/1000-22.0a.zip",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/01000-22.0a.zip",
                 "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
                 "conform": {

--- a/sources/jp/hyogo.json
+++ b/sources/jp/hyogo.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/hyogo.json
+++ b/sources/jp/hyogo.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-hyogo.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/28000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/hyogo.json
+++ b/sources/jp/hyogo.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/ibaraki.json
+++ b/sources/jp/ibaraki.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/ibaraki.json
+++ b/sources/jp/ibaraki.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/ibaraki.json
+++ b/sources/jp/ibaraki.json
@@ -14,7 +14,7 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/8000-22.0a.zip",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/08000-22.0a.zip",
                 "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
                 "conform": {

--- a/sources/jp/ibaraki.json
+++ b/sources/jp/ibaraki.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-ibaraki.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/8000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/ishikawa.json
+++ b/sources/jp/ishikawa.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/ishikawa.json
+++ b/sources/jp/ishikawa.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-ishikawa.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/17000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/ishikawa.json
+++ b/sources/jp/ishikawa.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/iwate.json
+++ b/sources/jp/iwate.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-iwate.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/3000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/iwate.json
+++ b/sources/jp/iwate.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/iwate.json
+++ b/sources/jp/iwate.json
@@ -14,7 +14,7 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/3000-22.0a.zip",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/03000-22.0a.zip",
                 "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
                 "conform": {

--- a/sources/jp/iwate.json
+++ b/sources/jp/iwate.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/kagawa.json
+++ b/sources/jp/kagawa.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/kagawa.json
+++ b/sources/jp/kagawa.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-kagawa.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/37000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/kagawa.json
+++ b/sources/jp/kagawa.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/kagoshima.json
+++ b/sources/jp/kagoshima.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/kagoshima.json
+++ b/sources/jp/kagoshima.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-kagoshima.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/46000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/kagoshima.json
+++ b/sources/jp/kagoshima.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/kanagawa.json
+++ b/sources/jp/kanagawa.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/kanagawa.json
+++ b/sources/jp/kanagawa.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/kanagawa.json
+++ b/sources/jp/kanagawa.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-kanagawa.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/14000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/kochi.json
+++ b/sources/jp/kochi.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/kochi.json
+++ b/sources/jp/kochi.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-kochi.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/39000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/kochi.json
+++ b/sources/jp/kochi.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/kumamoto.json
+++ b/sources/jp/kumamoto.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/kumamoto.json
+++ b/sources/jp/kumamoto.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-kumamoto.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/43000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/kumamoto.json
+++ b/sources/jp/kumamoto.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/kyoto.json
+++ b/sources/jp/kyoto.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/kyoto.json
+++ b/sources/jp/kyoto.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-kyoto.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/26000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/kyoto.json
+++ b/sources/jp/kyoto.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/mie.json
+++ b/sources/jp/mie.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/mie.json
+++ b/sources/jp/mie.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-mie.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/24000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/mie.json
+++ b/sources/jp/mie.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/miyagi.json
+++ b/sources/jp/miyagi.json
@@ -14,7 +14,7 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/4000-22.0a.zip",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/04000-22.0a.zip",
                 "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
                 "conform": {

--- a/sources/jp/miyagi.json
+++ b/sources/jp/miyagi.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/miyagi.json
+++ b/sources/jp/miyagi.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-miyagi.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/4000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/miyagi.json
+++ b/sources/jp/miyagi.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/miyazaki.json
+++ b/sources/jp/miyazaki.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/miyazaki.json
+++ b/sources/jp/miyazaki.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-miyazaki.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/45000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/miyazaki.json
+++ b/sources/jp/miyazaki.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/nagano.json
+++ b/sources/jp/nagano.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/nagano.json
+++ b/sources/jp/nagano.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-nagano.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/20000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/nagano.json
+++ b/sources/jp/nagano.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/nagasaki.json
+++ b/sources/jp/nagasaki.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-nagasaki.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/42000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/nagasaki.json
+++ b/sources/jp/nagasaki.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/nagasaki.json
+++ b/sources/jp/nagasaki.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/nara.json
+++ b/sources/jp/nara.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/nara.json
+++ b/sources/jp/nara.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/nara.json
+++ b/sources/jp/nara.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-nara.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/29000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/niigata.json
+++ b/sources/jp/niigata.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-niigata.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/15000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/niigata.json
+++ b/sources/jp/niigata.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/niigata.json
+++ b/sources/jp/niigata.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/oita.json
+++ b/sources/jp/oita.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/oita.json
+++ b/sources/jp/oita.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/oita.json
+++ b/sources/jp/oita.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-oita.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/44000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/okayama.json
+++ b/sources/jp/okayama.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/okayama.json
+++ b/sources/jp/okayama.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/okayama.json
+++ b/sources/jp/okayama.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-okayama.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/33000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/okinawa.json
+++ b/sources/jp/okinawa.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/okinawa.json
+++ b/sources/jp/okinawa.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-okinawa.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/47000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/okinawa.json
+++ b/sources/jp/okinawa.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/osaka.json
+++ b/sources/jp/osaka.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/osaka.json
+++ b/sources/jp/osaka.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-osaka.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/27000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/osaka.json
+++ b/sources/jp/osaka.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/saga.json
+++ b/sources/jp/saga.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/saga.json
+++ b/sources/jp/saga.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-saga.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/41000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/saga.json
+++ b/sources/jp/saga.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/saitama.json
+++ b/sources/jp/saitama.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/saitama.json
+++ b/sources/jp/saitama.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/saitama.json
+++ b/sources/jp/saitama.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-saitama.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/11000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/shiga.json
+++ b/sources/jp/shiga.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/shiga.json
+++ b/sources/jp/shiga.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-shiga.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/25000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/shiga.json
+++ b/sources/jp/shiga.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/shimane.json
+++ b/sources/jp/shimane.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/shimane.json
+++ b/sources/jp/shimane.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-shimane.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/32000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/shimane.json
+++ b/sources/jp/shimane.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/shizuoka.json
+++ b/sources/jp/shizuoka.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/shizuoka.json
+++ b/sources/jp/shizuoka.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-shizuoka.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/22000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/shizuoka.json
+++ b/sources/jp/shizuoka.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/tochigi.json
+++ b/sources/jp/tochigi.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-tochigi.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/9000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/tochigi.json
+++ b/sources/jp/tochigi.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/tochigi.json
+++ b/sources/jp/tochigi.json
@@ -14,7 +14,7 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/9000-22.0a.zip",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/09000-22.0a.zip",
                 "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
                 "conform": {

--- a/sources/jp/tochigi.json
+++ b/sources/jp/tochigi.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/tokushima.json
+++ b/sources/jp/tokushima.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-tokushima.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/36000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/tokushima.json
+++ b/sources/jp/tokushima.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/tokushima.json
+++ b/sources/jp/tokushima.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/tokyo.json
+++ b/sources/jp/tokyo.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/tokyo.json
+++ b/sources/jp/tokyo.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-tokyo.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/13000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/tokyo.json
+++ b/sources/jp/tokyo.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/tottori.json
+++ b/sources/jp/tottori.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/tottori.json
+++ b/sources/jp/tottori.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-tottori.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/31000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/tottori.json
+++ b/sources/jp/tottori.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/toyama.json
+++ b/sources/jp/toyama.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/toyama.json
+++ b/sources/jp/toyama.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-toyama.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/16000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/toyama.json
+++ b/sources/jp/toyama.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/wakayama.json
+++ b/sources/jp/wakayama.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-wakayama.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/30000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/wakayama.json
+++ b/sources/jp/wakayama.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/wakayama.json
+++ b/sources/jp/wakayama.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/yamagata.json
+++ b/sources/jp/yamagata.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/yamagata.json
+++ b/sources/jp/yamagata.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-yamagata.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/6000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/yamagata.json
+++ b/sources/jp/yamagata.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/yamagata.json
+++ b/sources/jp/yamagata.json
@@ -14,7 +14,7 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/6000-22.0a.zip",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/06000-22.0a.zip",
                 "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
                 "conform": {

--- a/sources/jp/yamaguchi.json
+++ b/sources/jp/yamaguchi.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/yamaguchi.json
+++ b/sources/jp/yamaguchi.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-yamaguchi.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/35000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/yamaguchi.json
+++ b/sources/jp/yamaguchi.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/yamanashi.json
+++ b/sources/jp/yamanashi.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・丁目名 ",
+                    "street": "大字・丁目名",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",

--- a/sources/jp/yamanashi.json
+++ b/sources/jp/yamanashi.json
@@ -14,10 +14,9 @@
             {
                 "name": "state",
                 "protocol": "http",
-                "data": "https://data.openaddresses.io/cache/jp-yamanashi.zip",
-                "website": "http://nlftp.mlit.go.jp/isj/index.html",
+                "data": "https://nlftp.mlit.go.jp/isj/dls/data/22.0a/19000-22.0a.zip",
+                "website": "https://nlftp.mlit.go.jp/isj/index.html",
                 "compression": "zip",
-                "attribution": "Japanese Ministry of Land, Infrastructure and Transport",
                 "conform": {
                     "format": "csv",
                     "lat": "緯度",
@@ -32,12 +31,16 @@
                     },
                     "street": "大字・町丁目名",
                     "lon": "経度",
-                    "encoding": "SHIFT_JISX0213"
+                    "encoding": "SHIFT_JISX0213",
+                    "city": "市区町村名",
+                    "region": "都道府県名"
                 },
                 "license": {
-                    "url": "http://nlftp.mlit.go.jp/ksj/other/yakkan.html",
+                    "url": "https://nlftp.mlit.go.jp/ksj/other/agreement.html",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": false
+                    "share-alike": false,
+                    "attribution name": "Japanese Ministry of Land, Infrastructure and Transport"
                 }
             }
         ]

--- a/sources/jp/yamanashi.json
+++ b/sources/jp/yamanashi.json
@@ -29,7 +29,7 @@
                         ],
                         "separator": "-"
                     },
-                    "street": "大字・町丁目名",
+                    "street": "大字・丁目名 ",
                     "lon": "経度",
                     "encoding": "SHIFT_JISX0213",
                     "city": "市区町村名",


### PR DESCRIPTION
This updates all Japan regions to 2023 data, adds city and region columns, and fleshes out license details.

The data urls appears to be stable and will just need the versions bumped up each year.