### PR TITLE
fix: Parcel ID for Burlington

### DIFF
--- a/sources/us/vt/city_of_burlington.json
+++ b/sources/us/vt/city_of_burlington.json
@@ -40,7 +40,7 @@
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
-                    "pid": "taxparcelid"
+                    "pid": "MAPLOTNO"
                 }
             }
         ]


### PR DESCRIPTION
The `taxparcelid` field doesn't exist in the source