### PR TITLE
Bulgaria addresses and buildings

### DIFF
--- a/sources/bg/countrywide.json
+++ b/sources/bg/countrywide.json
@@ -1,0 +1,39 @@
+{
+    "coverage": {
+        "country": "bg",
+        "ISO 3166": {
+            "alpha2": "BG",
+            "country": "Bulgaria"
+        }
+    },
+    "schema": 2,
+    "layers": {
+        "addresses": [
+            {
+                "name": "country",
+                "data": "https://data.openaddresses.io/cache/uploads/jeffdefacto/2025-01-07-a0j8a/bulgaria.zip",
+                "website": "https://kais.cadastre.bg/bg/OpenData",
+                "protocol": "http",
+                "compression": "zip",
+                "conform": {
+                    "format": "shapefile",
+                    "city": "ekattefn",
+                    "street": "strename",
+                    "number": "strnum"
+                }
+            }
+        ],
+        "buildings": [
+            {
+                "name": "country",
+                "data": "https://data.openaddresses.io/cache/uploads/jeffdefacto/2025-01-07-a0j8a/bulgaria.zip",
+                "website": "https://kais.cadastre.bg/bg/OpenData",
+                "protocol": "http",
+                "compression": "zip",
+                "conform": {
+                    "format": "shapefile"
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Data is listed as Open Data on their site https://kais.cadastre.bg/bg/OpenData. I dug around quite a bit but could not find any clarification on licensing unfortunately but hopefully it will come soon.

Building coverage seems pretty complete but I did notice that most of Lovech Province is currently missing. Extracted address data from the buildings is about 2/3 complete and is missing postal codes but its a good starting point. 

The data is broken up into about 4500 zip files so manual assembly is pretty necessary unfortunately. I believe I captured all the URLs in this text file ([bulgaria_urls.txt](https://github.com/user-attachments/files/18339380/bulgaria_urls.txt)) which can be used for future refreshing. I didn't write a script but the workflow was to download all of them, unzip, and then merge with `ogrmerge -single -f parquet -o bulgaria.parquet */*.shp`.