### PR TITLE
Fix field name typo/mismatch city_of_bothell.json

### DIFF
--- a/sources/us/wa/city_of_bothell.json
+++ b/sources/us/wa/city_of_bothell.json
@@ -25,7 +25,7 @@
                     "street": [
                         "PreDir",
                         "Street",
-                        "Street_Typ",
+                        "Street_Type",
                         "PostDir"
                     ],
                     "city": "PostalCity",


### PR DESCRIPTION
Looks like there was either a typo in this field name that got in at some point, or Bothell changed their field names.

From https://gisweb.bothellwa.gov/server/rest/services/public/COBMap_Public_Property_Land/MapServer/0, the correct field name is `Street_Type`.