### PR TITLE
Fixed URL to Hampton

### DIFF
--- a/sources/us/sc/hampton.json
+++ b/sources/us/sc/hampton.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://smpesri.scdot.org/arcgis/rest/services/GISMapping/SC_Parcels/MapServer/24",
+                "data": "https://smpesri.scdot.org/arcgis/rest/services/GISMapping/SC_Parcels/MapServer/25",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
@@ -26,7 +26,7 @@
         "parcels": [
             {
                 "name": "county",
-                "data": "https://smpesri.scdot.org/arcgis/rest/services/GISMapping/SC_Parcels/MapServer/24",
+                "data": "https://smpesri.scdot.org/arcgis/rest/services/GISMapping/SC_Parcels/MapServer/25",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",


### PR DESCRIPTION
Current URL is for Greenwood, which we already have a good source for.   Corrected URL to the Hampton folder.