### PR TITLE
feat(no): add region+unit contact, join number with letter

### DIFF
--- a/sources/no/countrywide.json
+++ b/sources/no/countrywide.json
@@ -11,8 +11,8 @@
         "addresses": [
             {
                 "name": "country",
-                "data": "https://nedlasting.geonorge.no/geonorge/Basisdata/MatrikkelenVegadresse/CSV/Basisdata_0000_Norge_25833_MatrikkelenVegadresse_CSV.zip",
-                "website": "https://kartkatalog.geonorge.no/metadata/cadastre--address-apartment-level/365b0591-b536-42a6-a20d-22e404fbfe55",
+                "data": "https://nedlasting.geonorge.no/geonorge/Basisdata/MatrikkelenAdresseLeilighetsniva/CSV/Basisdata_0000_Norge_25833_MatrikkelenAdresseLeilighetsniva_CSV.zip",
+                "website": "https://kartkatalog.geonorge.no/metadata/matrikkelen-adresse-leilighetsnivaa/365b0591-b536-42a6-a20d-22e404fbfe55",
                 "protocol": "http",
                 "compression": "zip",
                 "license": {
@@ -22,6 +22,12 @@
                     "attribution name": "Kartverket",
                     "share-alike": false
                 },
+                "contact": {
+                    "name": "Kartverket",
+                    "email": "kundesenter@kartverket.no",
+                    "address": "Kartverksveien 21, 3511 Hønefoss, Norway",
+                    "phone": "+47 32 11 80 00"
+                },
                 "conform": {
                     "format": "csv",
                     "csvsplit": ";",
@@ -29,11 +35,19 @@
                     "lat": "Nord",
                     "lon": "Øst",
                     "id": "adresseId",
-                    "number": "nummer",
+                    "number": {
+                        "function": "join",
+                        "fields": [
+                            "nummer",
+                            "bokstav"
+                        ],
+                        "separator": ""
+                    },
+                    "unit": "bruksenhetsnummerTekst",
                     "street": "adressenavn",
-                    "unit": "bokstav",
                     "city": "poststed",
-                    "postcode": "postnummer"
+                    "postcode": "postnummer",
+                    "region": "kommunenavn"
                 }
             }
         ]


### PR DESCRIPTION
Ref https://kartverket.no/eiendom/lokal-matrikkelmyndighet/adresser-i-matrikkelen/adresseveileder-handbok#16065: Letters should join the house number without spaces.

Unit wasn't correctly set due to the dataset used did not include unit level information. Using the dataset with unit informations takes the total to 3,573,856 from 2,595,717 before

Added contact info and region

Note: MatrikkelenVegadresse is deprecated. Should move to either what I did in this PR `Matrikkelen - Adresse Leilighetsnivå` or migrate to the dataset without unit information `Matrikkelen - Adresse`