### PR TITLE
Update Emilia Romagna data sources

### DIFF
--- a/sources/it/45/bo.json
+++ b/sources/it/45/bo.json
@@ -14,10 +14,10 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "http://geoportale.regione.emilia-romagna.it/it/download/dati-e-prodotti-cartografici-preconfezionati/database-topografico/tutti-download-preconfezionati/dati_dbtr_V_NCV_GPT_Bologna.zip",
+                "data": "https://www.dropbox.com/scl/fi/f5rqgefr9zf7i7zi2m1fp/bologna.zip?rlkey=vv0g4zvhjnknd2lza6ra34n5c&st=6hppx5jd&dl=1",
                 "website": "http://geoportale.regione.emilia-romagna.it/it/download/dati-e-prodotti-cartografici-preconfezionati/database-topografico/gestione-viabilita-e-indirizzi/dati-preconfezionati-dbtr-civico-ncv_gpt",
                 "license": {
-                    "url": "http://geoportale.regione.emilia-romagna.it/it/allegati/Licenza_CC-BY_2.5.pdf/view",
+                    "url": "https://creativecommons.org/licenses/by/4.0/deed.it",
                     "attribution": true,
                     "share-alike": false
                 },
@@ -27,20 +27,19 @@
                 "conform": {
                     "number": {
                         "fields": [
-                            "nm_civ",
-                            "sb_civ"
+                            "NM_CIV",
+                            "SB_CIV"
                         ],
                         "function": "join",
                         "separator": "/"
                     },
-                    "street": "tp_nom",
-                    "city": "nome_c",
-                    "district": "nm_prv",
+                    "street": "TP_NOM",
+                    "city": "NOME_C",
+                    "district": "NM_PRV",
                     "region": "Emilia-Romagna",
-                    "id": "id_e",
+                    "id": "ID_E",
                     "format": "shapefile",
-                    "file": "V_NCV_GPT.shp",
-                    "accuracy": 1
+                    "file": "bologna.shp"
                 }
             }
         ]

--- a/sources/it/45/bo.json
+++ b/sources/it/45/bo.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://www.dropbox.com/scl/fi/f5rqgefr9zf7i7zi2m1fp/bologna.zip?rlkey=vv0g4zvhjnknd2lza6ra34n5c&st=6hppx5jd&dl=1",
+                "data": "https://www.dropbox.com/scl/fi/ngtlzofka9gmd0zd1ikqk/V_NCV_GPT.zip?rlkey=l38pe4cgjfvqkjo7qsiof271j&st=sj1guecc&dl=1",
                 "website": "http://geoportale.regione.emilia-romagna.it/it/download/dati-e-prodotti-cartografici-preconfezionati/database-topografico/gestione-viabilita-e-indirizzi/dati-preconfezionati-dbtr-civico-ncv_gpt",
                 "license": {
                     "url": "https://creativecommons.org/licenses/by/4.0/deed.it",
@@ -39,7 +39,7 @@
                     "region": "Emilia-Romagna",
                     "id": "ID_E",
                     "format": "shapefile",
-                    "file": "bologna.shp"
+                    "file": "V_NCV_GPT.shp"
                 }
             }
         ]

