### PR TITLE
Fix Greenland attribution

### DIFF
--- a/sources/gl/countrywide.json
+++ b/sources/gl/countrywide.json
@@ -17,8 +17,7 @@
                     "url": "https://kortforsyning.asiaq.gl/Downloads/EN_Terms%20of%20use.pdf",
                     "attribution": true,
                     "attribution name": "Asiaq, Greenland Survey",
-                    "presumed": false,
-                    "remarks": "https://www.etalab.gouv.fr/wp-content/uploads/2018/11/open-licence.pdf"
+                    "share-alike": false
                 },
                 "compression": "zip",
                 "protocol": "http",


### PR DESCRIPTION
Autofill hallucinated some extra stuff in the json without me noticing.