### PR TITLE
fix us/nm/mckinley - update to renamed FeatureServer

### DIFF
--- a/sources/us/nm/mckinley.json
+++ b/sources/us/nm/mckinley.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://gis.gallupnm.us/server/rest/services/City_of_Gallup_Roads_and_Addresses_GIS1/FeatureServer/4",
+                "data": "https://gis.gallupnm.us/server/rest/services/City_of_Gallup_Roads_and_Addresses/FeatureServer/4",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",


### PR DESCRIPTION
The service `City_of_Gallup_Roads_and_Addresses_GIS1` was renamed to `City_of_Gallup_Roads_and_Addresses` on `gis.gallupnm.us`. Same layer 4 (now named `MCKINLEY_COUNTY_ADDRESS_POINTS`), same field names (`num`, `road`, `suffix`).