### PR TITLE
Update regexes for Alpine County

### DIFF
--- a/sources/us/ca/alpine.json
+++ b/sources/us/ca/alpine.json
@@ -25,18 +25,25 @@
                         "field": "Situs"
                     },
                     "street": {
-                        "function": "postfixed_street",
-                        "field": "Situs"
+                        "function": "regexp",
+                        "field": "Situs",
+                        "pattern": "[0-9]+ ([A-Za-z0-9/\\- ]*)(?: +##? *(?:.*))?$"
+                    },
+                    "unit": {
+                        "function": "regexp",
+                        "field": "Situs",
+                        "pattern": "[0-9]+ ([A-Za-z0-9/\\- ]*)( +##? *(.*))?$",
+                        "replace": "$3"
                     },
                     "city": {
                         "function": "regexp",
                         "field": "SITUSCITY",
-                        "pattern": "^([a-zA-Z ]+) [A-Z]{2}$"
+                        "pattern": "^([a-zA-Z ]+) [A-Z]{2}\\s?$"
                     },
                     "region": {
                         "function": "regexp",
                         "field": "SITUSCITY",
-                        "pattern": " ([A-Z]{2})$"
+                        "pattern": " ([A-Z]{2})\\s?$"
                     }
                 }
             }


### PR DESCRIPTION
Apparently there's a trailing space in `SITUSCITY`.  Also now it catches unit numbers.  The dataset is so small I manually reviewed the entire thing and the regexes work perfectly except for a small handful of addresses the county typed in wrong.