### PR TITLE
California county license updates

### DIFF
--- a/sources/us/ca/los_angeles.json
+++ b/sources/us/ca/los_angeles.json
@@ -46,11 +46,7 @@
                     ],
                     "postcode": "Zipcode",
                     "city": "PostComm1",
-                    "format": "geojson",
-                    "region": {
-                        "function": "constant",
-                        "value": "CA"
-                    }
+                    "format": "geojson"
                 }
             }
         ],

--- a/sources/us/ca/los_angeles.json
+++ b/sources/us/ca/los_angeles.json
@@ -14,11 +14,13 @@
         "addresses": [
             {
                 "name": "county",
-                "attribution": "Los Angeles County",
                 "data": "https://arcgis.gis.lacounty.gov/arcgis/rest/services/LACounty_Dynamic/CAMS/MapServer/1",
                 "license": {
-                    "url": "https://cams-lacounty.hub.arcgis.com/pages/cams-disclaimer",
-                    "text": "Indemnification"
+                    "url": "https://lacounty.maps.arcgis.com/sharing/rest/content/items/fa47b95a2f704df094cc19b834f4fb07/data",
+                    "text": "license to copy, publish, distribute and/or transmit the Data, to adapt the Data and to exploit the Data for commercial and/or personal use",
+                    "attribution name": "Los Angeles County",
+                    "attribution": false,
+                    "share-alike": false
                 },
                 "website": "https://data.lacounty.gov/datasets/cams-export-data/about",
                 "protocol": "ESRI",
@@ -44,7 +46,11 @@
                     ],
                     "postcode": "Zipcode",
                     "city": "PostComm1",
-                    "format": "geojson"
+                    "format": "geojson",
+                    "region": {
+                        "function": "constant",
+                        "value": "CA"
+                    }
                 }
             }
         ],

--- a/sources/us/ca/napa.json
+++ b/sources/us/ca/napa.json
@@ -17,7 +17,13 @@
                 "protocol": "ESRI",
                 "attribution": "Napa County",
                 "website": "https://gisdata.countyofnapa.org/datasets/napacounty::addresses-all/about",
-                "license": "https://opendatacommons.org/licenses/pddl/summary/",
+                "license": {
+                    "url": "https://opendatacommons.org/licenses/pddl/1-0/",
+                    "text": "Public Domain Dedication and License (PDDL) v1.0",
+                    "attribution": false,
+                    "share-alike": false,
+                    "attribution name": "Napa County"
+                },
                 "data": "https://services1.arcgis.com/Ko5rxt00spOfjMqj/arcgis/rest/services/Addresses_All/FeatureServer/0",
                 "conform": {
                     "number": "addressnum",
@@ -30,6 +36,10 @@
                     ],
                     "unit": "unitid",
                     "city": "postalarea",
+                    "region": {
+                        "function": "constant",
+                        "value": "CA"
+                    },
                     "postcode": "zip",
                     "format": "geojson"
                 }

--- a/sources/us/ca/napa.json
+++ b/sources/us/ca/napa.json
@@ -36,10 +36,6 @@
                     ],
                     "unit": "unitid",
                     "city": "postalarea",
-                    "region": {
-                        "function": "constant",
-                        "value": "CA"
-                    },
                     "postcode": "zip",
                     "format": "geojson"
                 }

--- a/sources/us/ca/nevada.json
+++ b/sources/us/ca/nevada.json
@@ -17,7 +17,14 @@
                 "attribution": "County of Nevada, California",
                 "data": "https://maps.nevadacountyca.gov/arcgis/rest/services/web_public/Open_Data_Layers_Nevada_County/MapServer/100",
                 "protocol": "ESRI",
-                "website": "https://maps-nevcounty.opendata.arcgis.com/",
+                "website": "https://maps-nevcounty.opendata.arcgis.com/datasets/nevcounty::parcel-situs-address/about",
+                "license": {
+                    "url": "http://creativecommons.org/licenses/by/4.0",
+                    "text": "CC BY 4.0",
+                    "attribution": true,
+                    "attribution name": "Nevada County",
+                    "share-alike": false
+                },
                 "conform": {
                     "number": "HouseNumber",
                     "street": "FullStreetName",

--- a/sources/us/ca/santa_cruz.json
+++ b/sources/us/ca/santa_cruz.json
@@ -20,9 +20,19 @@
                     "number": "SITNUMBER",
                     "street": "SITSTREET",
                     "postcode": "SITZIP",
-                    "city": "SITCITY"
+                    "city": "SITCITY",
+                    "region": {
+                        "function": "constant",
+                        "value": "CA"
+                    }
                 },
-                "attribution": "Santa Cruz County",
+                "license": {
+                    "url": "https://www.santacruzcountyca.gov/departments/geographicinformationsystems(gis).aspx",
+                    "text": "All datasets are free to download, use, and share without attribution.",
+                    "attribution name": "Santa Cruz County",
+                    "attribution": false,
+                    "share-alike": false
+                },
                 "data": "https://services1.arcgis.com/jJfZghspGKh8J9Jm/ArcGIS/rest/services/Address_Point/FeatureServer/1",
                 "website": "https://opendata-sccgis.opendata.arcgis.com/datasets/26baf9acc787499686576b5cc2f82fc6_1/about",
                 "protocol": "ESRI"

--- a/sources/us/ca/santa_cruz.json
+++ b/sources/us/ca/santa_cruz.json
@@ -20,11 +20,7 @@
                     "number": "SITNUMBER",
                     "street": "SITSTREET",
                     "postcode": "SITZIP",
-                    "city": "SITCITY",
-                    "region": {
-                        "function": "constant",
-                        "value": "CA"
-                    }
+                    "city": "SITCITY"
                 },
                 "license": {
                     "url": "https://www.santacruzcountyca.gov/departments/geographicinformationsystems(gis).aspx",


### PR DESCRIPTION
Added or clarified licenses for LA, Napa, Nevada, and Santa Cruz counties and added `CA` as the region to the datasets missing it.