### PR TITLE
Added parcels layer to ky/bullitt

### DIFF
--- a/sources/us/ky/bullitt.json
+++ b/sources/us/ky/bullitt.json
@@ -1,0 +1,26 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "21029",
+            "name": "Bullitt County",
+            "state": "Kentucky"
+        },
+        "country": "us",
+        "state": "ky",
+        "county": "Bullitt"
+    },
+    "schema": 2,
+    "layers": {
+        "parcels": [
+            {
+                "name": "county",
+                "data": "https://wfs.schneidercorp.com/arcgis/rest/services/BullittCountyKY_WFS/MapServer/0",
+                "protocol": "ESRI",
+                "conform": {
+                    "format": "geojson",
+                    "pid": "PARCEL_ID"
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a new source file for Bullitt County, KY (`sources/us/ky/bullitt.json`)
- Sources parcel data from the Schneider Corp WFS ArcGIS MapServer (layer 0)
- Uses `PARCEL_ID` as the parcel identifier field

## Test plan
- [x] Verify `sources/us/ky/bullitt.json` passes schema validation
- [x] Confirm the ESRI MapServer endpoint at `https://wfs.schneidercorp.com/arcgis/rest/services/BullittCountyKY_WFS/MapServer/0` is publicly accessible and returns parcel features
- [x] Confirm `PARCEL_ID` field is populated and unique across records

🤖 Generated with [Claude Code](https://claude.com/claude-code)