### PR TITLE
Belgium license update 

### DIFF
--- a/sources/be/bru/bosa-region-brussels-fr.json
+++ b/sources/be/bru/bosa-region-brussels-fr.json
@@ -40,8 +40,8 @@
                 "language": "fr",
                 "website": "https://opendata.bosa.be",
                 "license": {
-                    "url": "https://cirb.brussels/fr/nos-solutions/urbis-solutions/licence-urbis-open-data",
-                    "text": "CIRB licence ouverte",
+                    "url": "https://creativecommons.org/licenses/by/4.0/",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
                     "attribution name": "CIRB / SPRB"
                 },

--- a/sources/be/bru/bosa-region-brussels-nl.json
+++ b/sources/be/bru/bosa-region-brussels-nl.json
@@ -40,8 +40,8 @@
                 "language": "nl",
                 "website": "https://opendata.bosa.be",
                 "license": {
-                    "url": "https://cibg.brussels/nl/onze-oplossingen/urbis-solutions/urbis-open-data-licentie",
-                    "text": "CIBG open licentie",
+                    "url": "https://creativecommons.org/licenses/by/4.0/",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
                     "attribution name": "CIBG / GOB"
                 },

--- a/sources/be/vlg/bosa-region-flanders-fr.json
+++ b/sources/be/vlg/bosa-region-flanders-fr.json
@@ -40,8 +40,8 @@
                 "language": "fr",
                 "website": "https://opendata.bosa.be",
                 "license": {
-                    "url": "https://overheid.vlaanderen.be/sites/default/files/documenten/ict-egov/licenties/hergebruik/modellicentie_gratis_hergebruik_v1_0.html",
-                    "text": "Modellicentie gratis hergebruik",
+                    "url": "https://creativecommons.org/licenses/by/4.0/",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
                     "attribution name": "Informatie Vlaanderen"
                 },

--- a/sources/be/vlg/bosa-region-flanders-nl.json
+++ b/sources/be/vlg/bosa-region-flanders-nl.json
@@ -40,8 +40,8 @@
                 "language": "nl",
                 "website": "https://opendata.bosa.be",
                 "license": {
-                    "url": "https://overheid.vlaanderen.be/sites/default/files/documenten/ict-egov/licenties/hergebruik/modellicentie_gratis_hergebruik_v1_0.html",
-                    "text": "Modellicentie gratis hergebruik",
+                    "url": "https://creativecommons.org/licenses/by/4.0/",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
                     "attribution name": "Informatie Vlaanderen"
                 },


### PR DESCRIPTION
The data source currently lists CC-BY 4.0 for all the Belgium datasets. Updating to match.

https://opendata.bosa.be/index.nl.html