### PR TITLE
Propose Schema V3

### DIFF
--- a/schema/schema_v3/base.json
+++ b/schema/schema_v3/base.json
@@ -1,0 +1,222 @@
+{
+    "type": "object",
+    "if": {
+        "properties": {
+            "frequency": {
+                "const": "once"
+            }
+        }
+    },
+    "then": {
+        "required": [
+            "date"
+        ]
+    },
+    "else": {
+        "not": {
+            "required": [
+                "date"
+            ]
+        }
+    },
+    "required": [
+        "protocol",
+        "data"
+    ],
+    "properties": {
+        "protocol": {
+            "type": "string",
+            "enum": [
+                "http",
+                "ftp",
+                "esri"
+            ]
+        },
+        "data": {
+            "type": "string",
+            "description": "A URL referencing the dataset. This should point to the raw data and not a web portal. If there isn't a good URL for the source, process the file to the desired format, upload it to a third party file hosting service and ask for uploading that file to the cache which then gives you this URL.",
+            "minLength": 1
+        },
+        "website": {
+            "type": "string",
+            "description": "A URL referencing the data portal.",
+            "minLength": 1
+        },
+        "compression": {
+            "type": "string",
+            "enum": [
+                "zip"
+            ]
+        },
+        "license": {
+            "type": "object",
+            "if": {
+                "required": [
+                    "attribution_name"
+                ]
+            },
+            "then": {
+                "required": [
+                    "attribution"
+                ],
+                "properties": {
+                    "attribution": {
+                        "const": true
+                    }
+                }
+            },
+            "additionalProperties": false,
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "A fully qualified URL to a file (PDF or text document) of the full license of the source.",
+                    "minLength": 1
+                },
+                "text": {
+                    "type": "string",
+                    "description": "Short description of license terms, e.g. “CC BY 4.0”.",
+                    "minLength": 1
+                },
+                "attribution": {
+                    "type": "boolean",
+                    "description": "Is attribution to the copyright holder required? true if other attribution details are present, otherwise false."
+                },
+                "attribution_name": {
+                    "type": "string",
+                    "description": "Name of data copyright holder requiring attribution, e.g. “United Federation of Planets”.",
+                    "minLength": 1
+                },
+                "share-alike": {
+                    "type": "boolean",
+                    "description": "Must derivative works be licensed under the same or compatible terms as the original work?"
+                }
+            }
+        },
+        "contact": {
+            "type": "object",
+            "description": "Contact information for the dataset or provider.",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Full name of a specific contact person.",
+                    "minLength": 1
+                },
+                "title": {
+                    "type": "string",
+                    "description": "Title for the contact person, e.g. “GIS Coordinator“.",
+                    "minLength": 1
+                },
+                "phone": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "email": {
+                    "type": "string",
+                    "pattern": "/^\\S+@\\S+\\.\\S+$/"
+                },
+                "address": {
+                    "type": "string",
+                    "description": "Mailing address for the dataset provider.",
+                    "minLength": 1
+                }
+            }
+        },
+        "note": {
+            "description": "A human readable note about this layer.",
+            "oneOf": [
+                {
+                    "type": "string",
+                    "minLength": 1
+                },
+                {
+                    "type": "object"
+                }
+            ]
+        },
+        "language": {
+            "type": "string",
+            "description": "ISO 639-3 language code for the data.",
+            "pattern": "^[a-z]{3}$"
+        },
+        "date": {
+            "type": "object",
+            "description": "If frequency=once, the date of the data.",
+            "additionalProperties": false,
+            "required": [
+                "year"
+            ],
+            "properties": {
+                "year": {
+                    "type": "string",
+                    "pattern": "^\\d{4}$"
+                },
+                "month": {
+                    "type": "string",
+                    "pattern": "^(0?[1-9]|1[012])$"
+                },
+                "day": {
+                    "type": "string",
+                    "pattern": "^(0[1-9]|[12][0-9]|3[01])$"
+                }
+            }
+        },
+        "skip": {
+            "type": "boolean",
+            "description": "Skip running this source.",
+            "default": "false"
+        },
+        "frequency": {
+            "type": "string",
+            "description": "Frequency at which the source should be re-run.",
+            "default": "weekly",
+            "enum": [
+                "once",
+                "weekly",
+                "monthly"
+            ]
+        },
+        "test": {
+            "type": "object",
+            "required": [
+                "description",
+                "acceptance-tests"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "description": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "acceptance-tests": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "object",
+                        "required": [
+                            "description",
+                            "inputs",
+                            "expected"
+                        ],
+                        "additionalProperties": false,
+                        "properties": {
+                            "description": {
+                                "type": "string",
+                                "minLength": 1
+                            },
+                            "inputs": {
+                                "type": "object"
+                            },
+                            "expected": {
+                                "type": "object"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/schema/schema_v3/functions/chain.json
+++ b/schema/schema_v3/functions/chain.json
@@ -1,0 +1,50 @@
+{
+    "type": "object",
+    "required": [
+        "function",
+        "variable",
+        "functions"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "function": {
+            "type": "string",
+            "enum": [
+                "chain"
+            ]
+        },
+        "variable": {
+            "type": "string",
+            "pattern": "^.+$"
+        },
+        "functions": {
+            "type": "array",
+            "minItems": 2,
+            "items": {
+                "oneOf": [
+                    {
+                        "$ref": "regexp.json"
+                    },
+                    {
+                        "$ref": "postfixed_street.json"
+                    },
+                    {
+                        "$ref": "remove_prefix.json"
+                    },
+                    {
+                        "$ref": "remove_postfix.json"
+                    },
+                    {
+                        "$ref": "join.json"
+                    },
+                    {
+                        "$ref": "format.json"
+                    },
+                    {
+                        "$ref": "get.json"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/schema/schema_v3/functions/constant.json
+++ b/schema/schema_v3/functions/constant.json
@@ -1,0 +1,20 @@
+{
+    "type": "object",
+    "required": [
+        "function",
+        "value"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "function": {
+            "type": "string",
+            "enum": [
+                "constant"
+            ]
+        },
+        "value": {
+            "type": "string",
+            "pattern": "^.+$"
+        }
+    }
+}

--- a/schema/schema_v3/functions/first_non_empty.json
+++ b/schema/schema_v3/functions/first_non_empty.json
@@ -1,0 +1,24 @@
+{
+    "type": "object",
+    "required": [
+        "function",
+        "fields"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "function": {
+            "type": "string",
+            "enum": [
+                "first_non_empty"
+            ]
+        },
+        "fields": {
+            "type": "array",
+            "minItems": 2,
+            "items": {
+                "type": "string",
+                "pattern": "^.+$"
+            }
+        }
+    }
+}

--- a/schema/schema_v3/functions/format.json
+++ b/schema/schema_v3/functions/format.json
@@ -1,0 +1,29 @@
+{
+    "type": "object",
+    "required": [
+        "function",
+        "fields",
+        "format"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "function": {
+            "type": "string",
+            "enum": [
+                "format"
+            ]
+        },
+        "fields": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "string",
+                "pattern": "^.+$"
+            }
+        },
+        "format": {
+            "type": "string",
+            "pattern": "^.+$"
+        }
+    }
+}

--- a/schema/schema_v3/functions/get.json
+++ b/schema/schema_v3/functions/get.json
@@ -1,0 +1,25 @@
+{
+    "type": "object",
+    "required": [
+        "function",
+        "field",
+        "index"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "function": {
+            "type": "string",
+            "enum": [
+                "get"
+            ]
+        },
+        "field": {
+            "type": "string",
+            "pattern": "^.+$"
+        },
+        "index": {
+            "type": "integer",
+            "minimum": 0
+        }
+    }
+}

--- a/schema/schema_v3/functions/join.json
+++ b/schema/schema_v3/functions/join.json
@@ -1,0 +1,28 @@
+{
+    "type": "object",
+    "required": [
+        "function",
+        "fields"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "function": {
+            "type": "string",
+            "enum": [
+                "join"
+            ]
+        },
+        "fields": {
+            "type": "array",
+            "minItems": 2,
+            "items": {
+                "type": "string",
+                "pattern": "^.+$"
+            }
+        },
+        "separator": {
+            "type": "string",
+            "pattern": "^.+$"
+        }
+    }
+}

--- a/schema/schema_v3/functions/postfixed_street.json
+++ b/schema/schema_v3/functions/postfixed_street.json
@@ -1,0 +1,23 @@
+{
+    "type": "object",
+    "required": [
+        "function",
+        "field"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "function": {
+            "type": "string",
+            "enum": [
+                "postfixed_street"
+            ]
+        },
+        "field": {
+            "type": "string",
+            "pattern": "^.+$"
+        },
+        "may_contain_units": {
+            "type": "boolean"
+        }
+    }
+}

--- a/schema/schema_v3/functions/postfixed_unit.json
+++ b/schema/schema_v3/functions/postfixed_unit.json
@@ -1,0 +1,20 @@
+{
+    "type": "object",
+    "required": [
+        "function",
+        "field"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "function": {
+            "type": "string",
+            "enum": [
+                "postfixed_unit"
+            ]
+        },
+        "field": {
+            "type": "string",
+            "pattern": "^.+$"
+        }
+    }
+}

--- a/schema/schema_v3/functions/prefixed_number.json
+++ b/schema/schema_v3/functions/prefixed_number.json
@@ -1,0 +1,20 @@
+{
+    "type": "object",
+    "required": [
+        "function",
+        "field"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "function": {
+            "type": "string",
+            "enum": [
+                "prefixed_number"
+            ]
+        },
+        "field": {
+            "type": "string",
+            "pattern": "^.+$"
+        }
+    }
+}

--- a/schema/schema_v3/functions/regexp.json
+++ b/schema/schema_v3/functions/regexp.json
@@ -1,0 +1,29 @@
+{
+    "type": "object",
+    "required": [
+        "function",
+        "field",
+        "pattern"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "function": {
+            "type": "string",
+            "enum": [
+                "regexp"
+            ]
+        },
+        "field": {
+            "type": "string",
+            "pattern": "^.+$"
+        },
+        "pattern": {
+            "type": "string",
+            "pattern": "^.+$"
+        },
+        "replace": {
+            "type": "string",
+            "pattern": "^.+$"
+        }
+    }
+}

--- a/schema/schema_v3/functions/remove_postfix.json
+++ b/schema/schema_v3/functions/remove_postfix.json
@@ -1,0 +1,25 @@
+{
+    "type": "object",
+    "required": [
+        "function",
+        "field",
+        "field_to_remove"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "function": {
+            "type": "string",
+            "enum": [
+                "remove_postfix"
+            ]
+        },
+        "field": {
+            "type": "string",
+            "pattern": "^.+$"
+        },
+        "field_to_remove": {
+            "type": "string",
+            "pattern": "^.+$"
+        }
+    }
+}

--- a/schema/schema_v3/functions/remove_prefix.json
+++ b/schema/schema_v3/functions/remove_prefix.json
@@ -1,0 +1,25 @@
+{
+    "type": "object",
+    "required": [
+        "function",
+        "field",
+        "field_to_remove"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "function": {
+            "type": "string",
+            "enum": [
+                "remove_prefix"
+            ]
+        },
+        "field": {
+            "type": "string",
+            "pattern": "^.+$"
+        },
+        "field_to_remove": {
+            "type": "string",
+            "pattern": "^.+$"
+        }
+    }
+}

--- a/schema/schema_v3/geojson.json
+++ b/schema/schema_v3/geojson.json
@@ -1,0 +1,468 @@
+{
+    "$id": "geojson",
+    "title": "GeoJSON Object",
+    "type": "object",
+    "description": "This object represents a geometry, feature, or collection of features.",
+    "additionalProperties": true,
+    "required": [
+        "type"
+    ],
+    "properties": {
+        "type": {
+            "title": "Type",
+            "type": "string",
+            "description": "The type of GeoJSON object.",
+            "enum": [
+                "Point",
+                "MultiPoint",
+                "LineString",
+                "MultiLineString",
+                "Polygon",
+                "MultiPolygon",
+                "GeometryCollection",
+                "Feature",
+                "FeatureCollection"
+            ]
+        },
+        "crs": {
+            "title": "Coordinate Reference System (CRS)",
+            "description": "The coordinate reference system (CRS) of a GeoJSON object is determined by its `crs` member (referred to as the CRS object below). If an object has no crs member, then its parent or grandparent object's crs member may be acquired. If no crs member can be so acquired, the default CRS shall apply to the GeoJSON object.\n\n* The default CRS is a geographic coordinate reference system, using the WGS84 datum, and with longitude and latitude units of decimal degrees.\n\n* The value of a member named `crs` must be a JSON object (referred to as the CRS object below) or JSON null. If the value of CRS is null, no CRS can be assumed.\n\n* The crs member should be on the top-level GeoJSON object in a hierarchy (in feature collection, feature, geometry order) and should not be repeated or overridden on children or grandchildren of the object.\n\n* A non-null CRS object has two mandatory members: `type` and `properties`.\n\n* The value of the type member must be a string, indicating the type of CRS object.\n\n* The value of the properties member must be an object.\n\n* CRS shall not change coordinate ordering.",
+            "oneOf": [
+                {
+                    "type": "null"
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "type",
+                        "properties"
+                    ],
+                    "properties": {
+                        "type": {
+                            "title": "CRS Type",
+                            "type": "string",
+                            "description": "The value of the type member must be a string, indicating the type of CRS object.",
+                            "minLength": 1
+                        },
+                        "properties": {
+                            "title": "CRS Properties",
+                            "type": "object"
+                        }
+                    }
+                }
+            ],
+            "not": {
+                "anyOf": [
+                    {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "name"
+                                ]
+                            },
+                            "properties": {
+                                "not": {
+                                    "required": [
+                                        "name"
+                                    ],
+                                    "properties": {
+                                        "name": {
+                                            "type": "string",
+                                            "minLength": 1
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "link"
+                                ]
+                            },
+                            "properties": {
+                                "not": {
+                                    "title": "Link Object",
+                                    "type": "object",
+                                    "required": [
+                                        "href"
+                                    ],
+                                    "properties": {
+                                        "href": {
+                                            "title": "href",
+                                            "type": "string",
+                                            "description": "The value of the required `href` member must be a dereferenceable URI."
+                                        },
+                                        "type": {
+                                            "title": "Link Object Type",
+                                            "type": "string",
+                                            "description": "The value of the optional `type` member must be a string that hints at the format used to represent CRS parameters at the provided URI. Suggested values are: `proj4`, `ogcwkt`, `esriwkt`, but others can be used."
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "bbox": {
+            "title": "Bounding Box",
+            "type": "array",
+            "description": "To include information on the coordinate range for geometries, features, or feature collections, a GeoJSON object may have a member named `bbox`. The value of the bbox member must be a 2*n array where n is the number of dimensions represented in the contained geometries, with the lowest values for all axes followed by the highest values. The axes order of a bbox follows the axes order of geometries. In addition, the coordinate reference system for the bbox is assumed to match the coordinate reference system of the GeoJSON object of which it is a member.",
+            "minItems": 4,
+            "items": {
+                "type": "number"
+            }
+        }
+    },
+    "oneOf": [
+        {
+            "title": "Point",
+            "description": "For type `Point`, the `coordinates` member must be a single position.",
+            "required": [
+                "coordinates"
+            ],
+            "properties": {
+                "type": {
+                    "enum": [
+                        "Point"
+                    ]
+                },
+                "coordinates": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/coordinates"
+                        },
+                        {
+                            "$ref": "#/definitions/position"
+                        }
+                    ]
+                }
+            },
+            "allOf": [
+                {
+                    "$ref": "#/definitions/geometry"
+                }
+            ]
+        },
+        {
+            "title": "Multi Point Geometry",
+            "description": "For type `MultiPoint`, the `coordinates` member must be an array of positions.",
+            "required": [
+                "coordinates"
+            ],
+            "properties": {
+                "type": {
+                    "enum": [
+                        "MultiPoint"
+                    ]
+                },
+                "coordinates": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/coordinates"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/position"
+                            }
+                        }
+                    ]
+                }
+            },
+            "allOf": [
+                {
+                    "$ref": "#/definitions/geometry"
+                }
+            ]
+        },
+        {
+            "title": "Line String",
+            "description": "For type `LineString`, the `coordinates` member must be an array of two or more positions.\n\nA LinearRing is closed LineString with 4 or more positions. The first and last positions are equivalent (they represent equivalent points). Though a LinearRing is not explicitly represented as a GeoJSON geometry type, it is referred to in the Polygon geometry type definition.",
+            "required": [
+                "coordinates"
+            ],
+            "properties": {
+                "type": {
+                    "enum": [
+                        "LineString"
+                    ]
+                },
+                "coordinates": {
+                    "$ref": "#/definitions/lineStringCoordinates"
+                }
+            },
+            "allOf": [
+                {
+                    "$ref": "#/definitions/geometry"
+                }
+            ]
+        },
+        {
+            "title": "MultiLineString",
+            "description": "For type `MultiLineString`, the `coordinates` member must be an array of LineString coordinate arrays.",
+            "required": [
+                "coordinates"
+            ],
+            "properties": {
+                "type": {
+                    "enum": [
+                        "MultiLineString"
+                    ]
+                },
+                "coordinates": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/coordinates"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/lineStringCoordinates"
+                            }
+                        }
+                    ]
+                }
+            },
+            "allOf": [
+                {
+                    "$ref": "#/definitions/geometry"
+                }
+            ]
+        },
+        {
+            "title": "Polygon",
+            "description": "For type `Polygon`, the `coordinates` member must be an array of LinearRing coordinate arrays. For Polygons with multiple rings, the first must be the exterior ring and any others must be interior rings or holes.",
+            "required": [
+                "coordinates"
+            ],
+            "properties": {
+                "type": {
+                    "enum": [
+                        "Polygon"
+                    ]
+                },
+                "coordinates": {
+                    "$ref": "#/definitions/polygonCoordinates"
+                }
+            },
+            "allOf": [
+                {
+                    "$ref": "#/definitions/geometry"
+                }
+            ]
+        },
+        {
+            "title": "Multi-Polygon Geometry",
+            "description": "For type `MultiPolygon`, the `coordinates` member must be an array of Polygon coordinate arrays.",
+            "required": [
+                "coordinates"
+            ],
+            "properties": {
+                "type": {
+                    "enum": [
+                        "MultiPolygon"
+                    ]
+                },
+                "coordinates": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/coordinates"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/polygonCoordinates"
+                            }
+                        }
+                    ]
+                }
+            },
+            "allOf": [
+                {
+                    "$ref": "#/definitions/geometry"
+                }
+            ]
+        },
+        {
+            "title": "Geometry Collection",
+            "description": "A GeoJSON object with type `GeometryCollection` is a geometry object which represents a collection of geometry objects.\n\nA geometry collection must have a member with the name `geometries`. The value corresponding to `geometries` is an array. Each element in this array is a GeoJSON geometry object.",
+            "required": [
+                "geometries"
+            ],
+            "properties": {
+                "type": {
+                    "enum": [
+                        "GeometryCollection"
+                    ]
+                },
+                "geometries": {
+                    "title": "Geometries",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/geometry"
+                    }
+                }
+            },
+            "allOf": [
+                {
+                    "$ref": "#/definitions/geometry"
+                }
+            ]
+        },
+        {
+            "$ref": "#/definitions/feature"
+        },
+        {
+            "title": "Feature Collection",
+            "description": "A GeoJSON object with the type `FeatureCollection` is a feature collection object.\n\nAn object of type `FeatureCollection` must have a member with the name `features`. The value corresponding to `features` is an array. Each element in the array is a feature object as defined above.",
+            "required": [
+                "features"
+            ],
+            "properties": {
+                "type": {
+                    "enum": [
+                        "FeatureCollection"
+                    ]
+                },
+                "features": {
+                    "title": "Features",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/feature"
+                    }
+                }
+            }
+        }
+    ],
+    "definitions": {
+        "coordinates": {
+            "title": "Coordinates",
+            "type": "array",
+            "items": {
+                "oneOf": [
+                    {
+                        "type": "array"
+                    },
+                    {
+                        "type": "number"
+                    }
+                ]
+            }
+        },
+        "geometry": {
+            "title": "Geometry",
+            "description": "A geometry is a GeoJSON object where the type member's value is one of the following strings: `Point`, `MultiPoint`, `LineString`, `MultiLineString`, `Polygon`, `MultiPolygon`, or `GeometryCollection`.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "enum": [
+                        "Point",
+                        "MultiPoint",
+                        "LineString",
+                        "MultiLineString",
+                        "Polygon",
+                        "MultiPolygon",
+                        "GeometryCollection"
+                    ]
+                }
+            }
+        },
+        "feature": {
+            "title": "Feature",
+            "description": "A GeoJSON object with the type `Feature` is a feature object.\n\n* A feature object must have a member with the name `geometry`. The value of the geometry member is a geometry object as defined above or a JSON null value.\n\n* A feature object must have a member with the name `properties`. The value of the properties member is an object (any JSON object or a JSON null value).\n\n* If a feature has a commonly used identifier, that identifier should be included as a member of the feature object with the name `id`.",
+            "required": [
+                "geometry",
+                "properties"
+            ],
+            "type": "object",
+            "properties": {
+                "type": {
+                    "enum": [
+                        "Feature"
+                    ]
+                },
+                "geometry": {
+                    "title": "Geometry",
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/geometry"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "properties": {
+                    "title": "Properties",
+                    "oneOf": [
+                        {
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "id": {}
+            }
+        },
+        "linearRingCoordinates": {
+            "title": "Linear Ring Coordinates",
+            "description": "A LinearRing is closed LineString with 4 or more positions. The first and last positions are equivalent (they represent equivalent points). Though a LinearRing is not explicitly represented as a GeoJSON geometry type, it is referred to in the Polygon geometry type definition.",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/lineStringCoordinates"
+                },
+                {
+                    "type": "array",
+                    "minItems": 4
+                }
+            ]
+        },
+        "lineStringCoordinates": {
+            "title": "Line String Coordinates",
+            "description": "For type `LineString`, the `coordinates` member must be an array of two or more positions.",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/coordinates"
+                },
+                {
+                    "type": "array",
+                    "minLength": 2,
+                    "items": {
+                        "$ref": "#/definitions/position"
+                    }
+                }
+            ]
+        },
+        "polygonCoordinates": {
+            "title": "Polygon Coordinates",
+            "description": "For type `Polygon`, the `coordinates` member must be an array of LinearRing coordinate arrays. For Polygons with multiple rings, the first must be the exterior ring and any others must be interior rings or holes.",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/coordinates"
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/linearRingCoordinates"
+                    }
+                }
+            ]
+        },
+        "position": {
+            "title": "Position",
+            "type": "array",
+            "description": "A position is the fundamental geometry construct. The `coordinates` member of a geometry object is composed of one position (in the case of a Point geometry), an array of positions (LineString or MultiPoint geometries), an array of arrays of positions (Polygons, MultiLineStrings), or a multidimensional array of positions (MultiPolygon).\n\nA position is represented by an array of numbers. There must be at least two elements, and may be more. The order of elements must follow x, y, z order (easting, northing, altitude for coordinates in a projected coordinate reference system, or longitude, latitude, altitude for coordinates in a geographic coordinate reference system). Any number of additional elements are allowed -- interpretation and meaning of additional elements is beyond the scope of this specification.",
+            "minItems": 2,
+            "items": {
+                "type": "number"
+            }
+        }
+    }
+}

