### PR TITLE
Add ZIP Codes to Douglas County, WI

### DIFF
--- a/sources/us/wi/douglas.json
+++ b/sources/us/wi/douglas.json
@@ -24,7 +24,8 @@
                         "ADDR_SN",
                         "ADDR_ST",
                         "ADDR_SD"
-                    ]
+                    ],
+                    "postcode": "OBJECTID_12"
                 }
             }
         ],


### PR DESCRIPTION
It appears "OBJECTID_12" is actually the ZIP Code.