### PR TITLE
Hsinchu County Taiwan addresses

### DIFF
--- a/sources/tw/hsq/regionwide.json
+++ b/sources/tw/hsq/regionwide.json
@@ -1,0 +1,57 @@
+{
+    "coverage": {
+        "ISO 3166": {
+            "alpha2": "TW-HSQ",
+            "country": "Taiwan"
+        },
+        "country": "tw"
+    },
+    "schema": 2,
+    "layers": {
+        "addresses": [
+            {
+                "name": "state",
+                "website": "https://data.gov.tw/dataset/172380",
+                "data": "https://data.openaddresses.io/cache/uploads/jeffdefacto/2025-01-08-745q1/hsinchu_county.csv.zip",
+                "license": {
+                    "text": "CC BY 4.0",
+                    "url": "https://data.gov.tw/license",
+                    "attribution": true,
+                    "attribution name": "Hsinchu County Civil Affairs Office",
+                    "share-alike": false
+                },
+                "protocol": "http",
+                "compression": "zip",
+                "conform": {
+                    "format": "csv",
+                    "srs": "EPSG:4326",
+                    "number": {
+                        "function": "regexp",
+                        "field": "number",
+                        "pattern": "^([0-9０-９]+號?)"
+                    },
+                    "unit": {
+                        "function": "regexp",
+                        "field": "number",
+                        "pattern": "^(?:[0-9０-９]+號?)(.*)"
+                    },
+                    "street": {
+                        "function": "join",
+                        "fields": [
+                            "street",
+                            "area",
+                            "lane",
+                            "alley"
+                        ],
+                        "separator": ""
+                    },
+                    "city": "village",
+                    "district": "town",
+                    "region": "county",
+                    "lat": "Y",
+                    "lon": "X"
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
CC BY 4.0 compatible addresses for the county.

See the previous TW PR [here](https://github.com/openaddresses/openaddresses/pull/7479) on some of the data preparation steps.