### PR TITLE
fix us/mi/kalamazoo - update centerlines to Kalamazoo_DBO_City_Streets

### DIFF
--- a/sources/us/mi/kalamazoo.json
+++ b/sources/us/mi/kalamazoo.json
@@ -54,7 +54,7 @@
         "centerlines": [
             {
                 "name": "county",
-                "data": "https://gis.kalamazoocity.org/hosting/rest/services/General_Items/Streets/MapServer/1",
+                "data": "https://gis.kalamazoocity.org/hosting/rest/services/General_Items/Kalamazoo_DBO_City_Streets/MapServer/0",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",


### PR DESCRIPTION
`General_Items/Streets/MapServer/1` on `gis.kalamazoocity.org` now requires a token. The sibling service `General_Items/Kalamazoo_DBO_City_Streets/MapServer/0` on the same host is public and has identical field names (`PREFIX`, `NAME`, `TYPE`, `SUFFIX`, `L_F_ADD`, `L_T_ADD`, `R_F_ADD`, `R_T_ADD`, `L_ZIP`, `R_ZIP`).