### PR TITLE
Update city field and remove extra unit field for Grady GA

### DIFF
--- a/sources/us/ga/grady.json
+++ b/sources/us/ga/grady.json
@@ -24,11 +24,8 @@
                         "addrnumsuf"
                     ],
                     "street": "fullname",
-                    "unit": [
-                        "unittype",
-                        "unitid"
-                    ],
-                    "city": "msag",
+                    "unit": "unitid",
+                    "city": "municipality",
                     "region": "stateabbreviation"
                 }
             }


### PR DESCRIPTION
I removed `unittype` because it appears to be set to "BLDG" all the time.