### PR TITLE
Mexico National data update of the license and explanation of the tre…

### DIFF
--- a/sources/mx/countrywide.json
+++ b/sources/mx/countrywide.json
@@ -15,7 +15,7 @@
                 "website": "https://github.com/digital-guard/preserv-MX/tree/main/data/_pk0002.01",
                 "license": {
                     "text": "INEGI TERMS OF FREE USE OF INFORMATION",
-                    "url": "https://dl.digital-guard.org/96ff13f8be3bbfdbb8dd5ed5522d0086787272f4c2f9be95306655c795ac1d80.pdf",
+                    "url": "https://dl.digital-guard.org/647a8f64ed703b93ecc541f39fb7c08dbe445cb704ee78e69036ce5ef711b8a4.pdf",
                     "attribution": true,
                     "attribution name": "INEGI Instituto Nacional de Estadística y Geografía",
                     "share-alike": false


### PR DESCRIPTION
…atment applied to data by AddressForAll

Update of the license which continues of the family CC.BY, considering the data enrichment AddressForAll has done: Here follows what we have done on the data to complete missing Town names where these were missing, as well as postcodes: We took the 2400+ files available on the INEGI website and merged them into a single file. We filtered and selected only the attributes relevant for the openaddresses.io and overture.org projects. Using official administrative boundaries produced by the INEGI (https://www.inegi.org.mx/app/biblioteca/ficha.html?upc=794551132173 ), we completed the missing State and Municipality names. Subsequently, we utilized the postal code polygon database to complete the missing postal codes. The postal code polygon database was downloaded some time ago from these links, which are no longer functional but worked at the time. We were unable to locate updated, working links. https://datos.gob.mx/busca/dataset/codigos-postales-coordenadas-y-colonias  https://datos.gob.mx/busca/dataset/ubicacion-de-codigos-postales-en-mexico  The new consolidated database obtained is available here: https://dl.digital-guard.org/090735bf608a3202a141da670d960a05dbe464893ba49208fc37c30485f5bedc.zip