### PR TITLE
GH-5531: added parcels for 3 Regions + updated contact address

### DIFF
--- a/sources/be/bru/bosa-region-brussels-fr.json
+++ b/sources/be/bru/bosa-region-brussels-fr.json
@@ -43,12 +43,36 @@
                     "url": "https://creativecommons.org/licenses/by/4.0/",
                     "text": "CC-BY 4.0",
                     "attribution": true,
-                    "attribution name": "CIRB / SPRB"
+                    "attribution name": "Paradigm.Brussels"
                 },
                 "contact": {
                     "name": "Federal Public Service Policy and Support",
-                    "email": "opendata@belgium.be",
-                    "address": "Simon Bolivarlaan 30, WTC III, 1000 Brussels, Belgium"
+                    "email": "opendata@bosa.fgov.be",
+                    "address": "WTC III, Boulevard Simon Bolivar 30/1, 1000 Bruxelles, Belgium"
+                }
+            }
+        ],
+        "parcels": [
+            {
+                "name": "state",
+                "data": "https://opendata.fin.belgium.be/download/datasets/1d797df0-c988-11ed-abc3-0050569393d1_20250504_shp_3812_04000.zip",
+                "protocol": "http",
+                "conform": {
+                    "format": "shapefile",
+                    "pid": "CaPaKey"
+                },
+                "compression": "zip",
+                "website": "https://financien.belgium.be/fr/experts-partenaires/donnees-ouvertes-patrimoine/jeux-donnees/portail-telechargement",
+                "license": {
+                    "url": "https://creativecommons.org/licenses/by/4.0/",
+                    "text": "CC-BY 4.0",
+                    "attribution": true,
+                    "attribution name": "SPF Finances AGDP"
+                },
+                "contact": {
+                    "name": "Federal Public Service Finance AGDP",
+                    "email": "datadelivery@minfin.fed.be",
+                    "address": "North Galaxy, Boulevard du Roi Albert II 33, 1030 Schaarbeek, België Belgium"
                 }
             }
         ]

--- a/sources/be/bru/bosa-region-brussels-nl.json
+++ b/sources/be/bru/bosa-region-brussels-nl.json
@@ -43,12 +43,12 @@
                     "url": "https://creativecommons.org/licenses/by/4.0/",
                     "text": "CC-BY 4.0",
                     "attribution": true,
-                    "attribution name": "CIBG / GOB"
+                    "attribution name": "Paradigm.Brussels"
                 },
                 "contact": {
                     "name": "Federal Public Service Policy and Support",
-                    "email": "opendata@belgium.be",
-                    "address": "Simon Bolivarlaan 30, WTC III, 1000 Brussels, Belgium"
+                    "email": "opendata@bosa.fgov.be",
+                    "address": "WTC III, Simon Bolivarlaan 30/1, 1000 Brussel, Belgium"
                 }
             }
         ]

--- a/sources/be/vlg/bosa-region-flanders-fr.json
+++ b/sources/be/vlg/bosa-region-flanders-fr.json
@@ -43,12 +43,36 @@
                     "url": "https://creativecommons.org/licenses/by/4.0/",
                     "text": "CC-BY 4.0",
                     "attribution": true,
-                    "attribution name": "Informatie Vlaanderen"
+                    "attribution name": "Digitaal Vlaanderen"
                 },
                 "contact": {
                     "name": "Federal Public Service Policy and Support",
-                    "email": "opendata@belgium.be",
-                    "address": "Simon Bolivarlaan 30, WTC III, 1000 Brussels, Belgium"
+                    "email": "opendata@bosa.fgov.be",
+                    "address": "WTC III, Boulevard Simon Bolivar 30/1, 1000 Bruxelles, Belgium"
+                }
+            }
+        ],
+        "parcels": [
+            {
+                "name": "state",
+                "data": "https://opendata.fin.belgium.be/download/datasets/1d797df0-c988-11ed-abc3-0050569393d1_20250504_shp_3812_02000.zip",
+                "protocol": "http",
+                "conform": {
+                    "format": "shapefile",
+                    "pid": "CaPaKey"
+                },
+                "compression": "zip",
+                "website": "https://financien.belgium.be/fr/experts-partenaires/donnees-ouvertes-patrimoine/jeux-donnees/portail-telechargement",
+                "license": {
+                    "url": "https://creativecommons.org/licenses/by/4.0/",
+                    "text": "CC-BY 4.0",
+                    "attribution": true,
+                    "attribution name": "SPF Finances AGDP"
+                },
+                "contact": {
+                    "name": "Federal Public Service Finance AGDP",
+                    "email": "datadelivery@minfin.fed.be",
+                    "address": "North Galaxy, Boulevard du Roi Albert II 33, 1030 Schaarbeek, België Belgium"
                 }
             }
         ]

