### PR TITLE
au/nsw/sydney migrate from deprecated source to current

### DIFF
--- a/sources/au/nsw/city_of_sydney.json
+++ b/sources/au/nsw/city_of_sydney.json
@@ -22,6 +22,7 @@
                 },
                 "conform": {
                     "format": "geojson",
+                    "accuracy": 2,
                     "srs": "EPSG:4326",
                     "number": "HouseNumbers",
                     "street": "Street",


### PR DESCRIPTION
* migrates from the deprecated source to the current source from the city of sydney open data portal
* set addresses accuracy to "parcel" since the addresses are from the parcel geometry dataset