### PR TITLE
Add and fix Illinois sources

### DIFF
--- a/sources/us/il/calhoun.json
+++ b/sources/us/il/calhoun.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "17013",
+            "name": "Calhoun County",
+            "state": "Illinois"
+        },
+        "country": "us",
+        "state": "il",
+        "county": "Calhoun"
+    },
+    "schema": 2,
+    "layers": {
+        "addresses": [
+            {
+                "name": "county",
+                "data": "https://services6.arcgis.com/BN5dINZZvv0oeIev/arcgis/rest/services/Greene_Calhoun_addresses_roads/FeatureServer/1",
+                "protocol": "ESRI",
+                "conform": {
+                    "format": "geojson",
+                    "number": "Add_Number",
+                    "street": [
+                        "St_PreDir",
+                        "St_Name",
+                        "St_PosTyp",
+                        "St_PosDir"
+                    ],
+                    "city": "Inc_Muni"
+                }
+            }
+        ],
+        "centerlines": [
+            {
+                "name": "county",
+                "data": "https://services6.arcgis.com/BN5dINZZvv0oeIev/arcgis/rest/services/Greene_Calhoun_addresses_roads/FeatureServer/3",
+                "protocol": "ESRI",
+                "conform": {
+                    "format": "geojson",
+                    "name": {
+                        "function": "join",
+                        "fields": ["Direction", "Name", "Type"],
+                        "separator": " "
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/sources/us/il/champaign.json
+++ b/sources/us/il/champaign.json
@@ -23,7 +23,9 @@
                     "unit": "SubAddress",
                     "street": "StreetName",
                     "postcode": "Zip"
-                }
+                },
+                "skip": true,
+                "note": "ccgisc.org server restructured, address data now behind authentication"
             }
         ]
     }

--- a/sources/us/il/christian.json
+++ b/sources/us/il/christian.json
@@ -30,7 +30,8 @@
                 },
                 "data": "https://services2.bhamaps.com/arcgis/rest/services/AGS_christian_co_il_taxmap/MapServer/0",
                 "protocol": "ESRI",
-                "note": "address field is strange enough that this will need custom processing"
+                "note": "bhamaps.com servers are dead as of 2026-04",
+                "skip": true
             }
         ]
     }

--- a/sources/us/il/city-of-ofallon.json
+++ b/sources/us/il/city-of-ofallon.json
@@ -14,7 +14,7 @@
         },
         "country": "us",
         "state": "il",
-        "county": "Adams"
+        "county": "St. Clair"
     },
     "schema": 2,
     "layers": {

--- a/sources/us/il/city_of_aurora.json
+++ b/sources/us/il/city_of_aurora.json
@@ -38,7 +38,9 @@
                     },
                     "city": "CITY",
                     "postcode": "ZIPCODE"
-                }
+                },
+                "skip": true,
+                "note": "gis.aurora-il.org server is down as of 2026-04"
             }
         ]
     }

--- a/sources/us/il/city_of_aurora.json
+++ b/sources/us/il/city_of_aurora.json
@@ -21,26 +21,21 @@
         "addresses": [
             {
                 "name": "city",
+                "data": "https://ags.auroragov.org/aurora/rest/services/OpenData/MapServer/9",
                 "protocol": "ESRI",
-                "data": "https://gis.aurora-il.org/arcgis/rest/services/AddressPoints/AddressPoints/MapServer/0",
                 "conform": {
                     "format": "geojson",
-                    "number": {
-                        "function": "regexp",
-                        "field": "ADDRESS",
-                        "pattern": "^([0-9]+)"
-                    },
-                    "street": {
-                        "function": "regexp",
-                        "field": "ADDRESS",
-                        "pattern": "^(?:[0-9]+ )(.*)",
-                        "replace": "$1"
-                    },
+                    "number": "ADDRESS_NUMBER",
+                    "street": [
+                        "STREET_DIRECTION",
+                        "STREET_NAME",
+                        "STREET_TYPE",
+                        "DIRSUF"
+                    ],
+                    "unit": "ADDRESS_UNIT",
                     "city": "CITY",
-                    "postcode": "ZIPCODE"
-                },
-                "skip": true,
-                "note": "gis.aurora-il.org server is down as of 2026-04"
+                    "postcode": "ZIP_CODE"
+                }
             }
         ]
     }

--- a/sources/us/il/city_of_east_peoria.json
+++ b/sources/us/il/city_of_east_peoria.json
@@ -36,7 +36,9 @@
                     ],
                     "city": "CITY",
                     "postcode": "ZIP_CODE"
-                }
+                },
+                "skip": true,
+                "note": "FeatureServer now requires authentication token"
             }
         ],
         "parcels": [

--- a/sources/us/il/city_of_schaumburg.json
+++ b/sources/us/il/city_of_schaumburg.json
@@ -31,7 +31,9 @@
                     ],
                     "street": "pipu_loc_street",
                     "unit": "pipu_loc_unit"
