### PR TITLE
fix: us/nh/statewide

### DIFF
--- a/sources/us/nh/statewide.json
+++ b/sources/us/nh/statewide.json
@@ -12,7 +12,7 @@
         "addresses": [
             {
                 "name": "state",
-                "data": "https://nhgeodata.unh.edu/nhgeodata/rest/services/CAD/ParcelMosiac/MapServer/0",
+                "data": "https://nhgeodata.unh.edu/nhgeodata/rest/services/CAD/ParcelMosaic/MapServer/0",
                 "website": "https://new-hampshire-geodata-portal-1-nhgranit.hub.arcgis.com/datasets/NHGRANIT::parcel-points/about",
                 "protocol": "ESRI",
                 "conform": {
@@ -38,7 +38,7 @@
         "parcels": [
             {
                 "name": "state",
-                "data": "https://nhgeodata.unh.edu/nhgeodata/rest/services/CAD/ParcelMosiac/MapServer/1",
+                "data": "https://nhgeodata.unh.edu/nhgeodata/rest/services/CAD/ParcelMosaic/MapServer/1",
                 "website": "https://new-hampshire-geodata-portal-1-nhgranit.hub.arcgis.com/datasets/NHGRANIT::parcels-1/about",
                 "protocol": "ESRI",
                 "conform": {


### PR DESCRIPTION
Data URL had a spelling error