--- a/sources/it/45/bo.json
+++ b/sources/it/45/bo.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://www.dropbox.com/scl/fi/ngtlzofka9gmd0zd1ikqk/V_NCV_GPT.zip?rlkey=l38pe4cgjfvqkjo7qsiof271j&st=sj1guecc&dl=1",
+                "data": "https://data.openaddresses.io/cache/uploads/stepps00/2024-11-04-1wktm/V_NCV_GPT.zip",
                 "website": "http://geoportale.regione.emilia-romagna.it/it/download/dati-e-prodotti-cartografici-preconfezionati/database-topografico/gestione-viabilita-e-indirizzi/dati-preconfezionati-dbtr-civico-ncv_gpt",
                 "license": {
                     "url": "https://creativecommons.org/licenses/by/4.0/deed.it",

--- a/sources/it/45/fc.json
+++ b/sources/it/45/fc.json
@@ -14,10 +14,10 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "http://geoportale.regione.emilia-romagna.it/it/download/dati-e-prodotti-cartografici-preconfezionati/database-topografico/tutti-download-preconfezionati/dati_dbtr_V_NCV_GPT_Forli-Cesena.zip",
+                "data": "https://www.dropbox.com/scl/fi/40klmnnglzjgtsczko2ev/forli-cesena.zip?rlkey=tja593fov5bcj4dblhovkoaji&st=naw8c1v5&dl=1",
                 "website": "http://geoportale.regione.emilia-romagna.it/it/download/dati-e-prodotti-cartografici-preconfezionati/database-topografico/gestione-viabilita-e-indirizzi/dati-preconfezionati-dbtr-civico-ncv_gpt",
                 "license": {
-                    "url": "http://geoportale.regione.emilia-romagna.it/it/allegati/Licenza_CC-BY_2.5.pdf/view",
+                    "url": "https://creativecommons.org/licenses/by/4.0/deed.it",
                     "attribution": true,
                     "share-alike": false
                 },
@@ -27,20 +27,19 @@
                 "conform": {
                     "number": {
                         "fields": [
-                            "nm_civ",
-                            "sb_civ"
+                            "NM_CIV",
+                            "SB_CIV"
                         ],
                         "function": "join",
                         "separator": "/"
                     },
-                    "street": "tp_nom",
-                    "city": "nome_c",
-                    "district": "nm_prv",
+                    "street": "TP_NOM",
+                    "city": "NOME_C",
+                    "district": "NM_PRV",
                     "region": "Emilia-Romagna",
-                    "id": "id_e",
+                    "id": "ID_E",
                     "format": "shapefile",
-                    "file": "V_NCV_GPT.shp",
-                    "accuracy": 1
+                    "file": "forli-cesena.shp"
                 }
             }
         ]

--- a/sources/it/45/fc.json
+++ b/sources/it/45/fc.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://www.dropbox.com/scl/fi/ngtlzofka9gmd0zd1ikqk/V_NCV_GPT.zip?rlkey=l38pe4cgjfvqkjo7qsiof271j&st=d2v33ye6&dl=1",
+                "data": "https://data.openaddresses.io/cache/uploads/stepps00/2024-11-04-wji1p/V_NCV_GPT.zip",
                 "website": "http://geoportale.regione.emilia-romagna.it/it/download/dati-e-prodotti-cartografici-preconfezionati/database-topografico/gestione-viabilita-e-indirizzi/dati-preconfezionati-dbtr-civico-ncv_gpt",
                 "license": {
                     "url": "https://creativecommons.org/licenses/by/4.0/deed.it",

--- a/sources/it/45/fc.json
+++ b/sources/it/45/fc.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://www.dropbox.com/scl/fi/40klmnnglzjgtsczko2ev/forli-cesena.zip?rlkey=tja593fov5bcj4dblhovkoaji&st=naw8c1v5&dl=1",
+                "data": "https://www.dropbox.com/scl/fi/ngtlzofka9gmd0zd1ikqk/V_NCV_GPT.zip?rlkey=l38pe4cgjfvqkjo7qsiof271j&st=d2v33ye6&dl=1",
                 "website": "http://geoportale.regione.emilia-romagna.it/it/download/dati-e-prodotti-cartografici-preconfezionati/database-topografico/gestione-viabilita-e-indirizzi/dati-preconfezionati-dbtr-civico-ncv_gpt",
                 "license": {
                     "url": "https://creativecommons.org/licenses/by/4.0/deed.it",
@@ -39,7 +39,7 @@
                     "region": "Emilia-Romagna",
                     "id": "ID_E",
                     "format": "shapefile",
-                    "file": "forli-cesena.shp"
+                    "file": "V_NCV_GPT.shp"
                 }
             }
         ]

--- a/sources/it/45/fe.json
+++ b/sources/it/45/fe.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://www.dropbox.com/scl/fi/wx4z4j5xtfwwgy0unlnca/ferrara.zip?rlkey=9bh08jw03242r1b7z6w90nksd&st=ndsz3qnf&dl=1",
+                "data": "https://www.dropbox.com/scl/fi/ngtlzofka9gmd0zd1ikqk/V_NCV_GPT.zip?rlkey=l38pe4cgjfvqkjo7qsiof271j&st=tqj2yc66&dl=1",
                 "website": "http://geoportale.regione.emilia-romagna.it/it/download/dati-e-prodotti-cartografici-preconfezionati/database-topografico/gestione-viabilita-e-indirizzi/dati-preconfezionati-dbtr-civico-ncv_gpt",
                 "license": {
                     "url": "https://creativecommons.org/licenses/by/4.0/deed.it",
@@ -39,7 +39,7 @@
                     "region": "Emilia-Romagna",
                     "id": "ID_E",
                     "format": "shapefile",
-                    "file": "ferrara.shp"
+                    "file": "V_NCV_GPT.shp"
                 }
             }
         ]

