### PR TITLE
Update NO: contact, join number with letter and add region+unit

### DIFF
--- a/sources/no/countrywide.json
+++ b/sources/no/countrywide.json
@@ -12,7 +12,7 @@
             {
                 "name": "country",
                 "data": "https://nedlasting.geonorge.no/geonorge/Basisdata/MatrikkelenAdresseLeilighetsniva/CSV/Basisdata_0000_Norge_25833_MatrikkelenAdresseLeilighetsniva_CSV.zip",
-                "website": "https://kartkatalog.geonorge.no/metadata/matrikkelen-adresse/f7df7a18-b30f-4745-bd64-d0863812350c",
+                "website": "https://kartkatalog.geonorge.no/metadata/matrikkelen-adresse-leilighetsnivaa/365b0591-b536-42a6-a20d-22e404fbfe55",
                 "protocol": "http",
                 "compression": "zip",
                 "license": {


### PR DESCRIPTION
Ref https://kartverket.no/eiendom/lokal-matrikkelmyndighet/adresser-i-matrikkelen/adresseveileder-handbok#16065: Letters should join the house number without spaces.

Unit wasn't correctly set due to the dataset used did not include unit level information.

Added contact info and region

Note: MatrikkelenVegadresse is deprecated. Should move to either what I did in this PR `Matrikkelen - Adresse Leilighetsnivå` or migrate to the dataset without unit information `Matrikkelen - Adresse`