### PR TITLE
Updated Sicily Data

### DIFF
--- a/sources/it/82/statewide.json
+++ b/sources/it/82/statewide.json
@@ -13,7 +13,7 @@
         "addresses": [
             {
                 "name": "state",
-                "data": "https://jeffu.dev/data/it_82_addresses.geojson.zip",
+                "data": "https://data.openaddresses.io/cache/uploads/jeffdefacto/2024-11-03-gq20m/it_82_addresses.geojson.zip",
                 "website": "https://dati.regione.sicilia.it/dataset/carta-tecnica-numerica-scala-1-2-000-numeri-civici",
                 "note": "Website is dead but page and data can be viewed in Wayback Machine",
                 "license": {

--- a/sources/it/82/statewide.json
+++ b/sources/it/82/statewide.json
@@ -13,12 +13,15 @@
         "addresses": [
             {
                 "name": "state",
-                "data": "https://data.openaddresses.io/cache/uploads/sergiyprotsiv/6ed902/addresses.zip",
-                "website": "http://www.regione.sicilia.it/opendata/Numeri_Civici_CTN2000.zip",
+                "data": "https://jeffu.dev/data/it_82_addresses.geojson.zip",
+                "website": "https://dati.regione.sicilia.it/dataset/carta-tecnica-numerica-scala-1-2-000-numeri-civici",
+                "note": "Website is dead but page and data can be viewed in Wayback Machine",
                 "license": {
-                    "url": "https://creativecommons.org/licenses/by-sa/3.0/",
+                    "url": "https://creativecommons.org/licenses/by/4.0/",
+                    "text": "CC-BY 4.0",
                     "attribution": true,
-                    "share-alike": true
+                    "atrribution name": "Regione Siciliana",
+                    "share-alike": false
                 },
                 "protocol": "http",
                 "language": "it",


### PR DESCRIPTION
Updated Sicily to CC-BY 4.0 license.

The website is down but internet archive captured the page and the data [here](https://web.archive.org/web/20220927231744/https://dati.regione.sicilia.it/dataset/carta-tecnica-numerica-scala-1-2-000-numeri-civici) in 2022.

I don't believe there is any difference in the data between the current CC-SA dataset and the CC-BY version but to avoid any potential issue, I've repackaged the data from the source.