### PR TITLE
Fix broken Minnesota county source URLs

### DIFF
--- a/sources/us/mn/cass.json
+++ b/sources/us/mn/cass.json
@@ -14,29 +14,25 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://cassweb3.co.cass.mn.us/arcgis/rest/services/Basic_Layers2/MapServer/3",
+                "data": "https://cassweb.casscountymn.gov/arcgis/rest/services/DLANBasemap_Cass/MapServer/2",
                 "protocol": "ESRI",
-                "conform": {
-                    "number": {
-                        "function": "prefixed_number",
-                        "field": "ADDRESS"
-                    },
-                    "street": {
-                        "function": "postfixed_street",
-                        "field": "ADDRESS"
-                    },
-                    "format": "geojson"
-                }
-            }
-        ],
-        "parcels": [
-            {
-                "name": "county",
-                "data": "https://cassweb3.co.cass.mn.us/arcgis/rest/services/Basic_Layers2/MapServer/13",
-                "protocol": "ESRI",
+                "website": "https://cassweb.casscountymn.gov/arcgis/rest/services",
                 "conform": {
                     "format": "geojson",
-                    "pid": "APPRCL"
+                    "number": [
+                        "ANUMBER",
+                        "ANUMBERSUF"
+                    ],
+                    "street": [
+                        "ST_PRE_MOD",
+                        "ST_PRE_DIR",
+                        "ST_PRE_TYP",
+                        "ST_NAME",
+                        "ST_POS_TYP",
+                        "ST_POS_DIR"
+                    ],
+                    "district": "CO_NAME",
+                    "region": "STATE_CODE"
                 }
             }
         ]

--- a/sources/us/mn/faribault.json
+++ b/sources/us/mn/faribault.json
@@ -15,17 +15,29 @@
             {
                 "name": "county",
                 "protocol": "ESRI",
-                "data": "https://services2.arcgis.com/fxB2C8mQfjMb1848/ArcGIS/rest/services/TaxParcels/FeatureServer/0",
+                "data": "https://services2.arcgis.com/fxB2C8mQfjMb1848/ArcGIS/rest/services/E911/FeatureServer/0",
                 "conform": {
                     "format": "geojson",
-                    "number": "BLDG_NUM",
-                    "street": [
-                        "STREETNAME",
-                        "STREETTYPE",
-                        "SUFFIX_DIR"
-                    ],
-                    "city": "CITY",
-                    "postcode": "ZIP"
+                    "number": "E911_NO",
+                    "street": {
+                        "function": "regexp",
+                        "field": "E911_ADD",
+                        "pattern": "^\\d+\\s+(.*)"
+                    },
+                    "city": "E911_CITY",
+                    "region": "E911_ST",
+                    "postcode": "E911_ZIP"
+                }
+            }
+        ],
+        "parcels": [
+            {
+                "name": "county",
+                "protocol": "ESRI",
+                "data": "https://services2.arcgis.com/fxB2C8mQfjMb1848/ArcGIS/rest/services/TaxParcelsGAC/FeatureServer/0",
+                "conform": {
+                    "format": "geojson",
+                    "pid": "STATE_PIN"
                 }
             }
         ]

--- a/sources/us/mn/koochiching.json
+++ b/sources/us/mn/koochiching.json
@@ -14,31 +14,31 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://services3.arcgis.com/8mdusDCY0WncdJVw/ArcGIS/rest/services/Parcels/FeatureServer/0",
+                "data": "https://services3.arcgis.com/8mdusDCY0WncdJVw/arcgis/rest/services/KoochichingCountyParcelDataPublish/FeatureServer/0",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
                     "number": {
                         "function": "regexp",
                         "field": "ADDR_1",
-                        "pattern": "([0-9]*) (.*)",
+                        "pattern": "^(\\d+)\\s+.*",
                         "replace": "$1"
                     },
                     "street": {
                         "function": "regexp",
                         "field": "ADDR_1",
-                        "pattern": "([0-9]*) (.*)",
-                        "replace": "$2"
+                        "pattern": "^\\d+\\s+(.*)",
+                        "replace": "$1"
                     },
                     "city": "CITY",
-                    "postcode": "ZipCode5"
+                    "postcode": "ZIP_CODE_5"
                 }
             }
         ],
         "parcels": [
             {
                 "name": "county",
-                "data": "https://services3.arcgis.com/8mdusDCY0WncdJVw/ArcGIS/rest/services/KoochichingCountyParcels/FeatureServer/0",
+                "data": "https://services3.arcgis.com/8mdusDCY0WncdJVw/arcgis/rest/services/KoochichingCountyParcelDataPublish/FeatureServer/0",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",

--- a/sources/us/mn/pope.json
+++ b/sources/us/mn/pope.json
@@ -14,20 +14,30 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://gis.co.pope.mn.us/arcgis/rest/services/OpenData/OpenData/MapServer/0/",
+                "data": "https://gis.popecountymn.gov/arcgis/rest/services/Addressing/Addressing_public/FeatureServer/0",
                 "protocol": "ESRI",
+                "website": "https://gis.popecountymn.gov/arcgis/rest/services/Addressing",
                 "conform": {
                     "format": "geojson",
-                    "number": "ADDRNUM",
-                    "street": {
-                        "function": "regexp",
-                        "field": "FULLADDR",
-                        "pattern": "^(?:[0-9]+ )(.*)",
-                        "replace": "$1"
-                    },
+                    "number": [
+                        "ANUMBERPRE",
+                        "ANUMBER",
+                        "ANUMBERSUF"
+                    ],
+                    "street": [
+                        "ST_PRE_MOD",
+                        "ST_PRE_DIR",
+                        "ST_PRE_TYP",
+                        "ST_PRE_SEP",
+                        "ST_NAME",
+                        "ST_POS_TYP",
+                        "ST_POS_DIR",
+                        "ST_POS_MOD"
+                    ],
+                    "city": "CTU_NAME",
+                    "district": "CO_NAME",
                     "postcode": "ZIP",
-                    "city": "MUNICIPALITY",
-                    "region": "STATE"
+                    "region": "STATE_CODE"
                 }
             }
         ]

--- a/sources/us/mn/renville.json
+++ b/sources/us/mn/renville.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://gis.renvillecountymn.com/arcgis/rest/services/Link_Public_Map_Service/MapServer/115",
+                "data": "https://gis.renvillecountymn.gov/arcgis/rest/services/LandRecords/Address_Points/MapServer/0",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",


### PR DESCRIPTION
Fixes broken URLs for 5 Minnesota counties:

- **Cass County**: Switch to new server at cassweb.casscountymn.gov (old cassweb3.co.cass.mn.us is down)
- **Pope County**: Move to new domain gis.popecountymn.gov with updated Addressing service
- **Renville County**: Update domain from .com to .gov (gis.renvillecountymn.gov)
- **Faribault County**: Switch from TaxParcels layer to E911 layer for better address data, add parcels layer
- **Koochiching County**: Update service name to KoochichingCountyParcelDataPublish, fix field name (ZIP_CODE_5)

This is part of splitting up the larger Minnesota updates PR (#8156) into smaller, more manageable pieces. These are all fixes for currently broken sources.