### PR TITLE
update au/nsw source mirror

### DIFF
--- a/sources/au/nsw/statewide.json
+++ b/sources/au/nsw/statewide.json
@@ -81,7 +81,7 @@
         "parcels": [
             {
                 "name": "state",
-                "data": "https://data.openaddresses.io/cache/uploads/andrewharvey-openaddr/a68135/NSW_Property.zip",
+                "data": "https://www.alantgeo.com.au/share/NSWLandParcelPropertyTheme_Lot.zip",
                 "compression": "zip",
                 "website": "https://portal.spatial.nsw.gov.au/portal/home/item.html?id=6a96afdba8d6407d8bde5a3bbacb0f02",
                 "license": {
@@ -94,7 +94,7 @@
                 "protocol": "http",
                 "conform": {
                     "format": "gdb",
-                    "pid": "propid"
+                    "pid": "planoid"
                 }
             }
         ]


### PR DESCRIPTION
The OA upload-cache being a web form is hard for me to keep updated.

I have a cron job which sends a request for fresh data, and I then receive an email with a link. This way I can just `wget` the data straight on the server.

Long term it would be good to have OpenAddresses directly receive the email and automatically download/update it, but until now I'll keep doing it manually.