--- a/sources/be/vlg/bosa-region-flanders-nl.json
+++ b/sources/be/vlg/bosa-region-flanders-nl.json
@@ -43,12 +43,12 @@
                     "url": "https://creativecommons.org/licenses/by/4.0/",
                     "text": "CC-BY 4.0",
                     "attribution": true,
-                    "attribution name": "Informatie Vlaanderen"
+                    "attribution name": "Digitaal Vlaanderen"
                 },
                 "contact": {
                     "name": "Federal Public Service Policy and Support",
-                    "email": "opendata@belgium.be",
-                    "address": "Simon Bolivarlaan 30, WTC III, 1000 Brussels, Belgium"
+                    "email": "opendata@bosa.fgov.be",
+                    "address": "WTC III, Simon Bolivarlaan 30/1, 1000 Brussel, Belgium"
                 }
             }
         ]

--- a/sources/be/wal/bosa-region-wallonia-de.json
+++ b/sources/be/wal/bosa-region-wallonia-de.json
@@ -47,8 +47,8 @@
                 },
                 "contact": {
                     "name": "Federal Public Service Policy and Support",
-                    "email": "opendata@belgium.be",
-                    "address": "Simon Bolivarlaan 30, WTC III, 1000 Brussels, Belgium"
+                    "email": "opendata@bosa.fgov.be",
+                    "address": "WTC III, Simon Bolivarlaan 30/1, 1000 Brussel, Belgium"
                 }
             }
         ]

--- a/sources/be/wal/bosa-region-wallonia-fr.json
+++ b/sources/be/wal/bosa-region-wallonia-fr.json
@@ -47,8 +47,32 @@
                 },
                 "contact": {
                     "name": "Federal Public Service Policy and Support",
-                    "email": "opendata@belgium.be",
-                    "address": "Simon Bolivarlaan 30, WTC III, 1000 Brussels, Belgium"
+                    "email": "opendata@bosa.fgov.be",
+                    "address": "WTC III, Boulevard Simon Bolivar 30/1, 1000 Bruxelles, Belgium"
+                }
+            }
+        ],
+        "parcels": [
+            {
+                "name": "state",
+                "data": "https://opendata.fin.belgium.be/download/datasets/1d797df0-c988-11ed-abc3-0050569393d1_20250504_shp_3812_03000.zip",
+                "protocol": "http",
+                "conform": {
+                    "format": "shapefile",
+                    "pid": "CaPaKey"
+                },
+                "compression": "zip",
+                "website": "https://financien.belgium.be/fr/experts-partenaires/donnees-ouvertes-patrimoine/jeux-donnees/portail-telechargement",
+                "license": {
+                    "url": "https://creativecommons.org/licenses/by/4.0/",
+                    "text": "CC-BY 4.0",
+                    "attribution": true,
+                    "attribution name": "SPF Finances AGDP"
+                },
+                "contact": {
+                    "name": "Federal Public Service Finance AGDP",
+                    "email": "datadelivery@minfin.fed.be",
+                    "address": "North Galaxy, Boulevard du Roi Albert II 33, 1030 Schaarbeek, België Belgium"
                 }
             }
         ]


### PR DESCRIPTION
Added the parcel info on the "fr" files of the 3 Belgian Regions (not in nl, otherwise the same shapefiles get downloaded and processed twice...). Unfortunately there is no "latest version" link, so these shapefiles won't get updated, one has to manually change the links to newer files to get the new data... 

Also used a slightly different email and physical address for FPS Policy and Support for the addresses