### PR TITLE
Saxony-Anhalt statewide dataset

### DIFF
--- a/sources/de/st/statewide.json
+++ b/sources/de/st/statewide.json
@@ -24,7 +24,6 @@
                 "conform": {
                     "format": "csv",
                     "csvsplit": ";",
-                    "file": "Gebaeudereferenzen_st_202403.txt",
                     "srs": "EPSG:25832",
                     "headers": -1,
                     "street": "COLUMN15",

--- a/sources/de/st/statewide.json
+++ b/sources/de/st/statewide.json
@@ -1,0 +1,42 @@
+{
+    "coverage": {
+        "country": "de",
+        "state": "st",
+        "ISO 3166": {
+            "alpha2": "DE-ST"
+        }
+    },
+    "schema": 2,
+    "layers": {
+        "addresses": [
+            {
+                "name": "state",
+                "data": "https://www.lvermgeo.sachsen-anhalt.de/datei/anzeigen/id/258997,501/gebaeudereferenzen.zip",
+                "website": "https://www.lvermgeo.sachsen-anhalt.de/de/gdp-open-data.html",
+                "protocol": "http",
+                "compression": "zip",
+                "license": {
+                    "url": "https://www.govdata.de/dl-de/by-2-0",
+                    "text": "DL-DE->BY-2.0",
+                    "attribution": true,
+                    "attribution name": "LVermGeo"
+                },
+                "conform": {
+                    "format": "csv",
+                    "csvsplit": ";",
+                    "file": "Gebaeudereferenzen_st_202403.txt",
+                    "srs": "EPSG:25832",
+                    "headers": -1,
+                    "street": "COLUMN15",
+                    "number": "COLUMN16",
+                    "unit": "COLUMN17",
+                    "city": "COLUMN11",
+                    "district": "COLUMN9",
+                    "region": "COLUMN5",
+                    "lat": "COLUMN20",
+                    "lon": "COLUMN19"
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Adds statewide addresses for Saxony-Anhalt under a DL-DE->BY-2.0 license.