### PR TITLE
Spain full country dataset

### DIFF
--- a/sources/es/countrywide.json
+++ b/sources/es/countrywide.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "ISO 3166": {
+            "alpha2": "ES",
+            "country": "Spain"
+        },
+        "country": "es"
+    },
+    "schema": 2,
+    "layers": {
+        "addresses": [
+            {
+                "name": "country",
+                "data": "https://jeffu.dev/data/spain_addresses.csv.zip",
+                "website": "https://centrodedescargas.cnig.es/CentroDescargas/buscadorCatalogo.do",
+                "note": "Addresses comes in 52 regional packages in gpkg format combined with some parcel and municipal data. This was procssed by trimming the data down to addresses, merging into one layer, and converting to CSV.",
+                "license": {
+                    "text": "CC BY 4.0",
+                    "url": "http://www.ign.es/resources/licencia/Condiciones_licenciaUso_IGN.pdf",
+                    "attribution": true,
+                    "share-alike": false,
+                    "attribution name": "scne.es"
+
+                },
+                "protocol": "http",
+                "compression": "zip",
+                "conform": {
+                    "lon": "X",
+                    "lat": "Y",
+                    "number": "numero",
+                    "unit": "extension",
+                    "street": {
+                        "function": "join",
+                        "fields": [
+                            "tipo vial",
+                            "nombre via"
+                        ],
+                        "separator": " "
+                    },
+                    "postcode": "codigo_postal",
+                    "city": "poblacion",
+                    "format": "csv",
+                    "srs": "EPSG:4259"
+                }
+            }
+        ]
+    }
+}

--- a/sources/es/countrywide.json
+++ b/sources/es/countrywide.json
@@ -13,7 +13,7 @@
                 "name": "country",
                 "data": "https://jeffu.dev/data/spain_addresses.csv.zip",
                 "website": "https://centrodedescargas.cnig.es/CentroDescargas/buscadorCatalogo.do",
-                "note": "Addresses comes in 52 regional packages in gpkg format combined with some parcel and municipal data. This was procssed by trimming the data down to addresses, merging into one layer, and converting to CSV.",
+                "note": "Addresses comes in 52 regional packages in gpkg format combined with some parcel and municipal data. These were processed by trimming the data down to addresses, merging into one layer, and converting to CSV.",
                 "license": {
                     "text": "CC BY 4.0",
                     "url": "http://www.ign.es/resources/licencia/Condiciones_licenciaUso_IGN.pdf",
@@ -32,8 +32,8 @@
                     "street": {
                         "function": "join",
                         "fields": [
-                            "tipo vial",
-                            "nombre via"
+                            "tipo_vial",
+                            "nombre_via"
                         ],
                         "separator": " "
                     },

--- a/sources/es/countrywide.json
+++ b/sources/es/countrywide.json
@@ -11,7 +11,7 @@
         "addresses": [
             {
                 "name": "country",
-                "data": "https://jeffu.dev/data/spain_addresses.csv.zip",
+                "data": "https://data.openaddresses.io/cache/uploads/iandees/bbc9ff/spain_addresses.csv.zip",
                 "website": "https://centrodedescargas.cnig.es/CentroDescargas/buscadorCatalogo.do",
                 "note": "Addresses comes in 52 regional packages in gpkg format combined with some parcel and municipal data. These were processed by trimming the data down to addresses, merging into one layer, and converting to CSV.",
                 "license": {


### PR DESCRIPTION
https://www.cartociudad.es/ has full country data available that is significantly different than our current datasets so seems worth including.

There is some way to download them through INSPIRE [here](https://inspire-geoportal.ec.europa.eu/srv/eng/catalog.search#/datasetdetails?country=es&view=themeOverview&theme=none&resourceId=spaign_cartociudad_addresses) and that may be the better long term path for maintenance if someone can figure it out.

They also have the data available as geopackages through a site [here](https://centrodedescargas.cnig.es/CentroDescargas/buscadorCatalogo.do) which is where I ended up getting it, although its not possible to automate the download process unfortunately. The data comes in 52 regional geopackages but has some non address layers and needs to be converted to a compatible format anyway so I just combined them during that process into one file for simplicity.