### PR TITLE
Update sources for Juniata County, PA

### DIFF
--- a/sources/us/pa/juniata.json
+++ b/sources/us/pa/juniata.json
@@ -14,58 +14,51 @@
         "addresses": [
             {
                 "name": "county",
-                "website": "https://www.juniataco.org/departments/gis/",
+                "website": "https://www.juniataco.org/departments/assessment-gis/",
                 "contact": {
                     "name": "Michael J. Hower",
                     "title": "Director",
                     "phone": "717-436-7764",
                     "email": "mhower@juniataco.org",
-                    "address": "Juniata County Courthouse, Bridge and Main Streets, Mifflintown, PA 17059"
+                    "address": "1 N Main St, Mifflintown PA, 17059"
                 },
-                "data": "https://parcelviewer.geodecisions.com/arcgis/rest/services/Juniata/Public/MapServer/5",
+                "data": "https://maps.civ.quest/arcgis/rest/services/Juniata/Public/FeatureServer/6",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
-                    "number": "SAN",
+                    "number": "Add_Number",
                     "street": [
-                        "PRD",
-                        "STN",
-                        "STS",
-                        "POD"
+                        "St_PreMod",
+                        "St_PreDir",
+                        "St_PreTyp",
+                        "St_PreSep",
+                        "St_Name",
+                        "St_PosTyp",
+                        "St_PosDir",
+                        "St_PosMod"
                     ],
-                    "unit": "UNIT",
-                    "city": "CITY",
-                    "postcode": "ZIP"
+                    "unit": "Unit",
+                    "city": "Post_Comm",
+                    "postcode": "Post_Code"
                 }
             }
         ],
         "parcels": [
             {
                 "name": "county",
-                "website": "https://www.juniataco.org/departments/gis/",
+                "website": "https://www.juniataco.org/departments/assessment-gis/",
                 "contact": {
                     "name": "Michael J. Hower",
                     "title": "Director",
                     "phone": "717-436-7764",
                     "email": "mhower@juniataco.org",
-                    "address": "Juniata County Courthouse, Bridge and Main Streets, Mifflintown, PA 17059"
+                    "address": "1 N Main St, Mifflintown PA, 17059"
                 },
-                "data": "https://parcelviewer.geodecisions.com/arcgis/rest/services/Juniata/Public/MapServer/1",
+                "data": "https://maps.civ.quest/arcgis/rest/services/Juniata/Public/FeatureServer/0",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
                     "pid": "PARCELID"
-                }
-            }
-        ],
-        "buildings": [
-            {
-                "name": "county",
-                "website": "https://www.juniataco.org/departments/gis/",
-                "data": "https://parcelviewer.geodecisions.com/arcgis/rest/services/Juniata/Public/MapServer/5",
-                "protocol": "ESRI",
-                "conform": {
-                    "format": "geojson"
                 }
             }
         ]


### PR DESCRIPTION
They changed GIS companies it seems.
I removed the building footprints because I couldn't find a source for them; the old ESRI query URL isn't working anymore.