### PR TITLE
Revert Dooly County because source was a different county

### DIFF
--- a/sources/us/ga/dooly.json
+++ b/sources/us/ga/dooly.json
@@ -14,16 +14,21 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://services6.arcgis.com/VKHi8CC6pMIyYUIs/ArcGIS/rest/services/Address_Point_Master_File/FeatureServer/1",
-                "protocol": "ESRI",
+                "data": "https://data.openaddresses.io/cache/us-ga-dooly_county.csv",
+                "protocol": "http",
                 "conform": {
-                    "format": "geojson",
-                    "number": "AN",
-                    "street": "FullStreet",
-                    "unit": [
-                        "SecUnit",
-                        "SecRange"
-                    ]
+                    "format": "csv",
+                    "lat": "LAT",
+                    "lon": "LNG",
+                    "number": {
+                        "function": "prefixed_number",
+                        "field": "STR"
+                    },
+                    "street": {
+                        "function": "postfixed_street",
+                        "field": "STR"
+                    },
+                    "region": "REGION"
                 }
             }
         ]


### PR DESCRIPTION
The source was not Dooly County, and as far as I can tell Dooly doesn't have a publicly available and usable address source.