### PR TITLE
Allow string column names in accuracy conform schema

### DIFF
--- a/schema/layers/address_conform.json
+++ b/schema/layers/address_conform.json
@@ -12,6 +12,7 @@
     "accuracy": {
       "description": "https://github.com/openaddresses/openaddresses/blob/master/CONTRIBUTING.md#accuracy",
       "oneOf": [
+        { "type": "string" },
         { "type": "integer", "minimum": 1, "maximum": 5 },
         { "$ref": "../util/functions/map_integer.json" }
       ]


### PR DESCRIPTION
Extends #7922 to allow string column names for accuracy in the conform object.

Meant to help with https://github.com/openaddresses/openaddresses/issues/7910