--- a/schema/schema_v3/layers/addresses.json
+++ b/schema/schema_v3/layers/addresses.json
@@ -1,0 +1,388 @@
+{
+    "type": "object",
+    "required": [
+        "conform"
+    ],
+    "properties": {
+        "conform": {
+            "type": "object",
+            "allOf": [
+                {
+                    "if": {
+                        "properties": {
+                            "format": {
+                                "const": "csv"
+                            }
+                        }
+                    },
+                    "then": {
+                        "required": [
+                            "lon",
+                            "lat"
+                        ]
+                    },
+                    "else": {
+                        "not": {
+                            "required": [
+                                "lon",
+                                "lat",
+                                "csvsplit",
+                                "headers",
+                                "skiplines"
+                            ]
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "format": {
+                                "const": "gdb"
+                            }
+                        }
+                    },
+                    "then": {
+                        "required": [
+                            "layer"
+                        ]
+                    },
+                    "else": {
+                        "not": {
+                            "required": [
+                                "layer"
+                            ]
+                        }
+                    }
+                }
+            ],
+            "additionalProperties": false,
+            "required": [
+                "format",
+                "number",
+                "street"
+            ],
+            "properties": {
+                "format": {
+                    "type": "string",
+                    "enum": [
+                        "geojson",
+                        "shapefile",
+                        "shapefile-polygon",
+                        "gdb",
+                        "xml",
+                        "csv"
+                    ]
+                },
+                "addrtype": {
+                    "type": "string",
+                    "description": "industrial, residential, etc.",
+                    "minLength": 1
+                },
+                "accuracy": {
+                    "type": "integer",
+                    "description": "0=User Corrected, 1=Rooftop, 2=On Parcel, 3=Driveway, 4=Interpolation, 5=Unknown",
+                    "minimum": 1,
+                    "maximum": 5,
+                    "default": 5
+                },
+                "srs": {
+                    "type": "string",
+                    "pattern": "EPSG:[0-9]+"
+                },
+                "file": {
+                    "type": "string",
+                    "pattern": "^(?![.\\\/])[^\\\\]*$"
+                },
+                "layer": {
+                    "description": "The layer to use in the GDB",
+                    "oneOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "string",
+                            "minLength": 1
+                        }
+                    ]
+                },
+                "encoding": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "csvsplit": {
+                    "type": "string",
+                    "minLength": 1,
+                    "default": ","
+                },
+                "headers": {
+                    "type": "integer",
+                    "minimum": -1
+                },
+                "skiplines": {
+                    "type": "integer",
+                    "minimum": 1
+                },
+                "notes": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "id": {
+                    "description": "The unique identifier",
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "minLength": 1
+                        },
+                        {
+                            "$ref": "../functions/regexp.json"
+                        },
+                        {
+                            "$ref": "../functions/first_non_empty.json"
+                        },
+                        {
+                            "$ref": "../functions/remove_prefix.json"
+                        },
+                        {
+                            "$ref": "../functions/remove_postfix.json"
+                        },
+                        {
+                            "$ref": "../functions/join.json"
+                        },
+                        {
+                            "$ref": "../functions/format.json"
+                        },
+                        {
+                            "$ref": "../functions/chain.json"
+                        },
+                        {
+                            "$ref": "../functions/get.json"
+                        },
+                        {
+                            "$ref": "../functions/constant.json"
+                        }
+                    ]
+                },
+                "street": {
+                    "description": "The street/road name",
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "minLength": 1
+                        },
+                        {
+                            "$ref": "../functions/regexp.json"
+                        },
+                        {
+                            "$ref": "../functions/first_non_empty.json"
+                        },
+                        {
+                            "$ref": "../functions/postfixed_street.json"
+                        },
+                        {
+                            "$ref": "../functions/remove_prefix.json"
+                        },
+                        {
+                            "$ref": "../functions/remove_postfix.json"
+                        },
+                        {
+                            "$ref": "../functions/join.json"
+                        },
+                        {
+                            "$ref": "../functions/format.json"
+                        },
+                        {
+                            "$ref": "../functions/chain.json"
+                        },
+                        {
+                            "$ref": "../functions/get.json"
+                        },
+                        {
+                            "$ref": "../functions/constant.json"
+                        }
+                    ]
+                },
+                "number": {
+                    "description": "The house number",
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "minLength": 1
+                        },
+                        {
+                            "$ref": "../functions/regexp.json"
+                        },
+                        {
+                            "$ref": "../functions/first_non_empty.json"
+                        },
+                        {
+                            "$ref": "../functions/prefixed_number.json"
+                        },
+                        {
+                            "$ref": "../functions/remove_prefix.json"
+                        },
+                        {
+                            "$ref": "../functions/remove_postfix.json"
+                        },
+                        {
+                            "$ref": "../functions/join.json"
+                        },
+                        {
+                            "$ref": "../functions/format.json"
+                        },
+                        {
+                            "$ref": "../functions/chain.json"
+                        },
+                        {
+                            "$ref": "../functions/get.json"
+                        },
+                        {
+                            "$ref": "../functions/constant.json"
+                        }
+                    ]
+                },
+                "unit": {
+                    "description": "The suite/unit/apartment/floor number. Values such as \"74B\", \"189 1/2\", \"208.5\" are common as the number part of an address and they are not part of the \"unit\" for the address.",
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "minLength": 1
+                        },
+                        {
+                            "$ref": "../functions/postfixed_unit.json"
+                        },
+                        {
+                            "$ref": "../functions/regexp.json"
+                        },
+                        {
+                            "$ref": "../functions/first_non_empty.json"
+                        },
+                        {
+                            "$ref": "../functions/remove_prefix.json"
+                        },
+                        {
+                            "$ref": "../functions/remove_postfix.json"
+                        },
+                        {
+                            "$ref": "../functions/join.json"
+                        },
+                        {
+                            "$ref": "../functions/format.json"
+                        },
+                        {
+                            "$ref": "../functions/chain.json"
+                        },
+                        {
+                            "$ref": "../functions/get.json"
+                        },
+                        {
+                            "$ref": "../functions/constant.json"
+                        }
+                    ]
+                },
+                "postcode": {
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "minLength": 1
+                        },
+                        {
+                            "$ref": "../functions/regexp.json"
+                        },
+                        {
+                            "$ref": "../functions/first_non_empty.json"
+                        },
+                        {
+                            "$ref": "../functions/remove_prefix.json"
+                        },
+                        {
+                            "$ref": "../functions/remove_postfix.json"
+                        },
+                        {
+                            "$ref": "../functions/join.json"
+                        },
+                        {
+                            "$ref": "../functions/format.json"
+                        },
+                        {
+                            "$ref": "../functions/chain.json"
+                        },
+                        {
+                            "$ref": "../functions/get.json"
+                        },
+                        {
+                            "$ref": "../functions/constant.json"
+                        }
+                    ]
+                },
+                "address_levels": {
+                    "type": "array",
+                    "description": "The administrative levels present in an address. The number of values in this list and their meaning is country-dependent. For example, in the United States we expect two values: the state and the municipality, in that order. In other countries there might be only one. Other countries could have three or more. The array is ordered with the highest levels first.",
+                    "maxItems": 5,
+                    "items": {
+                        "oneOf": [
+                            {
+                                "type": "string",
+                                "minLength": 1
+                            },
+                            {
+                                "type": "null",
+                                "description": "Acts as a placeholder when there is no value for this address level, but a value exists at a lower level. The array should therefore not end with null."
+                            },
+                            {
+                                "$ref": "../functions/regexp.json"
+                            },
+                            {
+                                "$ref": "../functions/first_non_empty.json"
+                            },
+                            {
+                                "$ref": "../functions/remove_prefix.json"
+                            },
+                            {
+                                "$ref": "../functions/remove_postfix.json"
+                            },
+                            {
+                                "$ref": "../functions/join.json"
+                            },
+                            {
+                                "$ref": "../functions/format.json"
+                            },
+                            {
+                                "$ref": "../functions/chain.json"
+                            },
+                            {
+                                "$ref": "../functions/get.json"
+                            },
+                            {
+                                "$ref": "../functions/constant.json"
+                            }
+                        ]
+                    }
+                },
+                "lon": {
+                    "description": "The longitude value for the address.",
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "minLength": 1
+                        },
+                        {
+                            "$ref": "../functions/regexp.json"
+                        }
+                    ]
+                },
+                "lat": {
+                    "description": "The latitude value for the address.",
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "minLength": 1
+                        },
+                        {
+                            "$ref": "../functions/regexp.json"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/schema/schema_v3/layers/buildings.json
+++ b/schema/schema_v3/layers/buildings.json
@@ -1,0 +1,71 @@
+{
+    "type": "object",
+    "required": [
+        "conform"
+    ],
+    "properties": {
+        "conform": {
+            "type": "object",
+            "if": {
+                "properties": {
+                    "format": {
+                        "const": "gdb"
+                    }
+                }
+            },
+            "then": {
+                "required": [
+                    "layer"
+                ]
+            },
+            "else": {
+                "not": {
+                    "required": [
+                        "layer"
+                    ]
+                }
+            },
+            "additionalProperties": false,
+            "properties": {
+                "format": {
+                    "type": "string",
+                    "enum": [
+                        "geojson",
+                        "shapefile",
+                        "gdb"
+                    ]
+                },
+                "srs": {
+                    "type": "string",
+                    "pattern": "EPSG:[0-9]+"
+                },
+                "file": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "layer": {
+                    "description": "The layer to use in the GDB",
+                    "oneOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "string",
+                            "minLength": 1
+                        }
+                    ]
+                },
+                "id": {
+                    "description": "The unique identifier",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "height": {
+                    "description": "The height from the ground in meters",
+                    "type": "string",
+                    "minLength": 1
+                }
+            }
+        }
+    }
+}

