### PR TITLE
Add parcels layer to ky/madison

### DIFF
--- a/sources/us/ky/madison.json
+++ b/sources/us/ky/madison.json
@@ -25,6 +25,17 @@
                     "postcode": "ZIP_CODE"
                 }
             }
+        ],
+        "parcels": [
+            {
+                "name": "county",
+                "data": "https://arcserver.madisoncountyky.us/arcgis/rest/services/County_Web_Maps/County_Parcels/MapServer/1",
+                "protocol": "ESRI",
+                "conform": {
+                    "format": "geojson",
+                    "pid": "Parcel_ID"
+                }
+            }
         ]
     }
 }


### PR DESCRIPTION
The Madison County, KY GIS server publishes a dedicated County_Parcels MapServer with a Parcels polygon layer alongside the address data already cataloged here. This adds it as a `parcels` layer.

**Source URL:**
`https://arcserver.madisoncountyky.us/arcgis/rest/services/County_Web_Maps/County_Parcels/MapServer/1`

**Layer details:**
- Layer 0: `Parcel Labels` (polygon, label sublayer)
- Layer 1: `Parcels` ← used here, returns polygon features with `Parcel_ID`, `Acres`, `Zoning`, and related parcel attributes
- Service description: "County parcels map service with labels"

**Verification:**
- `?f=json` on the service root probes successfully
- Layer 1 sample query returns polygon geometry with the expected parcel attributes
- `Parcel_ID` chosen as the conform `pid`

**Conform:**
```json
"conform": {
    "format": "geojson",
    "pid": "Parcel_ID"
}
```