### PR TITLE
improve wallonia street names

### DIFF
--- a/sources/be/wal/bosa-region-wallonia-de.json
+++ b/sources/be/wal/bosa-region-wallonia-de.json
@@ -21,7 +21,13 @@
                     "encoding": "utf-8",
                     "accuracy": 3,
                     "number": "house_number",
-                    "street": "streetname_de",
+                    "street": {
+                        "function": "first_non_empty",
+                        "fields": [
+                            "streetname_de",
+                            "streetname_fr"
+                        ]
+                    },
                     "city": "municipality_name_de",
                     "postcode": "postcode",
                     "id": {

--- a/sources/be/wal/bosa-region-wallonia-fr.json
+++ b/sources/be/wal/bosa-region-wallonia-fr.json
@@ -21,7 +21,13 @@
                     "encoding": "utf-8",
                     "accuracy": 3,
                     "number": "house_number",
-                    "street": "streetname_fr",
+                    "street": {
+                        "function": "first_non_empty",
+                        "fields": [
+                            "streetname_fr",
+                            "streetname_de"
+                        ]
+                    },
                     "city": "municipality_name_fr",
                     "postcode": "postcode",
                     "id": {


### PR DESCRIPTION
In the source data, the street name columns only contain a french or a german name so our outputs are incomplete by only selecting one of them. This is not the case for the city columns so those can remain as they are.

Adding a first_non_empty clause to still favor the intended language but allow filling in with the fallback coverage.

