### PR TITLE
fix typo in street field name for Norway countrywide

### DIFF
--- a/sources/no/countrywide.json
+++ b/sources/no/countrywide.json
@@ -30,7 +30,7 @@
                     "lon": "Øst",
                     "id": "adresseId",
                     "number": "nummer",
-                    "street": "addressenavn",
+                    "street": "adressenavn",
                     "unit": "bokstav",
                     "city": "poststed",
                     "postcode": "postnummer"


### PR DESCRIPTION
This should hopefully fix the problem in #7813 with no `street` data for Norway's countrywide data.