### PR TITLE
Fixed URL to Kershaw

### DIFF
--- a/sources/us/sc/kershaw.json
+++ b/sources/us/sc/kershaw.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://smpesri.scdot.org/arcgis/rest/services/GISMapping/SC_Parcels/MapServer/27",
+                "data": "https://smpesri.scdot.org/arcgis/rest/services/GISMapping/SC_Parcels/MapServer/28",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
@@ -28,7 +28,7 @@
         "parcels": [
             {
                 "name": "county",
-                "data": "https://smpesri.scdot.org/arcgis/rest/services/GISMapping/SC_Parcels/MapServer/27",
+                "data": "https://smpesri.scdot.org/arcgis/rest/services/GISMapping/SC_Parcels/MapServer/28",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",


### PR DESCRIPTION
Current URL is for Jasper. Corrected URL to the Kershaw folder.