### PR TITLE
Add new map function schema definition

### DIFF
--- a/schema/layers/address_conform.json
+++ b/schema/layers/address_conform.json
@@ -1,281 +1,88 @@
 {
-    "description": "top-level address conform schema",
-    "type": "object",
-    "required": [
-        "number",
-        "street"
-    ],
-    "additionalProperties": false,
-    "properties": {
-        "format": {
-            "type": "string",
-            "enum": [
-                "geojson",
-                "shapefile",
-                "shapefile-polygon",
-                "gdb",
-                "xml",
-                "csv"
-            ]
-        },
-        "addrtype": {
-            "type": "string"
-        },
-        "accuracy": {
-            "description": "https://github.com/openaddresses/openaddresses/blob/master/CONTRIBUTING.md#accuracy",
-            "type": "integer",
-            "minimum": 1,
-            "maximum": 5
-        },
-        "srs": {
-            "type": "string",
-            "pattern": "EPSG:[0-9]+"
-        },
-        "file": {
-            "type": "string"
-        },
-        "layer": {
-            "description": "specifies a layer to use in the GDB",
-            "oneOf": [{
-                "type": "integer"
-            },{
-            "type": "string"
-            }]
-        },
-        "encoding": {
-            "type": "string"
-        },
-        "csvsplit": {
-            "type": "string"
-        },
-        "headers": {
-            "type": "integer",
-            "minimum": -1
-        },
-        "skiplines": {
-            "type": "integer",
-            "minimum": 1
-        },
-        "notes": {
-            "type": "string"
-        },
-        "id": {
-            "description": "unique identifier for the address row",
-            "oneOf": [{
-                "$ref": "../util/functions/base.json"
-            },{
-                "$ref": "../util/functions/regexp.json"
-            },{
-                "$ref": "../util/functions/first_non_empty.json"
-            },{
-                "$ref": "../util/functions/remove_prefix.json"
-            },{
-                "$ref": "../util/functions/remove_postfix.json"
-            },{
-                "$ref": "../util/functions/join.json"
-            },{
-                "$ref": "../util/functions/format.json"
-            },{
-                "$ref": "../util/functions/chain.json"
-            },{
-                "$ref": "../util/functions/get.json"
-            },{
-                "$ref": "../util/functions/constant.json"
-            }]
-        },
-        "number": {
-            "description": "the house number for the address row",
-            "oneOf": [{
-                "$ref": "../util/functions/base.json"
-            },{
-                "$ref": "../util/functions/regexp.json"
-            },{
-                "$ref": "../util/functions/first_non_empty.json"
-            },{
-                "$ref": "../util/functions/prefixed_number.json"
-            },{
-                "$ref": "../util/functions/remove_prefix.json"
-            },{
-                "$ref": "../util/functions/remove_postfix.json"
-            },{
-                "$ref": "../util/functions/join.json"
-            },{
-                "$ref": "../util/functions/format.json"
-            },{
-                "$ref": "../util/functions/chain.json"
-            },{
-                "$ref": "../util/functions/get.json"
-            },{
-                "$ref": "../util/functions/constant.json"
-            }]
-        },
-        "street": {
-            "description": "the street/road for the address row",
-            "oneOf": [{
-                "$ref": "../util/functions/base.json"
-            },{
-                "$ref": "../util/functions/regexp.json"
-            },{
-                "$ref": "../util/functions/first_non_empty.json"
-            },{
-                "$ref": "../util/functions/postfixed_street.json"
-            },{
-                "$ref": "../util/functions/remove_prefix.json"
-            },{
-                "$ref": "../util/functions/remove_postfix.json"
-            },{
-                "$ref": "../util/functions/join.json"
-            },{
-                "$ref": "../util/functions/format.json"
-            },{
-                "$ref": "../util/functions/chain.json"
-            },{
-                "$ref": "../util/functions/get.json"
-            },{
-                "$ref": "../util/functions/constant.json"
-            }]
-        },
-        "unit": {
-            "description": "the suite/unit/apartment for the address row",
-            "oneOf": [{
-                "$ref": "../util/functions/base.json"
-            },{
-                "$ref": "../util/functions/postfixed_unit.json"
-            },{
-                "$ref": "../util/functions/regexp.json"
-            },{
-                "$ref": "../util/functions/first_non_empty.json"
-            },{
-                "$ref": "../util/functions/remove_prefix.json"
-            },{
-                "$ref": "../util/functions/remove_postfix.json"
-            },{
-                "$ref": "../util/functions/join.json"
-            },{
-                "$ref": "../util/functions/format.json"
-            },{
-                "$ref": "../util/functions/chain.json"
-            },{
-                "$ref": "../util/functions/get.json"
-            },{
-                "$ref": "../util/functions/constant.json"
-            }]
-        },
-        "city": {
-            "description": "the city/locality for the address row",
-            "oneOf": [{
-                "$ref": "../util/functions/base.json"
-            },{
-                "$ref": "../util/functions/regexp.json"
-            },{
-                "$ref": "../util/functions/first_non_empty.json"
-            },{
-                "$ref": "../util/functions/remove_prefix.json"
-            },{
-                "$ref": "../util/functions/remove_postfix.json"
-            },{
-                "$ref": "../util/functions/join.json"
-            },{
-                "$ref": "../util/functions/format.json"
-            },{
-                "$ref": "../util/functions/chain.json"
-            },{
-                "$ref": "../util/functions/get.json"
-            },{
-                "$ref": "../util/functions/constant.json"
-            }]
-        },
-        "district": {
-            "description": "the county for the address row",
-            "oneOf": [{
-                "$ref": "../util/functions/base.json"
-            },{
-                "$ref": "../util/functions/regexp.json"
-            },{
-                "$ref": "../util/functions/first_non_empty.json"
-            },{
-                "$ref": "../util/functions/remove_prefix.json"
-            },{
-                "$ref": "../util/functions/remove_postfix.json"
-            },{
-                "$ref": "../util/functions/join.json"
-            },{
-                "$ref": "../util/functions/format.json"
-            },{
-                "$ref": "../util/functions/chain.json"
-            },{
-                "$ref": "../util/functions/get.json"
-            },{
-                "$ref": "../util/functions/constant.json"
-            }]
-        },
-        "region": {
-            "description": "the state/province for the address row",
-            "oneOf": [{
-                "$ref": "../util/functions/base.json"
-            },{
-                "$ref": "../util/functions/regexp.json"
-            },{
-                "$ref": "../util/functions/first_non_empty.json"
-            },{
-                "$ref": "../util/functions/remove_prefix.json"
-            },{
-                "$ref": "../util/functions/remove_postfix.json"
-            },{
-                "$ref": "../util/functions/join.json"
-            },{
-                "$ref": "../util/functions/format.json"
-            },{
-                "$ref": "../util/functions/chain.json"
-            },{
-                "$ref": "../util/functions/get.json"
-            },{
-                "$ref": "../util/functions/constant.json"
-            }]
-        },
-        "postcode": {
-            "description": "the postcode for the address row",
-            "oneOf": [{
-                "$ref": "../util/functions/base.json"
-            },{
-                "$ref": "../util/functions/regexp.json"
-            },{
-                "$ref": "../util/functions/first_non_empty.json"
-            },{
-                "$ref": "../util/functions/remove_prefix.json"
-            },{
-                "$ref": "../util/functions/remove_postfix.json"
-            },{
-                "$ref": "../util/functions/join.json"
-            },{
-                "$ref": "../util/functions/format.json"
-            },{
-                "$ref": "../util/functions/chain.json"
-            },{
-                "$ref": "../util/functions/get.json"
-            },{
-                "$ref": "../util/functions/constant.json"
-            }]
-        },
-        "lon": {
-            "description": "longitude value for the address row, only applies to CSV sources",
-            "oneOf": [{
-                "type": "null"
-            },{
-                "type": "string"
-            },{
-                "$ref": "../util/functions/regexp.json"
-            }]
-        },
-        "lat": {
-            "description": "latitude value for the address row, only applies to CSV sources",
-            "oneOf": [{
-                "type": "null"
-            },{
-                "type": "string"
-            },{
-                "$ref": "../util/functions/regexp.json"
-            }]
-        }
+  "description": "top-level address conform schema",
+  "type": "object",
+  "required": ["number", "street"],
+  "additionalProperties": false,
+  "properties": {
+    "format": {
+      "type": "string",
+      "enum": ["csv", "gdb", "geojson", "shapefile", "shapefile-polygon", "xml"]
+    },
+    "addrtype": { "type": "string" },
+    "accuracy": {
+      "description": "https://github.com/openaddresses/openaddresses/blob/master/CONTRIBUTING.md#accuracy",
+      "oneOf": [
+        { "type": "integer", "minimum": 1, "maximum": 5 },
+        { "$ref": "../util/functions/map_integer.json" }
+      ]
+    },
+    "srs": { "type": "string", "pattern": "EPSG:[0-9]+" },
+    "file": { "type": "string" },
+    "layer": {
+      "description": "specifies a layer to use in the GDB",
+      "oneOf": [{ "type": "integer" }, { "type": "string" }]
+    },
+    "encoding": { "type": "string" },
+    "csvsplit": { "type": "string" },
+    "headers": { "type": "integer", "minimum": -1 },
+    "skiplines": { "type": "integer", "minimum": 1 },
+    "notes": { "type": "string" },
+    "id": {
+      "description": "unique identifier for the address row",
+      "$ref": "../util/functions/standard_functions.json"
+    },
+    "number": {
+      "description": "the house number for the address row",
+      "oneOf": [
+        { "$ref": "../util/functions/standard_functions.json" },
+        { "$ref": "../util/functions/prefixed_number.json" }
+      ]
+    },
+    "street": {
+      "description": "the street/road for the address row",
+      "oneOf": [
+        { "$ref": "../util/functions/standard_functions.json" },
+        { "$ref": "../util/functions/postfixed_street.json" }
+      ]
+    },
+    "unit": {
+      "description": "the suite/unit/apartment for the address row",
+      "oneOf": [
+        { "$ref": "../util/functions/standard_functions.json" },
+        { "$ref": "../util/functions/postfixed_unit.json" }
+      ]
+    },
+    "city": {
+      "description": "the city/locality for the address row",
+      "$ref": "../util/functions/standard_functions.json"
+    },
+    "district": {
+      "description": "the county for the address row",
+      "$ref": "../util/functions/standard_functions.json"
+    },
+    "region": {
+      "description": "the state/province for the address row",
+      "$ref": "../util/functions/standard_functions.json"
+    },
+    "postcode": {
+      "description": "the postcode for the address row",
+      "$ref": "../util/functions/standard_functions.json"
+    },
+    "lon": {
+      "description": "longitude value for the address row, only applies to CSV sources",
+      "oneOf": [
+        { "type": "null" },
+        { "type": "string" },
+        { "$ref": "../util/functions/regexp.json" }
+      ]
+    },
+    "lat": {
+      "description": "latitude value for the address row, only applies to CSV sources",
+      "oneOf": [
+        { "type": "null" },
+        { "type": "string" },
+        { "$ref": "../util/functions/regexp.json" }
+      ]
     }
+  }
 }

--- a/schema/layers/building_conform.json
+++ b/schema/layers/building_conform.json
@@ -1,45 +1,23 @@
 {
-    "description": "top-level building conform schema",
-    "type": "object",
-    "additionalProperties": false,
-    "properties": {
-        "format": {
-            "type": "string",
-            "enum": [
-                "geojson",
-                "shapefile",
-                "gdb"
-            ]
-        },
-        "srs": {
-            "type": "string",
-            "pattern": "EPSG:[0-9]+"
-        },
-        "file": {
-            "type": "string"
-        },
-        "layer": {
-            "description": "specifies a layer to use in the GDB",
-            "oneOf": [{
-                "type": "integer"
-            },{
-            "type": "string"
-            }]
-        },
-        "notes": {
-            "type": "string"
-        },
-        "id": {
-            "description": "unique identifier for the building",
-            "oneOf": [{
-                "$ref": "../util/functions/base.json"
-            }]
-        },
-        "height": {
-            "description": "height of the building (from the ground) in meters",
-            "oneOf": [{
-                "$ref": "../util/functions/base.json"
-            }]
-        }
+  "description": "top-level building conform schema",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "format": { "type": "string", "enum": ["gdb", "geojson", "shapefile"] },
+    "srs": { "type": "string", "pattern": "EPSG:[0-9]+" },
+    "file": { "type": "string" },
+    "layer": {
+      "description": "specifies a layer to use in the GDB",
+      "oneOf": [{ "type": "integer" }, { "type": "string" }]
+    },
+    "notes": { "type": "string" },
+    "id": {
+      "description": "unique identifier for the building",
+      "$ref": "../util/functions/base.json"
+    },
+    "height": {
+      "description": "height of the building (from the ground) in meters",
+      "$ref": "../util/functions/base.json"
     }
+  }
 }

--- a/schema/layers/parcel_conform.json
+++ b/schema/layers/parcel_conform.json
@@ -1,59 +1,21 @@
 {
-    "description": "top-level parcel conform schema",
-    "type": "object",
-    "required": [
-        "pid"
-    ],
-    "additionalProperties": false,
-    "properties": {
-        "format": {
-            "type": "string",
-            "enum": [
-                "geojson",
-                "shapefile",
-                "gdb"
-            ]
-        },
-        "srs": {
-            "type": "string",
-            "pattern": "EPSG:[0-9]+"
-        },
-        "file": {
-            "type": "string"
-        },
-        "layer": {
-            "description": "specifies a layer to use in the GDB",
-            "oneOf": [{
-                "type": "integer"
-            },{
-                "type": "string"
-            }]
-        },
-        "encoding": {
-            "type": "string"
-        },
-        "notes": {
-            "type": "string"
-        },
-        "pid": {
-            "description": "unique identifier for the parcel row",
-            "oneOf": [{
-                "$ref": "../util/functions/base.json"
-            },{
-                "$ref": "../util/functions/regexp.json"
-            },{
-                "$ref": "../util/functions/remove_prefix.json"
-            },{
-                "$ref": "../util/functions/remove_postfix.json"
-            },{
-                "$ref": "../util/functions/join.json"
-            },{
-                "$ref": "../util/functions/format.json"
-            },{
-                "$ref": "../util/functions/chain.json"
-            },{
-                "$ref": "../util/functions/constant.json"
-            }]
-        }
+  "description": "top-level parcel conform schema",
+  "type": "object",
+  "required": ["pid"],
+  "additionalProperties": false,
+  "properties": {
+    "format": { "type": "string", "enum": ["gdb", "geojson", "shapefile"] },
+    "srs": { "type": "string", "pattern": "EPSG:[0-9]+" },
+    "file": { "type": "string" },
+    "layer": {
+      "description": "specifies a layer to use in the GDB",
+      "oneOf": [{ "type": "integer" }, { "type": "string" }]
+    },
+    "encoding": { "type": "string" },
+    "notes": { "type": "string" },
+    "pid": {
+      "description": "unique identifier for the parcel row",
+      "$ref": "../util/functions/standard_functions.json"
     }
+  }
 }

--- a/schema/retired/source_schema.json
+++ b/schema/retired/source_schema.json
@@ -1,549 +1,527 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "title": "Source",
-    "description": "An OpenAddresses source",
-    "type": "object",
-    "required": [
-        "protocol",
-        "data",
-        "coverage"
-    ],
-    "additionalProperties": false,
-    "properties": {
-        "protocol": {
-            "type": "string",
-            "enum": [
-                "http",
-                "ftp",
-                "ESRI"
-            ]
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Source",
+  "description": "An OpenAddresses source",
+  "type": "object",
+  "required": ["protocol", "data", "coverage"],
+  "additionalProperties": false,
+  "properties": {
+    "protocol": {
+      "type": "string",
+      "enum": ["http", "ftp", "ESRI"]
+    },
+    "data": {
+      "type": "string"
+    },
+    "coverage": {
+      "$ref": "#/definitions/coverage"
+    },
+    "website": {
+      "type": "string"
+    },
+    "email": {
+      "type": "string",
+      "format": "email"
+    },
+    "conform": {
+      "$ref": "#/definitions/conform"
+    },
+    "compression": {
+      "type": "string",
+      "const": "zip"
+    },
+    "license": {
+      "oneOf": [{ "type": "string" }, { "$ref": "#/definitions/license" }]
+    },
+    "contact": {
+      "$ref": "#/definitions/contact"
+    },
+    "note": {
+      "oneOf": [{ "type": "string" }, { "type": "object" }]
+    },
+    "attribution": {
+      "type": "string"
+    },
+    "language": {
+      "type": "string",
+      "pattern": "^[a-zA-Z]{2,3}$"
+    },
+    "year": {
+      "oneOf": [{ "type": "string" }, { "type": "integer" }]
+    },
+    "skip": {
+      "type": "boolean"
+    },
+    "test": {
+      "$ref": "#/definitions/test"
+    }
+  },
+  "definitions": {
+    "coverage": {
+      "type": "object",
+      "required": ["country"],
+      "properties": {
+        "country": {
+          "type": "string"
         },
-        "data": {
-            "type": "string"
+        "province": {
+          "type": "string"
         },
-        "coverage": {
-            "$ref": "#/definitions/coverage"
+        "state": {
+          "type": "string"
         },
-        "website": {
-            "type": "string"
+        "county": {
+          "type": "string"
         },
-        "email": {
-            "type": "string",
-            "format": "email"
+        "city": {
+          "type": "string"
         },
-        "conform": {
-            "$ref": "#/definitions/conform"
+        "geometry": {
+          "$ref": "http://json.schemastore.org/geojson#/definitions/geometry"
+        }
+      }
+    },
+    "license": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri"
         },
-        "compression": {
-            "type": "string",
-            "enum": ["zip"]
-        },
-        "license": {
-            "oneOf": [
-                { "type": "string" },
-                { "$ref": "#/definitions/license" }
-            ]
-        },
-        "contact": {
-            "$ref": "#/definitions/contact"
-        },
-        "note": {
-            "oneOf": [
-                { "type": "string" },
-                { "type": "object" }
-            ]
+        "text": {
+          "type": "string"
         },
         "attribution": {
-            "type": "string"
+          "type": "boolean"
         },
-        "language": {
-            "type": "string",
-            "pattern": "^[a-zA-Z]{2,3}$"
+        "attribution name": {
+          "type": "string"
         },
-        "year": {
-            "oneOf": [
-                { "type": "string" },
-                { "type": "integer" }
-            ]
+        "share-alike": {
+          "type": "boolean"
         },
-        "skip": {
-            "type": "boolean"
+        "presumed": {
+          "type": "boolean"
         },
-        "test": {
-            "$ref": "#/definitions/test"
+        "remarks": {
+          "type": "string",
+          "format": "uri"
         }
+      }
     },
-    "definitions": {
-        "coverage": {
-            "type": "object",
-            "required": [
-                "country"
-            ],
-            "properties": {
-                "country": {
-                    "type": "string"
-                },
-                "province": {
-                    "type": "string"
-                },
-                "state": {
-                    "type": "string"
-                },
-                "county": {
-                    "type": "string"
-                },
-                "city": {
-                    "type": "string"
-                },
-                "geometry": {
-                    "$ref": "http://json.schemastore.org/geojson#/definitions/geometry"
-                }
-            }
+    "contact": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
         },
-        "license": {
-            "type": "object",
-            "properties": {
-                "url": {
-                    "type": "string",
-                    "format": "uri"
-                },
-                "text": {
-                    "type": "string"
-                },
-                "attribution": {
-                    "type": "boolean"
-                },
-                "attribution name": {
-                    "type": "string"
-                },
-                "share-alike": {
-                    "type": "boolean"
-                },
-                "presumed": {
-                    "type": "boolean"
-                },
-                "remarks": {
-                    "type": "string",
-                    "format": "uri"
-                }
-            }
+        "title": {
+          "type": "string"
         },
-        "contact": {
-            "type": "object",
-            "properties": {
-                "name": {
-                    "type": "string"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "phone": {
-                    "type": "string"
-                },
-                "email": {
-                    "type": "string"
-                },
-                "address": {
-                    "type": "string"
-                }
-            }
+        "phone": {
+          "type": "string"
         },
-        "base_conform_field_value": {
-            "description": "convenience definition for one of null, string, or string array",
-            "oneOf": [
-                { "type": "string" },
-                {
-                    "type": "array",
-                    "minItems": 1,
-                    "items": { "type": "string" }
-                }
-            ]
+        "email": {
+          "type": "string"
         },
-        "conform": {
-            "description": "top-level conform object definition",
-            "type": "object",
-            "required": ["number", "street"],
-            "additionalProperties": false,
-            "properties": {
-                "format": {
-                    "type": "string",
-                    "enum": [
-                        "geojson",
-                        "shapefile",
-                        "shapefile-polygon",
-                        "gdb",
-                        "xml",
-                        "csv"
-                    ]
-                },
-                "addrtype": {
-                    "type": "string"
-                },
-                "accuracy": {
-                    "description": "https://github.com/openaddresses/openaddresses/blob/master/CONTRIBUTING.md#accuracy",
-                    "type": "integer",
-                    "minimum": 1,
-                    "maximum": 5
-                },
-                "srs": {
-                    "type": "string",
-                    "pattern": "EPSG:[0-9]+"
-                },
-                "file": {
-                    "type": "string"
-                },
-                "layer": {
-                    "description": "specifies a layer to use in the GDB",
-                    "oneOf": [
-                        { "type": "integer" },
-                        { "type": "string" }
-                    ]
-                },
-                "encoding": {
-                    "type": "string"
-                },
-                "csvsplit": {
-                    "type": "string"
-                },
-                "headers": {
-                    "type": "integer",
-                    "minimum": -1
-                },
-                "skiplines": {
-                    "type": "integer",
-                    "minimum": 1
-                },
-                "notes": {
-                    "type": "string"
-                },
-                "id": {
-                    "description": "unique identifier for the address row",
-                    "oneOf": [
-                        { "$ref": "#/definitions/base_conform_field_value" },
-                        { "$ref": "#/definitions/function_regexp" },
-                        { "$ref": "#/definitions/function_remove_prefix" },
-                        { "$ref": "#/definitions/function_remove_postfix" },
-                        { "$ref": "#/definitions/function_join" },
-                        { "$ref": "#/definitions/function_format" },
-                        { "$ref": "#/definitions/function_chain" }
-                    ]
-                },
-                "number": {
-                    "description": "the house number for the address row",
-                    "oneOf": [
-                        { "$ref": "#/definitions/base_conform_field_value" },
-                        { "$ref": "#/definitions/function_regexp" },
-                        { "$ref": "#/definitions/function_prefixed_number" },
-                        { "$ref": "#/definitions/function_remove_prefix" },
-                        { "$ref": "#/definitions/function_remove_postfix" },
-                        { "$ref": "#/definitions/function_join" },
-                        { "$ref": "#/definitions/function_format" },
-                        { "$ref": "#/definitions/function_chain" }
-                    ]
-                },
-                "street": {
-                    "description": "the street/road for the address row",
-                    "oneOf": [
-                        { "$ref": "#/definitions/base_conform_field_value" },
-                        { "$ref": "#/definitions/function_regexp" },
-                        { "$ref": "#/definitions/function_postfixed_street" },
-                        { "$ref": "#/definitions/function_remove_prefix" },
-                        { "$ref": "#/definitions/function_remove_postfix" },
-                        { "$ref": "#/definitions/function_join" },
-                        { "$ref": "#/definitions/function_format" },
-                        { "$ref": "#/definitions/function_chain" }
-                    ]
-                },
-                "unit": {
-                    "description": "the suite/unit/apartment for the address row",
-                    "oneOf": [
-                        { "$ref": "#/definitions/base_conform_field_value" },
-                        { "$ref": "#/definitions/function_regexp" },
-                        { "$ref": "#/definitions/function_postfixed_unit" },
-                        { "$ref": "#/definitions/function_remove_prefix" },
-                        { "$ref": "#/definitions/function_remove_postfix" },
-                        { "$ref": "#/definitions/function_join" },
-                        { "$ref": "#/definitions/function_format" },
-                        { "$ref": "#/definitions/function_chain" }
-                    ]
-                },
-                "city": {
-                    "description": "the city/locality for the address row",
-                    "oneOf": [
-                        { "$ref": "#/definitions/base_conform_field_value" },
-                        { "$ref": "#/definitions/function_regexp" },
-                        { "$ref": "#/definitions/function_remove_prefix" },
-                        { "$ref": "#/definitions/function_remove_postfix" },
-                        { "$ref": "#/definitions/function_join" },
-                        { "$ref": "#/definitions/function_format" },
-                        { "$ref": "#/definitions/function_chain" }
-                    ]
-                },
-                "district": {
-                    "description": "the county for the address row",
-                    "oneOf": [
-                        { "$ref": "#/definitions/base_conform_field_value" },
-                        { "$ref": "#/definitions/function_regexp" },
-                        { "$ref": "#/definitions/function_remove_prefix" },
-                        { "$ref": "#/definitions/function_remove_postfix" },
-                        { "$ref": "#/definitions/function_join" },
-                        { "$ref": "#/definitions/function_format" },
-                        { "$ref": "#/definitions/function_chain" }
-                    ]
-                },
-                "region": {
-                    "description": "the state/province for the address row",
-                    "oneOf": [
-                        { "$ref": "#/definitions/base_conform_field_value" },
-                        { "$ref": "#/definitions/function_regexp" },
-                        { "$ref": "#/definitions/function_remove_prefix" },
-                        { "$ref": "#/definitions/function_remove_postfix" },
-                        { "$ref": "#/definitions/function_join" },
-                        { "$ref": "#/definitions/function_format" },
-                        { "$ref": "#/definitions/function_chain" }
-                    ]
-                },
-                "postcode": {
-                    "description": "the postcode for the address row",
-                    "oneOf": [
-                        { "$ref": "#/definitions/base_conform_field_value" },
-                        { "$ref": "#/definitions/function_regexp" },
-                        { "$ref": "#/definitions/function_remove_prefix" },
-                        { "$ref": "#/definitions/function_remove_postfix" },
-                        { "$ref": "#/definitions/function_join" },
-                        { "$ref": "#/definitions/function_format" },
-                        { "$ref": "#/definitions/function_chain" }
-                    ]
-                },
-                "lon": {
-                    "description": "longitude value for the address row, only applies to CSV sources",
-                    "oneOf": [
-                        { "type": "null" },
-                        { "type": "string" },
-                        { "$ref": "#/definitions/function_regexp" }
-                    ]
-                },
-                "lat": {
-                    "description": "latitude value for the address row, only applies to CSV sources",
-                    "oneOf": [
-                        { "type": "null" },
-                        { "type": "string" },
-                        { "$ref": "#/definitions/function_regexp" }
-                    ]
-                }
-            }
-        },
-        "test": {
-            "description": "test definition",
-            "type": "object",
-            "required": ["description"],
-            "additionalProperties": false,
-            "properties": {
-                "enabled": {
-                    "type": "boolean"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "acceptance-tests": {
-                    "type": "array",
-                    "minItems": 1,
-                    "items": { "$ref": "#/definitions/acceptance-test" }
-                }
-            }
-        },
-        "acceptance-test": {
-            "description": "acceptance-test definition",
-            "type": "object",
-            "required": ["description", "inputs", "expected"],
-            "additionalProperties": false,
-            "properties": {
-                "description": {
-                    "type": "string"
-                },
-                "inputs": {
-                    "type": "object"
-                },
-                "expected": {
-                    "type": "object"
-                }
-            }
-        },
-        "function_regexp": {
-            "description": "regexp function definition",
-            "type": "object",
-            "required": ["function", "field", "pattern"],
-            "additionalProperties": false,
-            "properties": {
-                "function": {
-                    "type": "string",
-                    "enum": ["regexp"]
-                },
-                "field": {
-                    "type": "string"
-                },
-                "pattern": {
-                    "type": "string"
-                },
-                "replace": {
-                    "type": "string"
-                }
-            }
-        },
-        "function_prefixed_number": {
-            "description": "prefixed_number function definition",
-            "type": "object",
-            "required": ["function", "field"],
-            "additionalProperties": false,
-            "properties": {
-                "function": {
-                    "type": "string",
-                    "enum": ["prefixed_number"]
-                },
-                "field": {
-                    "type": "string"
-                }
-            }
-        },
-        "function_postfixed_street": {
-            "description": "postfixed_street function definition",
-            "type": "object",
-            "required": ["function", "field"],
-            "additionalProperties": false,
-            "properties": {
-                "function": {
-                    "type": "string",
-                    "enum": ["postfixed_street"]
-                },
-                "field": {
-                    "type": "string"
-                },
-                "may_contain_units": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "function_postfixed_unit": {
-            "description": "postfixed_unit function definition",
-            "type": "object",
-            "required": ["function", "field"],
-            "additionalProperties": false,
-            "properties": {
-                "function": {
-                    "type": "string",
-                    "enum": ["postfixed_unit"]
-                },
-                "field": {
-                    "type": "string"
-                }
-            }
-        },
-        "function_remove_prefix": {
-            "description": "remove_prefix function definition",
-            "type": "object",
-            "required": ["function", "field", "field_to_remove"],
-            "additionalProperties": false,
-            "properties": {
-                "function": {
-                    "type": "string",
-                    "enum": ["remove_prefix"]
-                },
-                "field": {
-                    "type": "string"
-                },
-                "field_to_remove": {
-                    "type": "string"
-                }
-            }
-        },
-        "function_remove_postfix": {
-            "description": "remove_postfix function definition",
-            "type": "object",
-            "required": ["function", "field", "field_to_remove"],
-            "additionalProperties": false,
-            "properties": {
-                "function": {
-                    "type": "string",
-                    "enum": ["remove_postfix"]
-                },
-                "field": {
-                    "type": "string"
-                },
-                "field_to_remove": {
-                    "type": "string"
-                }
-            }
-        },
-        "function_join": {
-            "description": "join function definition",
-            "type": "object",
-            "required": ["function", "fields"],
-            "additionalProperties": false,
-            "properties": {
-                "function": {
-                    "type": "string",
-                    "enum": ["join"]
-                },
-                "fields": {
-                    "type": "array",
-                    "minItems": 1,
-                    "items": { "type": "string" }
-                },
-                "separator": {
-                    "type": "string"
-                }
-            }
-        },
-        "function_format": {
-            "description": "format function definition",
-            "type": "object",
-            "required": ["function", "fields", "format"],
-            "additionalProperties": false,
-            "properties": {
-                "function": {
-                    "type": "string",
-                    "enum": ["format"]
-                },
-                "fields": {
-                    "type": "array",
-                    "minItems": 1,
-                    "items": { "type": "string" }
-                },
-                "format": {
-                    "type": "string"
-                }
-            }
-        },
-        "function_chain": {
-            "description": "chain function definition",
-            "type": "object",
-            "required": ["function", "variable", "functions"],
-            "additionalProperties": false,
-            "properties": {
-                "function": {
-                    "type": "string",
-                    "enum": ["chain"]
-                },
-                "variable": {
-                    "type": "string"
-                },
-                "functions": {
-                    "type": "array",
-                    "minItems": 1,
-                    "items": {
-                        "oneOf": [
-                            { "$ref": "#/definitions/base_conform_field_value" },
-                            { "$ref": "#/definitions/function_regexp" },
-                            { "$ref": "#/definitions/function_postfixed_street" },
-                            { "$ref": "#/definitions/function_remove_prefix" },
-                            { "$ref": "#/definitions/function_remove_postfix" },
-                            { "$ref": "#/definitions/function_join" },
-                            { "$ref": "#/definitions/function_format" },
-                            { "$ref": "#/definitions/function_chain" }
-                        ]
-                    }
-                }
-            }
+        "address": {
+          "type": "string"
         }
+      }
+    },
+    "base_conform_field_value": {
+      "description": "convenience definition for one of null, string, or string array",
+      "oneOf": [
+        { "type": "string" },
+        {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" }
+        }
+      ]
+    },
+    "conform": {
+      "description": "top-level conform object definition",
+      "type": "object",
+      "required": ["number", "street"],
+      "additionalProperties": false,
+      "properties": {
+        "format": {
+          "type": "string",
+          "enum": [
+            "geojson",
+            "shapefile",
+            "shapefile-polygon",
+            "gdb",
+            "xml",
+            "csv"
+          ]
+        },
+        "addrtype": {
+          "type": "string"
+        },
+        "accuracy": {
+          "description": "https://github.com/openaddresses/openaddresses/blob/master/CONTRIBUTING.md#accuracy",
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 5
+        },
+        "srs": {
+          "type": "string",
+          "pattern": "EPSG:[0-9]+"
+        },
+        "file": {
+          "type": "string"
+        },
+        "layer": {
+          "description": "specifies a layer to use in the GDB",
+          "oneOf": [{ "type": "integer" }, { "type": "string" }]
+        },
+        "encoding": {
+          "type": "string"
+        },
+        "csvsplit": {
+          "type": "string"
+        },
+        "headers": {
+          "type": "integer",
+          "minimum": -1
+        },
+        "skiplines": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "notes": {
+          "type": "string"
+        },
+        "id": {
+          "description": "unique identifier for the address row",
+          "oneOf": [
+            { "$ref": "#/definitions/base_conform_field_value" },
+            { "$ref": "#/definitions/function_regexp" },
+            { "$ref": "#/definitions/function_remove_prefix" },
+            { "$ref": "#/definitions/function_remove_postfix" },
+            { "$ref": "#/definitions/function_join" },
+            { "$ref": "#/definitions/function_format" },
+            { "$ref": "#/definitions/function_chain" }
+          ]
+        },
+        "number": {
+          "description": "the house number for the address row",
+          "oneOf": [
+            { "$ref": "#/definitions/base_conform_field_value" },
+            { "$ref": "#/definitions/function_regexp" },
+            { "$ref": "#/definitions/function_prefixed_number" },
+            { "$ref": "#/definitions/function_remove_prefix" },
+            { "$ref": "#/definitions/function_remove_postfix" },
+            { "$ref": "#/definitions/function_join" },
+            { "$ref": "#/definitions/function_format" },
+            { "$ref": "#/definitions/function_chain" }
+          ]
+        },
+        "street": {
+          "description": "the street/road for the address row",
+          "oneOf": [
+            { "$ref": "#/definitions/base_conform_field_value" },
+            { "$ref": "#/definitions/function_regexp" },
+            { "$ref": "#/definitions/function_postfixed_street" },
+            { "$ref": "#/definitions/function_remove_prefix" },
+            { "$ref": "#/definitions/function_remove_postfix" },
+            { "$ref": "#/definitions/function_join" },
+            { "$ref": "#/definitions/function_format" },
+            { "$ref": "#/definitions/function_chain" }
+          ]
+        },
+        "unit": {
+          "description": "the suite/unit/apartment for the address row",
+          "oneOf": [
+            { "$ref": "#/definitions/base_conform_field_value" },
+            { "$ref": "#/definitions/function_regexp" },
+            { "$ref": "#/definitions/function_postfixed_unit" },
+            { "$ref": "#/definitions/function_remove_prefix" },
+            { "$ref": "#/definitions/function_remove_postfix" },
+            { "$ref": "#/definitions/function_join" },
+            { "$ref": "#/definitions/function_format" },
+            { "$ref": "#/definitions/function_chain" }
+          ]
+        },
+        "city": {
+          "description": "the city/locality for the address row",
+          "oneOf": [
+            { "$ref": "#/definitions/base_conform_field_value" },
+            { "$ref": "#/definitions/function_regexp" },
+            { "$ref": "#/definitions/function_remove_prefix" },
+            { "$ref": "#/definitions/function_remove_postfix" },
+            { "$ref": "#/definitions/function_join" },
+            { "$ref": "#/definitions/function_format" },
+            { "$ref": "#/definitions/function_chain" }
+          ]
+        },
+        "district": {
+          "description": "the county for the address row",
+          "oneOf": [
+            { "$ref": "#/definitions/base_conform_field_value" },
+            { "$ref": "#/definitions/function_regexp" },
+            { "$ref": "#/definitions/function_remove_prefix" },
+            { "$ref": "#/definitions/function_remove_postfix" },
+            { "$ref": "#/definitions/function_join" },
+            { "$ref": "#/definitions/function_format" },
+            { "$ref": "#/definitions/function_chain" }
+          ]
+        },
+        "region": {
+          "description": "the state/province for the address row",
+          "oneOf": [
+            { "$ref": "#/definitions/base_conform_field_value" },
+            { "$ref": "#/definitions/function_regexp" },
+            { "$ref": "#/definitions/function_remove_prefix" },
+            { "$ref": "#/definitions/function_remove_postfix" },
+            { "$ref": "#/definitions/function_join" },
+            { "$ref": "#/definitions/function_format" },
+            { "$ref": "#/definitions/function_chain" }
+          ]
+        },
+        "postcode": {
+          "description": "the postcode for the address row",
+          "oneOf": [
+            { "$ref": "#/definitions/base_conform_field_value" },
+            { "$ref": "#/definitions/function_regexp" },
+            { "$ref": "#/definitions/function_remove_prefix" },
+            { "$ref": "#/definitions/function_remove_postfix" },
+            { "$ref": "#/definitions/function_join" },
+            { "$ref": "#/definitions/function_format" },
+            { "$ref": "#/definitions/function_chain" }
+          ]
+        },
+        "lon": {
+          "description": "longitude value for the address row, only applies to CSV sources",
+          "oneOf": [
+            { "type": "null" },
+            { "type": "string" },
+            { "$ref": "#/definitions/function_regexp" }
+          ]
+        },
+        "lat": {
+          "description": "latitude value for the address row, only applies to CSV sources",
+          "oneOf": [
+            { "type": "null" },
+            { "type": "string" },
+            { "$ref": "#/definitions/function_regexp" }
+          ]
+        }
+      }
+    },
+    "test": {
+      "description": "test definition",
+      "type": "object",
+      "required": ["description"],
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "description": {
+          "type": "string"
+        },
+        "acceptance-tests": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/definitions/acceptance-test" }
+        }
+      }
+    },
+    "acceptance-test": {
+      "description": "acceptance-test definition",
+      "type": "object",
+      "required": ["description", "inputs", "expected"],
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "inputs": {
+          "type": "object"
+        },
+        "expected": {
+          "type": "object"
+        }
+      }
+    },
+    "function_regexp": {
+      "description": "regexp function definition",
+      "type": "object",
+      "required": ["function", "field", "pattern"],
+      "additionalProperties": false,
+      "properties": {
+        "function": {
+          "type": "string",
+          "const": "regexp"
+        },
+        "field": {
+          "type": "string"
+        },
+        "pattern": {
+          "type": "string"
+        },
+        "replace": {
+          "type": "string"
+        }
+      }
+    },
+    "function_prefixed_number": {
+      "description": "prefixed_number function definition",
+      "type": "object",
+      "required": ["function", "field"],
+      "additionalProperties": false,
+      "properties": {
+        "function": {
+          "type": "string",
+          "const": "prefixed_number"
+        },
+        "field": {
+          "type": "string"
+        }
+      }
+    },
+    "function_postfixed_street": {
+      "description": "postfixed_street function definition",
+      "type": "object",
+      "required": ["function", "field"],
+      "additionalProperties": false,
+      "properties": {
+        "function": {
+          "type": "string",
+          "const": "postfixed_street"
+        },
+        "field": {
+          "type": "string"
+        },
+        "may_contain_units": {
+          "type": "boolean"
+        }
+      }
+    },
+    "function_postfixed_unit": {
+      "description": "postfixed_unit function definition",
+      "type": "object",
+      "required": ["function", "field"],
+      "additionalProperties": false,
+      "properties": {
+        "function": {
+          "type": "string",
+          "const": "postfixed_unit"
+        },
+        "field": {
+          "type": "string"
+        }
+      }
+    },
+    "function_remove_prefix": {
+      "description": "remove_prefix function definition",
+      "type": "object",
+      "required": ["function", "field", "field_to_remove"],
+      "additionalProperties": false,
+      "properties": {
+        "function": {
+          "type": "string",
+          "const": "remove_prefix"
+        },
+        "field": {
+          "type": "string"
+        },
+        "field_to_remove": {
+          "type": "string"
+        }
+      }
+    },
+    "function_remove_postfix": {
+      "description": "remove_postfix function definition",
+      "type": "object",
+      "required": ["function", "field", "field_to_remove"],
+      "additionalProperties": false,
+      "properties": {
+        "function": {
+          "type": "string",
+          "const": "remove_postfix"
+        },
+        "field": {
+          "type": "string"
+        },
+        "field_to_remove": {
+          "type": "string"
+        }
+      }
+    },
+    "function_join": {
+      "description": "join function definition",
+      "type": "object",
+      "required": ["function", "fields"],
+      "additionalProperties": false,
+      "properties": {
+        "function": {
+          "type": "string",
+          "const": "join"
+        },
+        "fields": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" }
+        },
+        "separator": {
+          "type": "string"
+        }
+      }
+    },
+    "function_format": {
+      "description": "format function definition",
+      "type": "object",
+      "required": ["function", "fields", "format"],
+      "additionalProperties": false,
+      "properties": {
+        "function": {
+          "type": "string",
+          "const": "format"
+        },
+        "fields": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" }
+        },
+        "format": {
+          "type": "string"
+        }
+      }
+    },
+    "function_chain": {
+      "description": "chain function definition",
+      "type": "object",
+      "required": ["function", "variable", "functions"],
+      "additionalProperties": false,
+      "properties": {
+        "function": {
+          "type": "string",
+          "const": "chain"
+        },
+        "variable": {
+          "type": "string"
+        },
+        "functions": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "oneOf": [
+              { "$ref": "#/definitions/base_conform_field_value" },
+              { "$ref": "#/definitions/function_regexp" },
+              { "$ref": "#/definitions/function_postfixed_street" },
+              { "$ref": "#/definitions/function_remove_prefix" },
+              { "$ref": "#/definitions/function_remove_postfix" },
+              { "$ref": "#/definitions/function_join" },
+              { "$ref": "#/definitions/function_format" },
+              { "$ref": "#/definitions/function_chain" }
+            ]
+          }
+        }
+      }
     }
+  }
 }

--- a/schema/util/functions/constant.json
+++ b/schema/util/functions/constant.json
@@ -1,18 +1,15 @@
 {
-    "description": "Insert a constant value",
-    "type": "object",
-    "required": [
-        "function",
-        "value"
-    ],
-    "additionalProperties": false,
-    "properties": {
-        "function": {
-            "type": "string",
-            "enum": [ "constant" ]
-        },
-        "value": {
-            "type": "string"
-        }
+  "description": "Insert a constant value",
+  "type": "object",
+  "required": ["function", "value"],
+  "additionalProperties": false,
+  "properties": {
+    "function": {
+      "type": "string",
+      "const": "constant"
+    },
+    "value": {
+      "type": "string"
     }
+  }
 }

--- a/schema/util/functions/map_integer.json
+++ b/schema/util/functions/map_integer.json
@@ -1,0 +1,15 @@
+{
+  "description": "map function definition",
+  "type": "object",
+  "required": ["function", "field", "mapping", "else"],
+  "additionalProperties": false,
+  "properties": {
+    "function": { "type": "string", "const": "map" },
+    "field": { "type": "string" },
+    "mapping": {
+      "type": "object",
+      "additionalProperties": { "type": "integer", "minimum": 1, "maximum": 5 }
+    },
+    "else": { "type": "integer", "minimum": 1, "maximum": 5 }
+  }
+}

--- a/schema/util/functions/map_string.json
+++ b/schema/util/functions/map_string.json
@@ -1,0 +1,15 @@
+{
+  "description": "map function definition",
+  "type": "object",
+  "required": ["function", "field", "mapping"],
+  "additionalProperties": false,
+  "properties": {
+    "function": { "type": "string", "const": "map" },
+    "field": { "type": "string" },
+    "mapping": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+    "else": { "type": "string" }
+  }
+}

--- a/schema/util/functions/standard_functions.json
+++ b/schema/util/functions/standard_functions.json
@@ -1,0 +1,15 @@
+{
+  "oneOf": [
+    { "$ref": "./base.json" },
+    { "$ref": "./chain.json" },
+    { "$ref": "./constant.json" },
+    { "$ref": "./first_non_empty.json" },
+    { "$ref": "./format.json" },
+    { "$ref": "./get.json" },
+    { "$ref": "./join.json" },
+    { "$ref": "./map_string.json" },
+    { "$ref": "./regexp.json" },
+    { "$ref": "./remove_postfix.json" },
+    { "$ref": "./remove_prefix.json" }
+  ]
+}

--- a/schema/util/geojson.json
+++ b/schema/util/geojson.json
@@ -7,7 +7,6 @@
   "required": ["type"],
 
   "properties": {
-
     "type": {
       "title": "Type",
       "type": "string",
@@ -51,10 +50,9 @@
 
       "not": {
         "anyOf": [
-
           {
             "properties": {
-              "type": { "enum": ["name"] },
+              "type": { "const": "name" },
               "properties": {
                 "not": {
                   "required": ["name"],
@@ -71,14 +69,13 @@
 
           {
             "properties": {
-              "type": { "enum": ["link"] },
+              "type": { "const": "link" },
               "properties": {
                 "not": {
                   "title": "Link Object",
                   "type": "object",
                   "required": ["href"],
                   "properties": {
-
                     "href": {
                       "title": "href",
                       "type": "string",
@@ -90,16 +87,13 @@
                       "type": "string",
                       "description": "The value of the optional `type` member must be a string that hints at the format used to represent CRS parameters at the provided URI. Suggested values are: `proj4`, `ogcwkt`, `esriwkt`, but others can be used."
                     }
-
                   }
                 }
               }
             }
           }
-
         ]
       }
-
     },
 
     "bbox": {
@@ -111,17 +105,15 @@
         "type": "number"
       }
     }
-
   },
 
   "oneOf": [
-
     {
       "title": "Point",
       "description": "For type `Point`, the `coordinates` member must be a single position.",
       "required": ["coordinates"],
       "properties": {
-        "type": { "enum": ["Point"] },
+        "type": { "const": "Point" },
         "coordinates": {
           "allOf": [
             { "$ref": "#/definitions/coordinates" },
@@ -137,7 +129,7 @@
       "description": "For type `MultiPoint`, the `coordinates` member must be an array of positions.",
       "required": ["coordinates"],
       "properties": {
-        "type": { "enum": ["MultiPoint"] },
+        "type": { "const": "MultiPoint" },
         "coordinates": {
           "allOf": [
             { "$ref": "#/definitions/coordinates" },
@@ -156,7 +148,7 @@
       "description": "For type `LineString`, the `coordinates` member must be an array of two or more positions.\n\nA LinearRing is closed LineString with 4 or more positions. The first and last positions are equivalent (they represent equivalent points). Though a LinearRing is not explicitly represented as a GeoJSON geometry type, it is referred to in the Polygon geometry type definition.",
       "required": ["coordinates"],
       "properties": {
-        "type": { "enum": ["LineString"] },
+        "type": { "const": "LineString" },
         "coordinates": { "$ref": "#/definitions/lineStringCoordinates" }
       },
       "allOf": [{ "$ref": "#/definitions/geometry" }]
@@ -167,7 +159,7 @@
       "description": "For type `MultiLineString`, the `coordinates` member must be an array of LineString coordinate arrays.",
       "required": ["coordinates"],
       "properties": {
-        "type": { "enum": ["MultiLineString"] },
+        "type": { "const": "MultiLineString" },
         "coordinates": {
           "allOf": [
             { "$ref": "#/definitions/coordinates" },
@@ -186,7 +178,7 @@
       "description": "For type `Polygon`, the `coordinates` member must be an array of LinearRing coordinate arrays. For Polygons with multiple rings, the first must be the exterior ring and any others must be interior rings or holes.",
       "required": ["coordinates"],
       "properties": {
-        "type": { "enum": ["Polygon"] },
+        "type": { "const": "Polygon" },
         "coordinates": { "$ref": "#/definitions/polygonCoordinates" }
       },
       "allOf": [{ "$ref": "#/definitions/geometry" }]
@@ -197,7 +189,7 @@
       "description": "For type `MultiPolygon`, the `coordinates` member must be an array of Polygon coordinate arrays.",
       "required": ["coordinates"],
       "properties": {
-        "type": { "enum": ["MultiPolygon"] },
+        "type": { "const": "MultiPolygon" },
         "coordinates": {
           "allOf": [
             { "$ref": "#/definitions/coordinates" },
@@ -216,7 +208,7 @@
       "description": "A GeoJSON object with type `GeometryCollection` is a geometry object which represents a collection of geometry objects.\n\nA geometry collection must have a member with the name `geometries`. The value corresponding to `geometries` is an array. Each element in this array is a GeoJSON geometry object.",
       "required": ["geometries"],
       "properties": {
-        "type": { "enum": ["GeometryCollection"] },
+        "type": { "const": "GeometryCollection" },
         "geometries": {
           "title": "Geometries",
           "type": "array",
@@ -233,7 +225,7 @@
       "description": "A GeoJSON object with the type `FeatureCollection` is a feature collection object.\n\nAn object of type `FeatureCollection` must have a member with the name `features`. The value corresponding to `features` is an array. Each element in the array is a feature object as defined above.",
       "required": ["features"],
       "properties": {
-        "type": { "enum": ["FeatureCollection"] },
+        "type": { "const": "FeatureCollection" },
         "features": {
           "title": "Features",
           "type": "array",
@@ -241,19 +233,14 @@
         }
       }
     }
-
   ],
 
   "definitions": {
-
     "coordinates": {
       "title": "Coordinates",
       "type": "array",
       "items": {
-        "oneOf": [
-          { "type": "array" },
-          { "type": "number" }
-        ]
+        "oneOf": [{ "type": "array" }, { "type": "number" }]
       }
     },
 
@@ -282,27 +269,19 @@
       "required": ["geometry", "properties"],
       "type": "object",
       "properties": {
-
-        "type": { "enum": ["Feature"] },
+        "type": { "const": "Feature" },
 
         "geometry": {
           "title": "Geometry",
-          "oneOf": [
-            { "$ref": "#/definitions/geometry" },
-            { "type": "null" }
-          ]
+          "oneOf": [{ "$ref": "#/definitions/geometry" }, { "type": "null" }]
         },
 
         "properties": {
           "title": "Properties",
-          "oneOf": [
-            { "type": "object" },
-            { "type": "null" }
-          ]
+          "oneOf": [{ "type": "object" }, { "type": "null" }]
         },
 
         "id": {}
-
       }
     },
 
@@ -352,7 +331,5 @@
         "type": "number"
       }
     }
-
   }
-
 }


### PR DESCRIPTION
\+ minor code cleanup

Fixes batch failures when trying to use the new map function:
```sh
ok - updating job: 715944 with {"status":"Running","version":"1.1.0","output":{"cache":false,"output":false,"preview":false,"validated":false},"loglink":"batch-prod-job/default/a46701f983cd4a27abf213b2deb4fdfa"}
[{"instancePath":"/layers/addresses/0/conform/accuracy","schemaPath":"#/properties/layers/properties/addresses/items/properties/conform/properties/accuracy/type","keyword":"type","params":{"type":"integer"},"message":"must be integer"}]
Error: Source does not conform to V2 schema
    at Job.fetch (file:///usr/local/src/batch/lib/job.js:87:19)
    at async flow (file:///usr/local/src/batch/task.js:82:9)
ok - updating job: 715944 with {"status":"Fail"}
false
```
https://batch.openaddresses.io/job/715944