### PR TITLE
Update for units in us/sc/berkeley

### DIFF
--- a/sources/us/sc/berkeley.json
+++ b/sources/us/sc/berkeley.json
@@ -24,6 +24,11 @@
                     },
                     "street": {
                         "function": "postfixed_street",
+                        "field": "ADDRESS",
+                        "may_contain_units": true
+                    },
+                    "unit": {
+                        "function": "postfixed_unit",
                         "field": "ADDRESS"
                     },
                     "city": "CITY",


### PR DESCRIPTION
Some addresses have unit numbers after the street names.