--- a/schema/schema_v3/layers/parcels.json
+++ b/schema/schema_v3/layers/parcels.json
@@ -1,0 +1,98 @@
+{
+    "type": "object",
+    "required": [
+        "conform"
+    ],
+    "properties": {
+        "conform": {
+            "type": "object",
+            "if": {
+                "properties": {
+                    "format": {
+                        "const": "gdb"
+                    }
+                }
+            },
+            "then": {
+                "required": [
+                    "layer"
+                ]
+            },
+            "else": {
+                "not": {
+                    "required": [
+                        "layer"
+                    ]
+                }
+            },
+            "required": [
+                "id"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "format": {
+                    "type": "string",
+                    "enum": [
+                        "geojson",
+                        "shapefile",
+                        "gdb"
+                    ]
+                },
+                "srs": {
+                    "type": "string",
+                    "pattern": "EPSG:[0-9]+"
+                },
+                "file": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "layer": {
+                    "description": "The layer to use in the GDB",
+                    "oneOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "string",
+                            "minLength": 1
+                        }
+                    ]
+                },
+                "encoding": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "id": {
+                    "description": "The unique identifier",
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "minLength": 1
+                        },
+                        {
+                            "$ref": "../functions/regexp.json"
+                        },
+                        {
+                            "$ref": "../functions/remove_prefix.json"
+                        },
+                        {
+                            "$ref": "../functions/remove_postfix.json"
+                        },
+                        {
+                            "$ref": "../functions/join.json"
+                        },
+                        {
+                            "$ref": "../functions/format.json"
+                        },
+                        {
+                            "$ref": "../functions/chain.json"
+                        },
+                        {
+                            "$ref": "../functions/constant.json"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/schema/source_schema_v3.json
+++ b/schema/source_schema_v3.json
@@ -1,0 +1,154 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "oa-source",
+    "title": "OpenAddresses Source",
+    "type": "object",
+    "required": [
+        "schema",
+        "coverage",
+        "layers"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "schema": {
+            "type": "number",
+            "enum": [
+                3
+            ]
+        },
+        "coverage": {
+            "type": "object",
+            "if": {
+                "properties": {
+                    "country": {
+                        "type": "object",
+                        "properties": {
+                            "code": {
+                                "const": "US"
+                            }
+                        }
+                    }
+                }
+            },
+            "then": {
+                "required": [
+                    "us-census-geoid"
+                ]
+            },
+            "else": {
+                "not": {
+                    "required": [
+                        "us-census-geoid"
+                    ]
+                }
+            },
+            "required": [
+                "country"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "country": {
+                    "type": "object",
+                    "required": [
+                        "code",
+                        "name"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                        "code": {
+                            "type": "string",
+                            "description": "ISO 3166-1 alpha-2 country code",
+                            "pattern": "^[A-Z]{2}$"
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Country name in English",
+                            "pattern": "^.+$"
+                        }
+                    }
+                },
+                "subdivision": {
+                    "type": "object",
+                    "required": [
+                        "code",
+                        "name"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                        "code": {
+                            "type": "string",
+                            "description": "ISO 3166-2 country subdivision code",
+                            "pattern": "^[A-Z]{2}-[A-Z0-9]{1,3}$"
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "The English (otherwise local) name of the subdivision.",
+                            "pattern": "^.+$"
+                        }
+                    }
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The English (otherwise local) name of the covered area, if it is smaller than the country or subdivision. Examples: \"Bond County\", \"City of Sioux Falls\"",
+                    "pattern": "^.+$"
+                },
+                "us-census-geoid": {
+                    "type": "string",
+                    "pattern": "^\\d{2}$|^\\d{5}$|^\\d{7}$"
+                },
+                "geometry": {
+                    "$ref": "schema_v3/geojson.json#/definitions/geometry"
+                }
+            }
+        },
+        "runner": {
+            "type": "string",
+            "default": "regular",
+            "enum": [
+                "regular",
+                "large"
+            ],
+            "description": "The instance size to run the ETL on - 99% of the time leave this field unpopulated."
+        },
+        "layers": {
+            "type": "object",
+            "additionalProperties": false,
+            "minProperties": 1,
+            "properties": {
+                "addresses": {
+                    "type": "object",
+                    "allOf": [
+                        {
+                            "$ref": "schema_v3/base.json"
+                        },
+                        {
+                            "$ref": "schema_v3/layers/addresses.json"
+                        }
+                    ]
+                },
+                "buildings": {
+                    "type": "object",
+                    "allOf": [
+                        {
+                            "$ref": "schema_v3/base.json"
+                        },
+                        {
+                            "$ref": "schema_v3/layers/buildings.json"
+                        }
+                    ]
+                },
+                "parcels": {
+                    "type": "object",
+                    "allOf": [
+                        {
+                            "$ref": "schema_v3/base.json"
+                        },
+                        {
+                            "$ref": "schema_v3/layers/parcels.json"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
The source schema defines what the entire OpenAddresses project is built upon: +2600 files that provide instructions on how to convert some structure into a defined structure. This conversion step uses files as its input that are often handwritten, copied together from other files, were never consistently updated according to their defining schema and have never been truly verified to match what they actually intend to describe.

Goals and considerations redesigning the schema:
- Make it consistent
- Make it country-neutral
- Define a clear logical structure
- Define clear patterns
- Give freedom only where intended and needed
- Remove deprecated, nonsensical, duplicated and non-existing things

Changes to all files:
- Add patterns to strings
- Add requirements to objects and arrays such as a minimum amount of items
- Improve and add more descriptions

Changes to the main file:
- Update schema version to 2020-12
- Improve the `coverage` object, making it more logical and structured
- Remove the unused `official_website` and `official_phone` objects. This data is already provided per layer.
- Make the `layers` object contain only a single layer object (previously it contained arrays containing the layers), making a source contain only one of each layer type. Currently, different regions (counties, cities, ...) are split into their own files. This change makes it clear to make use of that style.
- The base.json now contains all objects that were previously duplicated in all layer files, providing a better structure and clear separation.

Changes to all layers:
- Remove the `name` object. The `coverage` object already describes... the coverage. The way this is currently used seems redundant.
- Remove the `email` object. I find the actual purpose described in the CONTRIBUTING.md questionable, unrealistic and prone to misuse. An `email` object already exists in the `contact` object.
- Lowercase the `ESRI` field in the `protocol` object for consistency
- Remove possibilty to provide a single string for the `license` object. This behaviour was deprecated.
- Remove the deprecated `attribution` object.
- Convert the `year` object to a `date`, creating the possibilty to insert a specific date.
- Conditionally require the `date` object only when `frequency`=`once`
- Remove unused `timeout` object. Proving this type of information in a source file is in my opinion wrong and unrealistic. This should better be handled in the executing script.
- Remove references to the unused `base` function which does not exist in the codebase.
- Conditionally require the `layer` object only when `format`=`gdb`

Changes to the addresses layer:
- Convert `city`, `region` and `district` objects to an `address_levels` object. Taken from the OvertureMaps docs, this object makes addresses country-neutral. Finding the equivalents for	 these terms is not so easy for all countries. This makes it clear which level one wants to describe.
- Require the `format` for clarity
- Remove the `country` as this can be inherited from the `coverage`
- Conditionally require objects when `format`=`csv` (such as `csvsplit` or `headers`)

Changes to the pacels layer:
- For consistency, rename the `pid` object to `id`
- Allow the `id` to be a string and not just a function. It has always beed used this way but never officially described as such.

Ideas:
- Convert the `frequency` object to a `static_data` boolean that indicates whether the data is changing or static, such as for preprocessed files in the cache (equivalent to `frequency`=`once`). Does it really make a difference when the data is crawled weekly and not just monthly?  Why not crawl all non-static sources monthly and publish on the same day each month?

I'm of course willing to make the needed migrations and source code changes. I'm encouraged to continue working with you on improving this project in every aspect.
