### PR TITLE
fix ca/on/city_of_windsor - switch to PropertyParcels/MapServer/0

### DIFF
--- a/sources/ca/on/city_of_windsor.json
+++ b/sources/ca/on/city_of_windsor.json
@@ -16,7 +16,7 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://mappmycity.ca/arcgis/rest/services/MappMyCity/AllUniqueAddresses_Parcels/MapServer/1",
+                "data": "https://mappmycity.ca/arcgis/rest/services/PropertyParcels/MapServer/0",
                 "website": "https://mapp-my-city-citywindsor.hub.arcgis.com/",
                 "license": "https://www.citywindsor.ca/opendata/Documents/OpenDataTermsofUse.pdf",
                 "protocol": "ESRI",


### PR DESCRIPTION
The previous layer `MappMyCity/AllUniqueAddresses_Parcels/MapServer/1` now returns 0 features. `PropertyParcels/MapServer/0` on the same server (`mappmycity.ca`) has 132,450 features with identical field names (`street_address`, `street_name`, `street_suffix`, `street_direction`, `unit_number`).