--- a/sources/it/45/fe.json
+++ b/sources/it/45/fe.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://www.dropbox.com/scl/fi/ngtlzofka9gmd0zd1ikqk/V_NCV_GPT.zip?rlkey=l38pe4cgjfvqkjo7qsiof271j&st=tqj2yc66&dl=1",
+                "data": "https://data.openaddresses.io/cache/uploads/stepps00/2024-11-04-08z4b/V_NCV_GPT.zip",
                 "website": "http://geoportale.regione.emilia-romagna.it/it/download/dati-e-prodotti-cartografici-preconfezionati/database-topografico/gestione-viabilita-e-indirizzi/dati-preconfezionati-dbtr-civico-ncv_gpt",
                 "license": {
                     "url": "https://creativecommons.org/licenses/by/4.0/deed.it",

--- a/sources/it/45/fe.json
+++ b/sources/it/45/fe.json
@@ -14,10 +14,10 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "http://geoportale.regione.emilia-romagna.it/it/download/dati-e-prodotti-cartografici-preconfezionati/database-topografico/tutti-download-preconfezionati/dati_dbtr_V_NCV_GPT_Ferrara.zip",
+                "data": "https://www.dropbox.com/scl/fi/wx4z4j5xtfwwgy0unlnca/ferrara.zip?rlkey=9bh08jw03242r1b7z6w90nksd&st=ndsz3qnf&dl=1",
                 "website": "http://geoportale.regione.emilia-romagna.it/it/download/dati-e-prodotti-cartografici-preconfezionati/database-topografico/gestione-viabilita-e-indirizzi/dati-preconfezionati-dbtr-civico-ncv_gpt",
                 "license": {
-                    "url": "http://geoportale.regione.emilia-romagna.it/it/allegati/Licenza_CC-BY_2.5.pdf/view",
+                    "url": "https://creativecommons.org/licenses/by/4.0/deed.it",
                     "attribution": true,
                     "share-alike": false
                 },
@@ -27,20 +27,19 @@
                 "conform": {
                     "number": {
                         "fields": [
-                            "nm_civ",
-                            "sb_civ"
+                            "NM_CIV",
+                            "SB_CIV"
                         ],
                         "function": "join",
                         "separator": "/"
                     },
-                    "street": "tp_nom",
-                    "city": "nome_c",
-                    "district": "nm_prv",
+                    "street": "TP_NOM",
+                    "city": "NOME_C",
+                    "district": "NM_PRV",
                     "region": "Emilia-Romagna",
-                    "id": "id_e",
+                    "id": "ID_E",
                     "format": "shapefile",
-                    "file": "V_NCV_GPT.shp",
-                    "accuracy": 1
+                    "file": "ferrara.shp"
                 }
             }
         ]

--- a/sources/it/45/mo.json
+++ b/sources/it/45/mo.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://www.dropbox.com/scl/fi/ngtlzofka9gmd0zd1ikqk/V_NCV_GPT.zip?rlkey=l38pe4cgjfvqkjo7qsiof271j&st=tkfwpr6q&dl=1",
+                "data": "https://data.openaddresses.io/cache/uploads/stepps00/2024-11-04-wolkn/V_NCV_GPT.zip",
                 "website": "http://geoportale.regione.emilia-romagna.it/it/download/dati-e-prodotti-cartografici-preconfezionati/database-topografico/gestione-viabilita-e-indirizzi/dati-preconfezionati-dbtr-civico-ncv_gpt",
                 "license": {
                     "url": "https://creativecommons.org/licenses/by/4.0/deed.it",

--- a/sources/it/45/mo.json
+++ b/sources/it/45/mo.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://www.dropbox.com/scl/fi/rlcpzh9z7uk503mahif2s/modena.zip?rlkey=xfdkjkmjvoz32nw4x767oigni&st=8eyj4h3d&dl=1",
+                "data": "https://www.dropbox.com/scl/fi/ngtlzofka9gmd0zd1ikqk/V_NCV_GPT.zip?rlkey=l38pe4cgjfvqkjo7qsiof271j&st=tkfwpr6q&dl=1",
                 "website": "http://geoportale.regione.emilia-romagna.it/it/download/dati-e-prodotti-cartografici-preconfezionati/database-topografico/gestione-viabilita-e-indirizzi/dati-preconfezionati-dbtr-civico-ncv_gpt",
                 "license": {
                     "url": "https://creativecommons.org/licenses/by/4.0/deed.it",
@@ -39,7 +39,7 @@
                     "region": "Emilia-Romagna",
                     "id": "ID_E",
                     "format": "shapefile",
-                    "file": "modena.shp"
+                    "file": "V_NCV_GPT.shp"
                 }
             }
         ]