-                }
+                },
+                "skip": true,
+                "note": "gisweb.ci.schaumburg.il.us server is down as of 2026-04"
             }
         ]
     }

--- a/sources/us/il/city_of_west_peoria.json
+++ b/sources/us/il/city_of_west_peoria.json
@@ -34,7 +34,9 @@
                     "city": "CITY",
                     "region": "STATE",
                     "postcode": "PZIP"
-                }
+                },
+                "skip": true,
+                "note": "City_of_West_Peoria service removed from centralilmaps.com"
             }
         ]
     }

--- a/sources/us/il/clark.json
+++ b/sources/us/il/clark.json
@@ -29,7 +29,9 @@
                         "replace": "$1"
                     },
                     "format": "geojson"
-                }
+                },
+                "skip": true,
+                "note": "bhamaps.com servers are dead as of 2026-04"
             }
         ]
     }

--- a/sources/us/il/coles.json
+++ b/sources/us/il/coles.json
@@ -44,7 +44,9 @@
                         "pattern": "(\\d{5})",
                         "replace": "$1"
                     }
-                }
+                },
+                "skip": true,
+                "note": "colesco.illinois.gov has SSL certificate failure"
             }
         ],
         "parcels": [

--- a/sources/us/il/dekalb.json
+++ b/sources/us/il/dekalb.json
@@ -1,13 +1,13 @@
 {
     "coverage": {
         "US Census": {
-            "geoid": "17035",
-            "name": "Cumberland County",
+            "geoid": "17037",
+            "name": "DeKalb County",
             "state": "Illinois"
         },
         "country": "us",
         "state": "il",
-        "county": "Cumberland"
+        "county": "DeKalb"
     },
     "schema": 2,
     "layers": {

--- a/sources/us/il/edgar.json
+++ b/sources/us/il/edgar.json
@@ -39,7 +39,9 @@
                         "field": "PropertyAddress2",
                         "pattern": "(\\d{5}(?:-\\d{4})?)$"
                     }
-                }
+                },
+                "skip": true,
+                "note": "bhamaps.com servers are dead as of 2026-04"
             }
         ],
         "parcels": [
@@ -50,7 +52,9 @@
                 "conform": {
                     "format": "geojson",
                     "pid": "PIN"
-                }
+                },
+                "skip": true,
+                "note": "bhamaps.com servers are dead as of 2026-04"
             }
         ]
     }

--- a/sources/us/il/fulton.json
+++ b/sources/us/il/fulton.json
@@ -1,0 +1,56 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "17057",
+            "name": "Fulton County",
+            "state": "Illinois"
+        },
+        "country": "us",
+        "state": "il",
+        "county": "Fulton"
+    },
+    "schema": 2,
+    "layers": {
+        "addresses": [
+            {
+                "name": "county",
+                "data": "https://services1.arcgis.com/Ggva1SWphWGX4bb8/arcgis/rest/services/Fulton_NG911_WFL1/FeatureServer/0",
+                "protocol": "ESRI",
+                "conform": {
+                    "format": "geojson",
+                    "number": "Add_Number",
+                    "street": [
+                        "St_PreDir",
+                        "St_Name",
+                        "St_PosTyp",
+                        "St_PosDir"
+                    ],
+                    "unit": "Unit",
+                    "city": "Post_Comm",
+                    "postcode": "Post_Code"
+                }
+            }
+        ],
+        "centerlines": [
+            {
+                "name": "county",
+                "data": "https://services1.arcgis.com/Ggva1SWphWGX4bb8/arcgis/rest/services/Fulton_NG911_WFL1/FeatureServer/1",
+                "protocol": "ESRI",
+                "conform": {
+                    "format": "geojson",
+                    "name": {
+                        "function": "join",
+                        "fields": ["St_PreDir", "St_Name", "St_PosTyp", "St_PosDir"],
+                        "separator": " "
+                    },
+                    "addr_from_left": "FromAddr_L",
+                    "addr_to_left": "ToAddr_L",
+                    "addr_from_right": "FromAddr_R",
+                    "addr_to_right": "ToAddr_R",
+                    "zip_left": "PostCode_L",
+                    "zip_right": "PostCode_R"
+                }
+            }
+        ]
+    }
+}

