### PR TITLE
Update Toscana attribution name

### DIFF
--- a/sources/it/52/statewide.json
+++ b/sources/it/52/statewide.json
@@ -18,7 +18,7 @@
                 "license": {
                     "url": "https://creativecommons.org/licenses/by/4.0",
                     "text": "CC-BY 4.0",
-                    "attribution text": "Regione Toscana",
+                    "attribution name": "Regione Toscana",
                     "attribution": true,
                     "share-alike": false
                 },


### PR DESCRIPTION
Change `attribution text` to `attribution name` to match the typical standard