--- a/sources/it/45/mo.json
+++ b/sources/it/45/mo.json
@@ -14,10 +14,10 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "http://geoportale.regione.emilia-romagna.it/it/download/dati-e-prodotti-cartografici-preconfezionati/database-topografico/tutti-download-preconfezionati/dati_dbtr_V_NCV_GPT_Modena.zip",
+                "data": "https://www.dropbox.com/scl/fi/rlcpzh9z7uk503mahif2s/modena.zip?rlkey=xfdkjkmjvoz32nw4x767oigni&st=8eyj4h3d&dl=1",
                 "website": "http://geoportale.regione.emilia-romagna.it/it/download/dati-e-prodotti-cartografici-preconfezionati/database-topografico/gestione-viabilita-e-indirizzi/dati-preconfezionati-dbtr-civico-ncv_gpt",
                 "license": {
-                    "url": "http://geoportale.regione.emilia-romagna.it/it/allegati/Licenza_CC-BY_2.5.pdf/view",
+                    "url": "https://creativecommons.org/licenses/by/4.0/deed.it",
                     "attribution": true,
                     "share-alike": false
                 },
@@ -27,20 +27,19 @@
                 "conform": {
                     "number": {
                         "fields": [
-                            "nm_civ",
-                            "sb_civ"
+                            "NM_CIV",
+                            "SB_CIV"
                         ],
                         "function": "join",
                         "separator": "/"
                     },
-                    "street": "tp_nom",
-                    "city": "nome_c",
-                    "district": "nm_prv",
+                    "street": "TP_NOM",
+                    "city": "NOME_C",
+                    "district": "NM_PRV",
                     "region": "Emilia-Romagna",
-                    "id": "id_e",
+                    "id": "ID_E",
                     "format": "shapefile",
-                    "file": "V_NCV_GPT.shp",
-                    "accuracy": 1
+                    "file": "modena.shp"
                 }
             }
         ]

--- a/sources/it/45/pc.json
+++ b/sources/it/45/pc.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://www.dropbox.com/scl/fi/ngtlzofka9gmd0zd1ikqk/V_NCV_GPT.zip?rlkey=l38pe4cgjfvqkjo7qsiof271j&st=lwi42w6v&dl=1",
+                "data": "https://data.openaddresses.io/cache/uploads/stepps00/2024-11-04-fhzn2/V_NCV_GPT.zip",
                 "website": "http://geoportale.regione.emilia-romagna.it/it/download/dati-e-prodotti-cartografici-preconfezionati/database-topografico/gestione-viabilita-e-indirizzi/dati-preconfezionati-dbtr-civico-ncv_gpt",
                 "license": {
                     "url": "https://creativecommons.org/licenses/by/4.0/deed.it",

--- a/sources/it/45/pc.json
+++ b/sources/it/45/pc.json
@@ -14,10 +14,10 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "http://geoportale.regione.emilia-romagna.it/it/download/dati-e-prodotti-cartografici-preconfezionati/database-topografico/tutti-download-preconfezionati/dati_dbtr_V_NCV_GPT_Piacenza.zip",
+                "data": "https://www.dropbox.com/scl/fi/0ggvzblz06tg48h3flyib/piacenza.zip?rlkey=rm20wi1vlubttcd44jhe8dj69&st=dx26rnv9&dl=1",
                 "website": "http://geoportale.regione.emilia-romagna.it/it/download/dati-e-prodotti-cartografici-preconfezionati/database-topografico/gestione-viabilita-e-indirizzi/dati-preconfezionati-dbtr-civico-ncv_gpt",
                 "license": {
-                    "url": "http://geoportale.regione.emilia-romagna.it/it/allegati/Licenza_CC-BY_2.5.pdf/view",
+                    "url": "https://creativecommons.org/licenses/by/4.0/deed.it",
                     "attribution": true,
                     "share-alike": false
                 },
@@ -27,20 +27,19 @@
                 "conform": {
                     "number": {
                         "fields": [
-                            "nm_civ",
-                            "sb_civ"
+                            "NM_CIV",
+                            "SB_CIV"
                         ],
                         "function": "join",
                         "separator": "/"
                     },
-                    "street": "tp_nom",
-                    "city": "nome_c",
-                    "district": "nm_prv",
+                    "street": "TP_NOM",
+                    "city": "NOME_C",
+                    "district": "NM_PRV",
                     "region": "Emilia-Romagna",
-                    "id": "id_e",
+                    "id": "ID_E",
                     "format": "shapefile",
-                    "file": "V_NCV_GPT.shp",
-                    "accuracy": 1
+                    "file": "piacenza.shp"
                 }
             }
         ]

