### PR TITLE
Hsinchu City Taiwan addresses

### DIFF
--- a/sources/tw/hsz/regionwide.json
+++ b/sources/tw/hsz/regionwide.json
@@ -1,0 +1,52 @@
+{
+    "coverage": {
+        "ISO 3166": {
+            "alpha2": "TW-HSZ",
+            "country": "Taiwan"
+        },
+        "country": "tw"
+    },
+    "schema": 2,
+    "layers": {
+        "addresses": [
+            {
+                "name": "state",
+                "website": "https://data.gov.tw/dataset/157547",
+                "data": "https://data.openaddresses.io/cache/uploads/jeffdefacto/2025-01-08-4wtub/hsinchu_city.csv.zip",
+                "license": {
+                    "text": "CC BY 4.0",
+                    "url": "https://data.gov.tw/license",
+                    "attribution": true,
+                    "attribution name": "Hsinchu City Civil Affairs Office",
+                    "share-alike": false
+                },
+                "protocol": "http",
+                "compression": "zip",
+                "conform": {
+                    "format": "csv",
+                    "srs": "EPSG:4326",
+                    "number": {
+                        "function": "regexp",
+                        "field": "address",
+                        "pattern": "^(?:.*?)([0-9０-９]+號)"
+                    },
+                    "unit": {
+                        "function": "regexp",
+                        "field": "address",
+                        "pattern": "^(?:.*號)(.*)"
+                    },
+                    "street": {
+                        "function": "regexp",
+                        "field": "address",
+                        "pattern": "^(.*?)(?:[0-9０-９]+號)"
+                    },
+                    "city": "village",
+                    "district": "town",
+                    "region": "county",
+                    "lat": "Y",
+                    "lon": "X"
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
CC BY 4.0 compatible addresses for the city.

See the previous TW PR https://github.com/openaddresses/openaddresses/pull/7479 on some of the data preparation steps.