### PR TITLE
Updated Toscana data

### DIFF
--- a/sources/it/52/statewide.json
+++ b/sources/it/52/statewide.json
@@ -13,7 +13,7 @@
         "addresses": [
             {
                 "name": "state",
-                "data": "https://jeffu.dev/data/IT_52_2022_06.zip",
+                "data": "https://data.openaddresses.io/cache/uploads/jeffdefacto/2024-11-03-ggsh6/IT_52_2022_06.zip",
                 "website": "http://www502.regione.toscana.it/geoscopio/download/grafo_stradale/",
                 "license": {
                     "url": "https://creativecommons.org/licenses/by/4.0",

--- a/sources/it/52/statewide.json
+++ b/sources/it/52/statewide.json
@@ -13,12 +13,14 @@
         "addresses": [
             {
                 "name": "state",
-                "data": "https://data.openaddresses.io/cache/uploads/migurski/e0f26a/toscana20160804-utf8.zip",
-                "website": "http://dati.toscana.it/dataset/grafo-civici/resource/07ebfc93-ff38-404a-8f2f-1f3dffe0b280",
+                "data": "https://jeffu.dev/data/IT_52_2022_06.zip",
+                "website": "http://www502.regione.toscana.it/geoscopio/download/grafo_stradale/",
                 "license": {
-                    "url": "https://creativecommons.org/licenses/by-sa/4.0/",
+                    "url": "https://creativecommons.org/licenses/by/4.0",
+                    "text": "CC-BY 4.0",
+                    "attribution text": "Regione Toscana",
                     "attribution": true,
-                    "share-alike": true
+                    "share-alike": false
                 },
                 "protocol": "http",
                 "compression": "zip",
@@ -33,7 +35,7 @@
                     "region": "Toscana",
                     "id": "cod_civ",
                     "format": "shapefile",
-                    "file": "shp/civici.shp",
+                    "file": "IT_52_2022_06/civici.shp",
                     "accuracy": 1
                 }
             }


### PR DESCRIPTION
Updates Toscana to latest data which is from June 2022.

There are 40k or so more addresses, but most notably the license changed at some point to CC-BY 4.0.

Source is still at http://www502.regione.toscana.it/geoscopio/download/grafo_stradale/ and the data unfortunately still comes as a zip within a zip so won't build directly. 