--- a/sources/it/45/pc.json
+++ b/sources/it/45/pc.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://www.dropbox.com/scl/fi/0ggvzblz06tg48h3flyib/piacenza.zip?rlkey=rm20wi1vlubttcd44jhe8dj69&st=dx26rnv9&dl=1",
+                "data": "https://www.dropbox.com/scl/fi/ngtlzofka9gmd0zd1ikqk/V_NCV_GPT.zip?rlkey=l38pe4cgjfvqkjo7qsiof271j&st=lwi42w6v&dl=1",
                 "website": "http://geoportale.regione.emilia-romagna.it/it/download/dati-e-prodotti-cartografici-preconfezionati/database-topografico/gestione-viabilita-e-indirizzi/dati-preconfezionati-dbtr-civico-ncv_gpt",
                 "license": {
                     "url": "https://creativecommons.org/licenses/by/4.0/deed.it",
@@ -39,7 +39,7 @@
                     "region": "Emilia-Romagna",
                     "id": "ID_E",
                     "format": "shapefile",
-                    "file": "piacenza.shp"
+                    "file": "V_NCV_GPT.shp"
                 }
             }
         ]

--- a/sources/it/45/pr.json
+++ b/sources/it/45/pr.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://www.dropbox.com/scl/fi/ngtlzofka9gmd0zd1ikqk/V_NCV_GPT.zip?rlkey=l38pe4cgjfvqkjo7qsiof271j&st=6sjy7hgt&dl=1",
+                "data": "https://data.openaddresses.io/cache/uploads/stepps00/2024-11-04-dl8os/V_NCV_GPT.zip",
                 "website": "http://geoportale.regione.emilia-romagna.it/it/download/dati-e-prodotti-cartografici-preconfezionati/database-topografico/gestione-viabilita-e-indirizzi/dati-preconfezionati-dbtr-civico-ncv_gpt",
                 "license": {
                     "url": "https://creativecommons.org/licenses/by/4.0/deed.it",

--- a/sources/it/45/pr.json
+++ b/sources/it/45/pr.json
@@ -14,10 +14,10 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "http://geoportale.regione.emilia-romagna.it/it/download/dati-e-prodotti-cartografici-preconfezionati/database-topografico/tutti-download-preconfezionati/dati_dbtr_V_NCV_GPT_Parma.zip",
+                "data": "https://www.dropbox.com/scl/fi/1c46xt4mpgfkrow0jt9r3/parma.zip?rlkey=wdx7jna6ntbkwhm8mb59opfie&st=z3fj7tx4&dl=1",
                 "website": "http://geoportale.regione.emilia-romagna.it/it/download/dati-e-prodotti-cartografici-preconfezionati/database-topografico/gestione-viabilita-e-indirizzi/dati-preconfezionati-dbtr-civico-ncv_gpt",
                 "license": {
-                    "url": "http://geoportale.regione.emilia-romagna.it/it/allegati/Licenza_CC-BY_2.5.pdf/view",
+                    "url": "https://creativecommons.org/licenses/by/4.0/deed.it",
                     "attribution": true,
                     "share-alike": false
                 },
@@ -27,20 +27,19 @@
                 "conform": {
                     "number": {
                         "fields": [
-                            "nm_civ",
-                            "sb_civ"
+                            "NM_CIV",
+                            "SB_CIV"
                         ],
                         "function": "join",
                         "separator": "/"
                     },
-                    "street": "tp_nom",
-                    "city": "nome_c",
-                    "district": "nm_prv",
+                    "street": "TP_NOM",
+                    "city": "NOME_C",
+                    "district": "NM_PRV",
                     "region": "Emilia-Romagna",
-                    "id": "id_e",
+                    "id": "ID_E",
                     "format": "shapefile",
-                    "file": "V_NCV_GPT.shp",
-                    "accuracy": 1
+                    "file": "parma.shp"
                 }
             }
         ]

