### PR TITLE
Added parcels layer to ky/lexington-fayette

### DIFF
--- a/sources/us/ky/lexington-fayette.json
+++ b/sources/us/ky/lexington-fayette.json
@@ -38,5 +38,16 @@
                 "note": "An additional UNIT column appears to describe sub-address units"
             }
         ]
+        "parcels": [
+            {
+                "name": "county",
+                "data": "https://services1.arcgis.com/Mg7DLdfYcSWIaDnu/arcgis/rest/services/Parcel/FeatureServer/0",
+                "protocol": "ESRI",
+                "conform": {
+                    "format": "geojson",
+                    "pid": "PVANUM"
+                }
+            }
+        ]
     }
 }

--- a/sources/us/ky/lexington-fayette.json
+++ b/sources/us/ky/lexington-fayette.json
@@ -37,7 +37,7 @@
                 },
                 "note": "An additional UNIT column appears to describe sub-address units"
             }
-        ]
+        ],
         "parcels": [
             {
                 "name": "county",


### PR DESCRIPTION
## Summary
- Adds a parcels layer to the existing `sources/us/ky/lexington-fayette.json` (Fayette County, KY)
- Sources parcel data from the Lexington-Fayette Urban County Government ArcGIS FeatureServer
- Uses `PVANUM` (Property Valuation Administrator Number) as the parcel identifier field

## Test plan
- [ ] Verify `sources/us/ky/lexington-fayette.json` passes schema validation
- [ ] Confirm the ESRI FeatureServer endpoint at `https://services1.arcgis.com/Mg7DLdfYcSWIaDnu/arcgis/rest/services/Parcel/FeatureServer/0` is publicly accessible and returns parcel features
- [ ] Confirm `PVANUM` field is populated and unique across records

🤖 Generated with [Claude Code](https://claude.com/claude-code)