### PR TITLE
migrate nz/countrywide to pilot dataset

### DIFF
--- a/sources/nz/countrywide.json
+++ b/sources/nz/countrywide.json
@@ -11,7 +11,7 @@
         "addresses": [
             {
                 "name": "country",
-                "data": "https://data.linz.govt.nz/services;key=441c0097257f45ab84d5ea4d24723f23/wfs?service=WFS&request=GetFeature&outputformat=CSV&typeNames=layer-123113",
+                "data": "https://data.linz.govt.nz/services;key=441c0097257f45ab84d5ea4d24723f23/wfs?service=WFS&request=GetFeature&outputformat=JSON&typeNames=layer-123113",
                 "website": "https://data.linz.govt.nz/layer/123113-nz-addresses-pilot/",
                 "license": {
                     "url": "https://creativecommons.org/licenses/by/4.0/",
@@ -24,10 +24,8 @@
                 "note": "This data is curated and produced by the Land Information New Zealand (LINZ) Data Service",
                 "protocol": "http",
                 "conform": {
-                    "format": "csv",
+                    "format": "geojson",
                     "srs": "EPSG:4167",
-                    "lon": "gd2000_xcoord",
-                    "lat": "gd2000_ycoord",
                     "id": "address_id",
                     "unit": "unit",
                     "number": {


### PR DESCRIPTION
~~**DRAFT PR do not merge yet** awaiting for this new dataset to become official on 4th March 2026.~~

LINZ have just announced changes to their NZ Addresses dataset to be published in March 2026, see https://data.linz.govt.nz/document/25898-nz-addresses-data-dictionary-pilot/

Changes include
`unit` field renamed
<img width="646" height="111" alt="image" src="https://github.com/user-attachments/assets/d85d9757-c25f-410c-b6b9-b95e2f3bc1f7" />

address number prefix removed
<img width="656" height="181" alt="image" src="https://github.com/user-attachments/assets/20cd6921-9b2d-4e7e-ae4e-349c34862652" />

road name fields changed, however the `full_road_name` field we are using is unchanged

coordinate fields removed
<img width="661" height="164" alt="image" src="https://github.com/user-attachments/assets/0c879c90-fe06-4037-8f00-1232d63fae45" />

the current URL will output coordinates as WKT `POINT (-46.2988688167 168.2442077)` which it doesn't appear that OA supports... therefore I changed the output to GeoJSON.

This PR applies the changes and migrates to the new dataset. We can choose to go live (merge) this now or wait for the Pilot dataset to finalise and be released due in March 2026.

cc @dwsilk

closes #7857