--- a/sources/it/45/pr.json
+++ b/sources/it/45/pr.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://www.dropbox.com/scl/fi/1c46xt4mpgfkrow0jt9r3/parma.zip?rlkey=wdx7jna6ntbkwhm8mb59opfie&st=z3fj7tx4&dl=1",
+                "data": "https://www.dropbox.com/scl/fi/ngtlzofka9gmd0zd1ikqk/V_NCV_GPT.zip?rlkey=l38pe4cgjfvqkjo7qsiof271j&st=6sjy7hgt&dl=1",
                 "website": "http://geoportale.regione.emilia-romagna.it/it/download/dati-e-prodotti-cartografici-preconfezionati/database-topografico/gestione-viabilita-e-indirizzi/dati-preconfezionati-dbtr-civico-ncv_gpt",
                 "license": {
                     "url": "https://creativecommons.org/licenses/by/4.0/deed.it",
@@ -39,7 +39,7 @@
                     "region": "Emilia-Romagna",
                     "id": "ID_E",
                     "format": "shapefile",
-                    "file": "parma.shp"
+                    "file": "V_NCV_GPT.shp"
                 }
             }
         ]

--- a/sources/it/45/ra.json
+++ b/sources/it/45/ra.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://www.dropbox.com/scl/fi/xcsm3ls391w28a9nso4hj/ravenna.zip?rlkey=s03pw3c3i4n4g2ix60v9xr7sg&st=di39ypx9&dl=1",
+                "data": "https://www.dropbox.com/scl/fi/ngtlzofka9gmd0zd1ikqk/V_NCV_GPT.zip?rlkey=l38pe4cgjfvqkjo7qsiof271j&st=xudplxxf&dl=1",
                 "website": "http://geoportale.regione.emilia-romagna.it/it/download/dati-e-prodotti-cartografici-preconfezionati/database-topografico/gestione-viabilita-e-indirizzi/dati-preconfezionati-dbtr-civico-ncv_gpt",
                 "license": {
                     "url": "https://creativecommons.org/licenses/by/4.0/deed.it",
@@ -39,7 +39,7 @@
                     "region": "Emilia-Romagna",
                     "id": "ID_E",
                     "format": "shapefile",
-                    "file": "ravenna.shp"
+                    "file": "V_NCV_GPT.shp"
                 }
             }
         ]

--- a/sources/it/45/ra.json
+++ b/sources/it/45/ra.json
@@ -14,10 +14,10 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "http://geoportale.regione.emilia-romagna.it/it/download/dati-e-prodotti-cartografici-preconfezionati/database-topografico/tutti-download-preconfezionati/dati_dbtr_V_NCV_GPT_Ravenna.zip",
+                "data": "https://www.dropbox.com/scl/fi/xcsm3ls391w28a9nso4hj/ravenna.zip?rlkey=s03pw3c3i4n4g2ix60v9xr7sg&st=di39ypx9&dl=1",
                 "website": "http://geoportale.regione.emilia-romagna.it/it/download/dati-e-prodotti-cartografici-preconfezionati/database-topografico/gestione-viabilita-e-indirizzi/dati-preconfezionati-dbtr-civico-ncv_gpt",
                 "license": {
-                    "url": "http://geoportale.regione.emilia-romagna.it/it/allegati/Licenza_CC-BY_2.5.pdf/view",
+                    "url": "https://creativecommons.org/licenses/by/4.0/deed.it",
                     "attribution": true,
                     "share-alike": false
                 },
@@ -27,20 +27,19 @@
                 "conform": {
                     "number": {
                         "fields": [
-                            "nm_civ",
-                            "sb_civ"
+                            "NM_CIV",
+                            "SB_CIV"
                         ],
                         "function": "join",
                         "separator": "/"
                     },
-                    "street": "tp_nom",
-                    "city": "nome_c",
-                    "district": "nm_prv",
+                    "street": "TP_NOM",
+                    "city": "NOME_C",
+                    "district": "NM_PRV",
                     "region": "Emilia-Romagna",
-                    "id": "id_e",
+                    "id": "ID_E",
                     "format": "shapefile",
-                    "file": "V_NCV_GPT.shp",
-                    "accuracy": 1
+                    "file": "ravenna.shp"
                 }
             }
         ]