--- a/sources/us/il/greene.json
+++ b/sources/us/il/greene.json
@@ -1,0 +1,48 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "17061",
+            "name": "Greene County",
+            "state": "Illinois"
+        },
+        "country": "us",
+        "state": "il",
+        "county": "Greene"
+    },
+    "schema": 2,
+    "layers": {
+        "addresses": [
+            {
+                "name": "county",
+                "data": "https://services6.arcgis.com/BN5dINZZvv0oeIev/arcgis/rest/services/Greene_Calhoun_addresses_roads/FeatureServer/2",
+                "protocol": "ESRI",
+                "conform": {
+                    "format": "geojson",
+                    "number": "Add_Number",
+                    "street": [
+                        "St_PreDir",
+                        "St_Name",
+                        "St_PosTyp",
+                        "St_PosDir"
+                    ],
+                    "city": "Inc_Muni"
+                }
+            }
+        ],
+        "centerlines": [
+            {
+                "name": "county",
+                "data": "https://services6.arcgis.com/BN5dINZZvv0oeIev/arcgis/rest/services/Greene_Calhoun_addresses_roads/FeatureServer/4",
+                "protocol": "ESRI",
+                "conform": {
+                    "format": "geojson",
+                    "name": {
+                        "function": "join",
+                        "fields": ["Direction", "Name", "Type"],
+                        "separator": " "
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/sources/us/il/jackson.json
+++ b/sources/us/il/jackson.json
@@ -28,7 +28,9 @@
                         "pattern": "^([0-9]+)"
                     },
                     "format": "geojson"
-                }
+                },
+                "skip": true,
+                "note": "bhamaps.com servers are dead as of 2026-04"
             }
         ]
     }

--- a/sources/us/il/jersey.json
+++ b/sources/us/il/jersey.json
@@ -29,7 +29,9 @@
                         "replace": "$1"
                     },
                     "format": "geojson"
-                }
+                },
+                "skip": true,
+                "note": "bhamaps.com servers are dead as of 2026-04"
             }
         ]
     }

--- a/sources/us/il/lawrence.json
+++ b/sources/us/il/lawrence.json
@@ -35,7 +35,9 @@
                         "replace": "$1"
                     },
                     "format": "geojson"
-                }
+                },
+                "skip": true,
+                "note": "bhamaps.com servers are dead as of 2026-04"
             }
         ]
     }

--- a/sources/us/il/macoupin.json
+++ b/sources/us/il/macoupin.json
@@ -29,7 +29,9 @@
                         "replace": "$1"
                     },
                     "format": "geojson"
-                }
+                },
+                "skip": true,
+                "note": "bhamaps.com servers are dead as of 2026-04"
             }
         ]
     }

--- a/sources/us/il/madison.json
+++ b/sources/us/il/madison.json
@@ -1,0 +1,54 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "17119",
+            "name": "Madison County",
+            "state": "Illinois"
+        },
+        "country": "us",
+        "state": "il",
+        "county": "Madison"
+    },
+    "schema": 2,
+    "layers": {
+        "addresses": [
+            {
+                "name": "county",
+                "data": "https://gisportal.co.madison.il.us/servera/rest/services/CCAO/Parcel_Owners/MapServer/0",
+                "protocol": "ESRI",
+                "conform": {
+                    "format": "geojson",
+                    "number": "NUM",
+                    "street": [
+                        "ST_NAME",
+                        "ST_TYPE"
+                    ],
+                    "city": "CITY",
+                    "postcode": "ZIP",
+                    "region": "STATE"
+                }
+            }
+        ],
+        "parcels": [
+            {
+                "name": "county",
+                "data": "https://gisportal.co.madison.il.us/servera/rest/services/CCAO/Parcel_Owners/MapServer/0",
+                "protocol": "ESRI",
+                "conform": {
+                    "format": "geojson",
+                    "pid": "PIN"
+                }
+            }
+        ],
+        "buildings": [
+            {
+                "name": "county",
+                "data": "https://gisportal.co.madison.il.us/servera/rest/services/Edit/Structures/FeatureServer/0",
+                "protocol": "ESRI",
+                "conform": {
+                    "format": "geojson"
+                }
+            }
+        ]
+    }
+}

--- a/sources/us/il/massac.json
+++ b/sources/us/il/massac.json
@@ -25,7 +25,9 @@
                     ],
                     "postcode": "ZIP_CODE",
                     "format": "geojson"
-                }
+                },
+                "skip": true,
+                "note": "bhamaps.com servers are dead as of 2026-04"
             }
         ],
         "parcels": [
@@ -36,7 +38,9 @@
                 "conform": {
                     "format": "geojson",
                     "pid": "Parcel_Number"
-                }
+                },
+                "skip": true,
+                "note": "bhamaps.com servers are dead as of 2026-04"
             }
         ]
     }

--- a/sources/us/il/menard.json
+++ b/sources/us/il/menard.json
@@ -30,7 +30,9 @@
                     },
                     "format": "geojson",
                     "accuracy": 2
-                }
+                },
+                "skip": true,
+                "note": "bhamaps.com servers are dead as of 2026-04"
             }
         ]
     }

