### PR TITLE
Added parcels layer to ky/franklin

### DIFF
--- a/sources/us/ky/franklin.json
+++ b/sources/us/ky/franklin.json
@@ -30,6 +30,18 @@
                     "postcode": "Comm_Zip"
                 }
             }
+        ],
+        "parcels": [
+            {
+                "name": "county",
+                "data": "https://services7.arcgis.com/HM4C7tGF5KT34U6h/arcgis/rest/services/FRANKLIN_CO_ARCGIS_ONLINE_2_gdb/FeatureServer/37",
+                "protocol": "ESRI",
+                "conform": {
+                    "format": "geojson",
+                    "srs": "EPSG:4326",
+                    "pid": "PID_NUMBER__MAP_"
+                }
+            }
         ]
     }
 }


### PR DESCRIPTION
## Summary
- Adds a parcels layer to the existing `sources/us/ky/franklin.json` (Franklin County, KY)
- Sources parcel data from the Franklin County ArcGIS FeatureServer (layer 37)
- Uses `PID_NUMBER__MAP_` as the parcel identifier field
- Specifies `EPSG:4326` SRS as provided by the data source

🤖 Generated with [Claude Code](https://claude.com/claude-code)