### PR TITLE
Added parcels layer to ky/mercer

### DIFF
--- a/sources/us/ky/mercer.json
+++ b/sources/us/ky/mercer.json
@@ -1,0 +1,27 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "21167",
+            "name": "Mercer County",
+            "state": "Kentucky"
+        },
+        "country": "us",
+        "state": "ky",
+        "county": "Mercer"
+    },
+    "schema": 2,
+    "layers": {
+        "parcels": [
+            {
+                "name": "county",
+                "data": "https://maps.mercercounty.org/arcgis/rest/services/PIP/MercerPortalMap/MapServer/6",
+                "protocol": "ESRI",
+                "conform": {
+                    "format": "geojson",
+                    "srs": "EPSG:4326",
+                    "pid": "PAMS_PIN"
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a new source file for Mercer County, KY (`sources/us/ky/mercer.json`)
- Sources parcel data from the Mercer County ArcGIS MapServer (layer 6)
- Uses `PAMS_PIN` as the parcel identifier field
- Specifies `EPSG:4326` SRS as provided by the data source

🤖 Generated with [Claude Code](https://claude.com/claude-code)