### PR TITLE
Remove incorrect State column from Del Norte

### DIFF
--- a/sources/us/ca/del_norte.json
+++ b/sources/us/ca/del_norte.json
@@ -25,7 +25,6 @@
                         "StreetType"
                     ],
                     "city": "Community",
-                    "region": "AddressSta",
                     "postcode": "Zip"
                 }
             }


### PR DESCRIPTION
State column previously used was for parcel owner's address presumably so contained other values beyond CA. Removed for now and can replaced with a constant in the future.