### PR TITLE
fix us/ca/del_norte - update service name to Parcels_20240628

### DIFF
--- a/sources/us/ca/del_norte.json
+++ b/sources/us/ca/del_norte.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://services3.arcgis.com/IkUDY1vRIUWiVvcz/arcgis/rest/services/Parcels/FeatureServer/0",
+                "data": "https://services3.arcgis.com/IkUDY1vRIUWiVvcz/arcgis/rest/services/Parcels_20240628/FeatureServer/0",
                 "website": "https://www.co.del-norte.ca.us/departments/information-technology/geographic-information-services-gis",
                 "protocol": "ESRI",
                 "conform": {
@@ -32,7 +32,7 @@
         "parcels": [
             {
                 "name": "county",
-                "data": "https://services3.arcgis.com/IkUDY1vRIUWiVvcz/arcgis/rest/services/Parcels/FeatureServer/0",
+                "data": "https://services3.arcgis.com/IkUDY1vRIUWiVvcz/arcgis/rest/services/Parcels_20240628/FeatureServer/0",
                 "website": "https://www.co.del-norte.ca.us/departments/information-technology/geographic-information-services-gis",
                 "protocol": "ESRI",
                 "conform": {


### PR DESCRIPTION
The ArcGIS Online service was renamed from `Parcels` to `Parcels_20240628` on the same org (`IkUDY1vRIUWiVvcz`). Same layer 0, same field names (`StreetNum`, `Street`, `StreetType`, `Community`, `Zip`, `Asmt`).