### PR TITLE
include AU external territory ISO 3166 codes in coverage

### DIFF
--- a/sources/au/christmas_island.json
+++ b/sources/au/christmas_island.json
@@ -1,5 +1,10 @@
 {
     "coverage": {
+        "ISO 3166": {
+            "alpha2": "AU-CX",
+            "state": "Christmas Island",
+            "country": "Australia"
+        },
         "country": "au",
         "state": "christmas-island"
     },

--- a/sources/au/cocos_island.json
+++ b/sources/au/cocos_island.json
@@ -1,5 +1,10 @@
 {
     "coverage": {
+        "ISO 3166": {
+            "alpha2": "AU-CC",
+            "state": "Cocos Island",
+            "country": "Australia"
+        },
         "country": "au",
         "state": "cocos-island"
     },


### PR DESCRIPTION
this still won't be included in the coverage map since the source data doesn't use these codes, see https://github.com/openaddresses/batch/issues/485