### PR TITLE
County data marked as state

### DIFF
--- a/sources/us/co/sedgwick.json
+++ b/sources/us/co/sedgwick.json
@@ -6,13 +6,14 @@
             "state": "Colorado"
         },
         "country": "us",
-        "state": "co"
+        "state": "co",
+        "county": "Sedgwick"
     },
     "schema": 2,
     "layers": {
         "addresses": [
             {
-                "name": "state",
+                "name": "county",
                 "data": "https://gis.colorado.gov/public/rest/services/OIT/SedgwickCounty/MapServer/3",
                 "protocol": "ESRI",
                 "conform": {
@@ -25,7 +26,7 @@
         ],
         "parcels": [
             {
-                "name": "state",
+                "name": "county",
                 "data": "https://gis.colorado.gov/public/rest/services/OIT/SedgwickCounty/MapServer/3",
                 "protocol": "ESRI",
                 "conform": {


### PR DESCRIPTION
Sedgwick is a county extract on the state server, and should be marked as county.