### PR TITLE
fix us/sc/charleston - update to GIS_VIEWER/New_Public_Search/MapServer

### DIFF
--- a/sources/us/sc/charleston.json
+++ b/sources/us/sc/charleston.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://gisccapps.charlestoncounty.org/arcgis/rest/services/GIS_VIEWER/Public_Search/MapServer/1",
+                "data": "https://gisccapps.charlestoncounty.org/arcgis/rest/services/GIS_VIEWER/New_Public_Search/MapServer/1",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
@@ -35,18 +35,18 @@
         "parcels": [
             {
                 "name": "county",
-                "data": "https://gisccapps.charlestoncounty.org/arcgis/rest/services/GIS_VIEWER/Public_Search/MapServer/4",
+                "data": "https://gisccapps.charlestoncounty.org/arcgis/rest/services/GIS_VIEWER/New_Public_Search/MapServer/7",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
-                    "pid": "FEATURES.SDE.P_POLY_PARCEL.PID"
+                    "pid": "PID"
                 }
             }
         ],
         "buildings": [
             {
                 "name": "county",
-                "data": "https://gisccapps.charlestoncounty.org/arcgis/rest/services/GIS_VIEWER/Public_Search/MapServer/7",
+                "data": "https://gisccapps.charlestoncounty.org/arcgis/rest/services/GIS_VIEWER/New_Public_Search/MapServer/6",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson"


### PR DESCRIPTION
`GIS_VIEWER/Public_Search/MapServer` on `gisccapps.charlestoncounty.org` returns 404. The replacement service is `GIS_VIEWER/New_Public_Search/MapServer` on the same host.

- Addresses: layer 1, `WHOLE_ADDRESS` field unchanged
- Parcels: layer 4 → layer 7; pid field `FEATURES.SDE.P_POLY_PARCEL.PID` → `PID`
- Buildings: layer 7 → layer 6