### PR TITLE
Fix zipcodes on Seminole, FL and Clarke, GA

### DIFF
--- a/sources/us/fl/seminole.json
+++ b/sources/us/fl/seminole.json
@@ -33,7 +33,11 @@
                     ],
                     "unit": "ADDRESS2",
                     "city": "CITY",
-                    "postcode": "ZIP",
+                    "postcode": {
+                        "function": "regexp",
+                        "field": "ZIP",
+                        "pattern": "(.*)(?:\\.\\d+$)"
+                    },
                     "id": "PARCEL"
                 }
             }

--- a/sources/us/ga/clarke.json
+++ b/sources/us/ga/clarke.json
@@ -34,7 +34,11 @@
                     ],
                     "city": "POSTALCITY",
                     "region": "State",
-                    "postcode": "Zipcode"
+                    "postcode": {
+                        "function": "regexp",
+                        "field": "Zipcode",
+                        "pattern": "(.*)(?:\\.\\d+$)"
+                    }
                 }
             }
         ],


### PR DESCRIPTION
These zipcodes had a trailing `.0` for some reason. The regex removes it.