--- a/sources/us/il/moultrie.json
+++ b/sources/us/il/moultrie.json
@@ -42,7 +42,9 @@
                         "pattern": "([0-9]+)(.*)~(.*), IL ([0-9]+)",
                         "replace": "$4"
                     }
-                }
+                },
+                "skip": true,
+                "note": "bhamaps.com servers are dead as of 2026-04"
             }
         ]
     }

--- a/sources/us/il/putnam.json
+++ b/sources/us/il/putnam.json
@@ -30,7 +30,9 @@
                     },
                     "format": "geojson",
                     "accuracy": 2
-                }
+                },
+                "skip": true,
+                "note": "bhamaps.com servers are dead as of 2026-04"
             }
         ]
     }

--- a/sources/us/il/rock_island.json
+++ b/sources/us/il/rock_island.json
@@ -1,0 +1,53 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "17161",
+            "name": "Rock Island County",
+            "state": "Illinois"
+        },
+        "country": "us",
+        "state": "il",
+        "county": "Rock Island"
+    },
+    "schema": 2,
+    "layers": {
+        "addresses": [
+            {
+                "name": "county",
+                "data": "https://gis.rockislandcountyil.gov/arcgis/rest/services/Hosted/AddressPoints/FeatureServer/0",
+                "protocol": "ESRI",
+                "conform": {
+                    "format": "geojson",
+                    "number": "num_only",
+                    "street": {
+                        "function": "regexp",
+                        "field": "address",
+                        "pattern": "^\\d+\\s+(.*)"
+                    },
+                    "city": "city"
+                }
+            }
+        ],
+        "centerlines": [
+            {
+                "name": "county",
+                "data": "https://gis.rockislandcountyil.gov/arcgis/rest/services/Hosted/STREETS_NEW/FeatureServer/0",
+                "protocol": "ESRI",
+                "conform": {
+                    "format": "geojson",
+                    "name": {
+                        "function": "join",
+                        "fields": ["prefix", "name", "type", "suffix"],
+                        "separator": " "
+                    },
+                    "addr_from_left": "l_f_add",
+                    "addr_to_left": "l_t_add",
+                    "addr_from_right": "r_f_add",
+                    "addr_to_right": "r_t_add",
+                    "zip_left": "zipl",
+                    "zip_right": "zipr"
+                }
+            }
+        ]
+    }
+}

--- a/sources/us/il/vermilion.json
+++ b/sources/us/il/vermilion.json
@@ -29,7 +29,9 @@
                         "replace": "$1"
                     },
                     "format": "geojson"
-                }
+                },
+                "skip": true,
+                "note": "bhamaps.com servers are dead as of 2026-04"
             }
         ],
         "parcels": [
@@ -40,7 +42,9 @@
                 "conform": {
                     "pid": "PIN",
                     "format": "geojson"
-                }
+                },
+                "skip": true,
+                "note": "bhamaps.com servers are dead as of 2026-04"
             }
         ]
     }

--- a/sources/us/il/williamson.json
+++ b/sources/us/il/williamson.json
@@ -29,7 +29,9 @@
                         "replace": "$1"
                     },
                     "format": "geojson"
-                }
+                },
+                "skip": true,
+                "note": "bhamaps.com servers are dead as of 2026-04"
             }
         ],
         "parcels": [
@@ -40,7 +42,9 @@
                 "conform": {
                     "pid": "PIN",
                     "format": "geojson"
-                }
+                },
+                "skip": true,
+                "note": "bhamaps.com servers are dead as of 2026-04"
             }
         ]
     }


### PR DESCRIPTION
## Summary
- Add 5 new county sources: Fulton (NG911), Rock Island, Greene, Calhoun, Madison
- Fix DeKalb County geoid (was incorrectly set to Cumberland) and O'Fallon county field (was Adams, should be St. Clair)
- Replace City of Aurora source with new server at ags.auroragov.org
- Mark 19 broken sources as skipped (13 on dead bhamaps.com, plus Champaign, Aurora, Schaumburg, West Peoria, East Peoria, Coles)

## Notes
- bhamaps.com servers are completely dead; many have migrated to REACH platform on ArcGIS Online (parcel-based). Replacements identified but not yet written for: Christian, Edgar, Jackson, Lawrence, Macoupin.
- West Peoria and East Peoria are already covered by existing Peoria County and Tazewell County sources respectively.
- Schaumburg is already covered by existing Cook County source.
- Research notes saved in `output/il-source-updates-notes.md` for follow-up work.

## Test plan
- [ ] CI runs on new Fulton, Rock Island, Greene, Calhoun, Madison sources
- [ ] CI runs on updated Aurora source
- [ ] Skipped sources don't cause CI failures