### PR TITLE
Add parcels layer to ky/jefferson

### DIFF
--- a/sources/us/ky/jefferson.json
+++ b/sources/us/ky/jefferson.json
@@ -80,6 +80,18 @@
                     "zip_right": "ZIP_RIGHT"
                 }
             }
+        ],
+        "parcels": [
+            {
+                "name": "county",
+                "data": "https://gis.lojic.org/maps/rest/services/LojicSolutions/OpenDataPVA/MapServer/1",
+                "protocol": "ESRI",
+                "conform": {
+                    "format": "geojson",
+                    "pid": "PARCELID"
+                },
+                "attribution": "Metro Louisville, LOJIC partners"
+            }
         ]
     }
 }


### PR DESCRIPTION
## Summary
- Adds a `parcels` layer to `sources/us/ky/jefferson.json` sourced from the LOJIC OpenDataPVA MapServer (Jefferson County KY Parcels), maintained by the Louisville Metro PVA.
- Uses `PARCELID` as `pid`.

## Test plan
- [ ] `openaddr-process-one` (or CI) successfully fetches the new parcels layer
- [ ] Output GeoJSON has populated `pid` values

🤖 Generated with [Claude Code](https://claude.com/claude-code)