### PR TITLE
fix us/co/fremont - switch to AUT_LAND_RECORDS/FeatureServer

### DIFF
--- a/sources/us/co/fremont.json
+++ b/sources/us/co/fremont.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://fremontgis.com/server/rest/services/FC_ADDRESSES/MapServer/1",
+                "data": "https://fremontgis.com/server/rest/services/AUT_LAND_RECORDS/FeatureServer/1082516613",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
@@ -30,19 +30,18 @@
                         "GL_UNIT_ID"
                     ],
                     "city": "PO_NAME",
-                    "postcode": "PO_ZIP",
-                    "region": "PO_STATE"
+                    "postcode": "PO_ZIP"
                 }
             }
         ],
         "parcels": [
             {
                 "name": "county",
-                "data": "https://fremontgis.com/server/rest/services/Hosted/Mail_List/FeatureServer/0",
+                "data": "https://fremontgis.com/server/rest/services/AUT_LAND_RECORDS/FeatureServer/1082516613",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
-                    "pid": "parcelnumber"
+                    "pid": "PARCELNUMBER"
                 }
             }
         ]


### PR DESCRIPTION
Both the `FC_ADDRESSES/MapServer/1` (addresses) and `Hosted/Mail_List/FeatureServer/0` (parcels) layers return 404 on `fremontgis.com`.

`AUT_LAND_RECORDS/FeatureServer/1082516613` (FC Parcels) on the same server contains all the original address fields (`GL_HSE_NUM`, `GL_DIR_PFX`, `GL_STR_NAM`, `GL_TYP_SFX`, `GL_PSL_SFX`, `GL_UNIT_TYP`, `GL_UNIT_ID`, `PO_NAME`, `PO_ZIP`) and the parcel identifier (`PARCELNUMBER`). Both layers now point to this single endpoint.