--- a/sources/it/45/ra.json
+++ b/sources/it/45/ra.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://www.dropbox.com/scl/fi/ngtlzofka9gmd0zd1ikqk/V_NCV_GPT.zip?rlkey=l38pe4cgjfvqkjo7qsiof271j&st=xudplxxf&dl=1",
+                "data": "https://data.openaddresses.io/cache/uploads/stepps00/2024-11-04-chqzp/V_NCV_GPT.zip",
                 "website": "http://geoportale.regione.emilia-romagna.it/it/download/dati-e-prodotti-cartografici-preconfezionati/database-topografico/gestione-viabilita-e-indirizzi/dati-preconfezionati-dbtr-civico-ncv_gpt",
                 "license": {
                     "url": "https://creativecommons.org/licenses/by/4.0/deed.it",

--- a/sources/it/45/re.json
+++ b/sources/it/45/re.json
@@ -14,10 +14,10 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "http://geoportale.regione.emilia-romagna.it/it/download/dati-e-prodotti-cartografici-preconfezionati/database-topografico/tutti-download-preconfezionati/dati_dbtr_V_NCV_GPT_ReggioEmilia.zip",
+                "data": "https://www.dropbox.com/scl/fi/n1yjnswwzzleaptyghsej/reggio-emilia.zip?rlkey=1r0mxjb6e6zw661c078mt4lke&st=t8q0lyim&dl=1",
                 "website": "http://geoportale.regione.emilia-romagna.it/it/download/dati-e-prodotti-cartografici-preconfezionati/database-topografico/gestione-viabilita-e-indirizzi/dati-preconfezionati-dbtr-civico-ncv_gpt",
                 "license": {
-                    "url": "http://geoportale.regione.emilia-romagna.it/it/allegati/Licenza_CC-BY_2.5.pdf/view",
+                    "url": "https://creativecommons.org/licenses/by/4.0/deed.it",
                     "attribution": true,
                     "share-alike": false
                 },
@@ -27,20 +27,19 @@
                 "conform": {
                     "number": {
                         "fields": [
-                            "nm_civ",
-                            "sb_civ"
+                            "NM_CIV",
+                            "SB_CIV"
                         ],
                         "function": "join",
                         "separator": "/"
                     },
-                    "street": "tp_nom",
-                    "city": "nome_c",
-                    "district": "nm_prv",
+                    "street": "TP_NOM",
+                    "city": "NOME_C",
+                    "district": "NM_PRV",
                     "region": "Emilia-Romagna",
-                    "id": "id_e",
+                    "id": "ID_E",
                     "format": "shapefile",
-                    "file": "V_NCV_GPT.shp",
-                    "accuracy": 1
+                    "file": "reggio-emilia.shp"
                 }
             }
         ]

--- a/sources/it/45/re.json
+++ b/sources/it/45/re.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://www.dropbox.com/scl/fi/ngtlzofka9gmd0zd1ikqk/V_NCV_GPT.zip?rlkey=l38pe4cgjfvqkjo7qsiof271j&st=vx3xqdif&dl=1",
+                "data": "https://data.openaddresses.io/cache/uploads/stepps00/2024-11-04-0bqaj/V_NCV_GPT.zip",
                 "website": "http://geoportale.regione.emilia-romagna.it/it/download/dati-e-prodotti-cartografici-preconfezionati/database-topografico/gestione-viabilita-e-indirizzi/dati-preconfezionati-dbtr-civico-ncv_gpt",
                 "license": {
                     "url": "https://creativecommons.org/licenses/by/4.0/deed.it",

--- a/sources/it/45/re.json
+++ b/sources/it/45/re.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://www.dropbox.com/scl/fi/n1yjnswwzzleaptyghsej/reggio-emilia.zip?rlkey=1r0mxjb6e6zw661c078mt4lke&st=t8q0lyim&dl=1",
+                "data": "https://www.dropbox.com/scl/fi/ngtlzofka9gmd0zd1ikqk/V_NCV_GPT.zip?rlkey=l38pe4cgjfvqkjo7qsiof271j&st=vx3xqdif&dl=1",
                 "website": "http://geoportale.regione.emilia-romagna.it/it/download/dati-e-prodotti-cartografici-preconfezionati/database-topografico/gestione-viabilita-e-indirizzi/dati-preconfezionati-dbtr-civico-ncv_gpt",
                 "license": {
                     "url": "https://creativecommons.org/licenses/by/4.0/deed.it",
@@ -39,7 +39,7 @@
                     "region": "Emilia-Romagna",
                     "id": "ID_E",
                     "format": "shapefile",
-                    "file": "reggio-emilia.shp"
+                    "file": "V_NCV_GPT.shp"
                 }
             }
         ]

