### PR TITLE
Specify encoding

### DIFF
--- a/sources/se/municipality_of_goteborg.json
+++ b/sources/se/municipality_of_goteborg.json
@@ -30,7 +30,8 @@
           "number": "nr_littera",
           "street": "gatunamn",
           "format": "shapefile",
-          "file": "adresser.shp"
+          "file": "adresser.shp",
+          "encoding": "utf-8"
         }
       }
     ]


### PR DESCRIPTION
UTF-8 is specified in the shp zip .cpg file, so trying that.

Currently has an encoding issue:
https://batch.openaddresses.io/job/765872#map=0/0/0
<img width="784" height="914" alt="image" src="https://github.com/user-attachments/assets/0bf1ed4f-8713-4466-b52c-d5525d914988" />


ETA, the previous run had this in the logs:
```
2026-02-06 14:57:39,334 WARNING: No encoding given and OGR couldn't guess. Trying ISO-8859-1, YOLO!
2026-02-06 14:57:39,334   DEBUG: Assuming shapefile data is encoded iso-8859-1
```
But the shapefile I downloaded had `adresser.cpg` file with the contents `UTF-8` , so it doesn't appear to be used.