### PR TITLE
Update Massachusetts source

### DIFF
--- a/sources/us/ma/statewide.json
+++ b/sources/us/ma/statewide.json
@@ -12,14 +12,14 @@
         "addresses": [
             {
                 "name": "state",
-                "data": "https://arcgisserver.digital.mass.gov/arcgisserver/rest/services/AGOL/MassGIS_Master_Address_Points/MapServer/0",
+                "data": "https://hub.arcgis.com/api/v3/datasets/c33281538f854507a90351760c3468fc_0/downloads/data?format=geojson&spatialRefId=4326&where=1%3D1",
                 "website": "https://gis.data.mass.gov/maps/a0049ad319674c439516b2df1173d8f5/about",
                 "license": {
                     "text": "Public Domain",
                     "attribution name": "Office of Geographic Information (MassGIS), Commonwealth of Massachusetts, MassIT",
                     "share-alike": false
                 },
-                "protocol": "ESRI",
+                "protocol": "http",
                 "conform": {
                     "format": "geojson",
                     "number": "FULL_NUMBER_STANDARDIZED",


### PR DESCRIPTION
The web service is failing to fully download. This changes it to a geojson link instead.