--- a/sources/it/45/rn.json
+++ b/sources/it/45/rn.json
@@ -14,10 +14,10 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "http://geoportale.regione.emilia-romagna.it/it/download/dati-e-prodotti-cartografici-preconfezionati/database-topografico/tutti-download-preconfezionati/dati_dbtr_V_NCV_GPT_Rimini.zip",
+                "data": "https://www.dropbox.com/scl/fi/5rx28iumfwb6nd1dx5xxn/rimini.zip?rlkey=h7psxb9ljcozuv2eve5f8imxs&st=ppz5y663&dl=1",
                 "website": "http://geoportale.regione.emilia-romagna.it/it/download/dati-e-prodotti-cartografici-preconfezionati/database-topografico/gestione-viabilita-e-indirizzi/dati-preconfezionati-dbtr-civico-ncv_gpt",
                 "license": {
-                    "url": "http://geoportale.regione.emilia-romagna.it/it/allegati/Licenza_CC-BY_2.5.pdf/view",
+                    "url": "https://creativecommons.org/licenses/by/4.0/deed.it",
                     "attribution": true,
                     "share-alike": false
                 },
@@ -27,20 +27,19 @@
                 "conform": {
                     "number": {
                         "fields": [
-                            "nm_civ",
-                            "sb_civ"
+                            "NM_CIV",
+                            "SB_CIV"
                         ],
                         "function": "join",
                         "separator": "/"
                     },
-                    "street": "tp_nom",
-                    "city": "nome_c",
-                    "district": "nm_prv",
+                    "street": "TP_NOM",
+                    "city": "NOME_C",
+                    "district": "NM_PRV",
                     "region": "Emilia-Romagna",
-                    "id": "id_e",
+                    "id": "ID_E",
                     "format": "shapefile",
-                    "file": "V_NCV_GPT.shp",
-                    "accuracy": 1
+                    "file": "rimini.shp"
                 }
             }
         ]

--- a/sources/it/45/rn.json
+++ b/sources/it/45/rn.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://www.dropbox.com/scl/fi/ngtlzofka9gmd0zd1ikqk/V_NCV_GPT.zip?rlkey=l38pe4cgjfvqkjo7qsiof271j&st=udq0giui&dl=1",
+                "data": "https://data.openaddresses.io/cache/uploads/stepps00/2024-11-04-ugita/V_NCV_GPT.zip",
                 "website": "http://geoportale.regione.emilia-romagna.it/it/download/dati-e-prodotti-cartografici-preconfezionati/database-topografico/gestione-viabilita-e-indirizzi/dati-preconfezionati-dbtr-civico-ncv_gpt",
                 "license": {
                     "url": "https://creativecommons.org/licenses/by/4.0/deed.it",

--- a/sources/it/45/rn.json
+++ b/sources/it/45/rn.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://www.dropbox.com/scl/fi/5rx28iumfwb6nd1dx5xxn/rimini.zip?rlkey=h7psxb9ljcozuv2eve5f8imxs&st=ppz5y663&dl=1",
+                "data": "https://www.dropbox.com/scl/fi/ngtlzofka9gmd0zd1ikqk/V_NCV_GPT.zip?rlkey=l38pe4cgjfvqkjo7qsiof271j&st=udq0giui&dl=1",
                 "website": "http://geoportale.regione.emilia-romagna.it/it/download/dati-e-prodotti-cartografici-preconfezionati/database-topografico/gestione-viabilita-e-indirizzi/dati-preconfezionati-dbtr-civico-ncv_gpt",
                 "license": {
                     "url": "https://creativecommons.org/licenses/by/4.0/deed.it",
@@ -39,7 +39,7 @@
                     "region": "Emilia-Romagna",
                     "id": "ID_E",
                     "format": "shapefile",
-                    "file": "rimini.shp"
+                    "file": "V_NCV_GPT.shp"
                 }
             }
         ]


### PR DESCRIPTION
This pull request updates data sources used in the Emilia Romagna region of Italy.

~~Data was processed and uploaded to Dropbox, but will need to be re-hosted. The process for generating the files in Dropbox is as follows (required nine times, once per commune within Emilia Romagna):~~

~~- Navigate to https://geoportale.regione.emilia-romagna.it/download/download-data?type=dbtopo~~
~~- Select the " DBTR - Civico - (NCV_GPT) - LimiteProvinciale (4000 Kmq)" layer~~
~~- Under "Area di interesse" select "Area personalizzata"~~
~~- Select a commune in the popup window~~
~~- Submit the form with an email~~

~~An email with a link to a zip file is provided. No additional data processing should be necessary.~~

Data urls have been updated and tested the batch-machine tooling.