### PR TITLE
Add parcels layer for ky/boyle

### DIFF
--- a/sources/us/ky/boyle.json
+++ b/sources/us/ky/boyle.json
@@ -1,0 +1,27 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "21021",
+            "name": "Boyle County",
+            "state": "Kentucky"
+        },
+        "country": "us",
+        "state": "ky",
+        "county": "Boyle"
+    },
+    "schema": 2,
+    "layers": {
+        "parcels": [
+            {
+                "name": "county",
+                "data": "https://services3.arcgis.com/YNGbWQGxX08glHX9/arcgis/rest/services/Parcel_Boundary/FeatureServer/2",
+                "protocol": "ESRI",
+                "conform": {
+                    "format": "geojson",
+                    "pid": "OBJECTID"
+                },
+                "attribution": "Danville-Boyle County Planning & Zoning Commission"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
## Summary
- Adds new source `sources/us/ky/boyle.json` with a `parcels` layer for Boyle County, KY.
- Source: Danville-Boyle County Planning & Zoning Commission ESRI FeatureServer (`Parcel_Boundary/2`).
- The layer's only attribute fields are `OBJECTID`, `ACRES`, `GlobalID`, and shape — there is no PVA-style parcel number, so `OBJECTID` is used as `pid` (precedent: `us/ga/turner.json`, `us/ak/city_of_bethel.json`, etc.).

## Test plan
- [x] `npx tape test/schema_validation_v2.test.js test/sources_validator.test.js` — file passes (`ok sources/us/ky/boyle.json`).
- [x] Ran openaddresses/batch-machine `openaddr-process-one` end-to-end against the new source: downloaded 13,205 parcel polygons, produced `out.geojson` with `pid` populated and Polygon geometry in EPSG:4326, no source problems reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)