### PR TITLE
Latvia country wide dataset

### DIFF
--- a/sources/lv/countrywide.json
+++ b/sources/lv/countrywide.json
@@ -12,7 +12,9 @@
             {
                 "name": "country",
                 "data": "https://grafws.kadastrs.lv/atom/ad/20241028/Address.gml.zip",
+                "note": "URL updates every monday to that date. Adjust to refresh data.", 
                 "website": "https://data.gov.lv/dati/eng/dataset/adreses-inspire/resource/22e0163f-b107-4f5b-9588-26a065f01c45",
+                "frequency": "weekly",
                 "license": {
                     "text": "CC-BY 4.0",
                     "url": "https://creativecommons.org/licenses/by/4.0/",
@@ -26,18 +28,24 @@
                     "encoding": "UTF-8",
                     "format": "xml",
                     "file": "Address.gml",
+                    "id": "gml_id",
                     "postcode": {
                         "function": "regexp",
                         "field": "description",
                         "pattern": "(LV-[0-9]*)"
                     },
-                    "number": "text",
+                    "number": "designator",
                     "street": {
                         "function": "regexp",
-                        "field": "description",
-                        "pattern": "(?:.*,\\s)(.*)|(.*)(?:\\s\\d+.*)"
+                        "field": "text",
+                        "pattern": "^(?!\".*\")(.*)(?:\\s\\d+.*)$"
                     },
                     "city": {
+                        "function": "regexp",
+                        "field": "description",
+                        "pattern": "(?:.*,\\s)(.*)(?:,.*)(?:,.*)(?:,.*)"
+                    },
+                    "district": {
                         "function": "regexp",
                         "field": "description",
                         "pattern": "(?:.*,\\s)(.*)(?:,.*)(?:,.*)"
@@ -46,7 +54,7 @@
                         "function": "regexp",
                         "field": "description",
                         "pattern": "(?:.*,\\s)(.*)(?:,.*)"
-                    },
+                    }
                 }
             }
         ]

--- a/sources/lv/countrywide.json
+++ b/sources/lv/countrywide.json
@@ -11,7 +11,7 @@
         "addresses": [
             {
                 "name": "country",
-                "data": "https://grafws.kadastrs.lv/atom/ad/20241014/Address.gml.zip",
+                "data": "https://grafws.kadastrs.lv/atom/ad/20241028/Address.gml.zip",
                 "website": "https://data.gov.lv/dati/eng/dataset/adreses-inspire/resource/22e0163f-b107-4f5b-9588-26a065f01c45",
                 "license": {
                     "text": "CC-BY 4.0",
@@ -26,33 +26,27 @@
                     "encoding": "UTF-8",
                     "format": "xml",
                     "file": "Address.gml",
-                    "id": "localId",
                     "postcode": {
                         "function": "regexp",
                         "field": "description",
                         "pattern": "(LV-[0-9]*)"
                     },
-                    "number": "designator",
+                    "number": "text",
                     "street": {
                         "function": "regexp",
                         "field": "description",
-                        "pattern": "^(.*)(?: [0-9][^ ]* .* [0-9]{5} \\S)"
+                        "pattern": "(?:.*,\\s)(.*)|(.*)(?:\\s\\d+.*)"
                     },
                     "city": {
                         "function": "regexp",
                         "field": "description",
-                        "pattern": "(?: [0-9][^ ]* )(.*)(?: [0-9]{5} \\S)"
-                    },
-                    "district": {
-                        "function": "regexp",
-                        "field": "description",
-                        "pattern": "^(.*)(?: [0-9][^ ]* .* [0-9]{5} \\S)"
+                        "pattern": "(?:.*,\\s)(.*)(?:,.*)(?:,.*)"
                     },
                     "region": {
                         "function": "regexp",
                         "field": "description",
-                        "pattern": "^(.*)(?: [0-9][^ ]* .* [0-9]{5} \\S)"
-                    }
+                        "pattern": "(?:.*,\\s)(.*)(?:,.*)"
+                    },
                 }
             }
         ]

--- a/sources/lv/countrywide.json
+++ b/sources/lv/countrywide.json
@@ -12,7 +12,7 @@
             {
                 "name": "country",
                 "data": "https://grafws.kadastrs.lv/atom/ad/20241028/Address.gml.zip",
-                "note": "URL updates every monday to that date. Adjust to refresh data.", 
+                "note": "URL updates every monday to that date. Adjust to refresh data.",
                 "website": "https://data.gov.lv/dati/eng/dataset/adreses-inspire/resource/22e0163f-b107-4f5b-9588-26a065f01c45",
                 "frequency": "weekly",
                 "license": {

--- a/sources/lv/countrywide.json
+++ b/sources/lv/countrywide.json
@@ -1,0 +1,60 @@
+{
+    "coverage": {
+        "ISO 3166": {
+            "alpha2": "LV",
+            "country": "Latvia"
+        },
+        "country": "lv"
+    },
+    "schema": 2,
+    "layers": {
+        "addresses": [
+            {
+                "name": "country",
+                "data": "https://grafws.kadastrs.lv/atom/ad/20241014/Address.gml.zip",
+                "website": "https://data.gov.lv/dati/eng/dataset/adreses-inspire/resource/22e0163f-b107-4f5b-9588-26a065f01c45",
+                "license": {
+                    "text": "CC-BY 4.0",
+                    "url": "https://creativecommons.org/licenses/by/4.0/",
+                    "attribution": true,
+                    "attribution name": "Valsts digitālās attīstības aģentūra",
+                    "share-alike": false
+                },
+                "protocol": "http",
+                "compression": "zip",
+                "conform": {
+                    "encoding": "UTF-8",
+                    "format": "xml",
+                    "file": "Address.gml",
+                    "id": "localId",
+                    "postcode": {
+                        "function": "regexp",
+                        "field": "description",
+                        "pattern": "(LV-[0-9]*)"
+                    },
+                    "number": "designator",
+                    "street": {
+                        "function": "regexp",
+                        "field": "description",
+                        "pattern": "^(.*)(?: [0-9][^ ]* .* [0-9]{5} \\S)"
+                    },
+                    "city": {
+                        "function": "regexp",
+                        "field": "description",
+                        "pattern": "(?: [0-9][^ ]* )(.*)(?: [0-9]{5} \\S)"
+                    },
+                    "district": {
+                        "function": "regexp",
+                        "field": "description",
+                        "pattern": "^(.*)(?: [0-9][^ ]* .* [0-9]{5} \\S)"
+                    },
+                    "region": {
+                        "function": "regexp",
+                        "field": "description",
+                        "pattern": "^(.*)(?: [0-9][^ ]* .* [0-9]{5} \\S)"
+                    }
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Ingestion of cc-by 4.0 latvia dataset.

Meta data is here with the license.
https://geometadati.viss.gov.lv/geoportal/rest/document?id={E7CD2078-0767-4686-B169-EDE511C23998}

The url updates every Monday with a new link using the current date so this will need to be periodically updated in the json to ingest fresh data. E.g. this week's url is [https://grafws.kadastrs.lv/atom/ad/20241028/Address.gml.zip](url) and next week will be [https://grafws.kadastrs.lv/atom/ad/20241104/Address.gml.zip](url)

Latest URL can be found here.
https://grafws.kadastrs.lv/atom/ad/atom_Address.xml