### PR TITLE
fix us/sd/charles_mix - update to CHARLES_MIX_WEB_LAYERS2

### DIFF
--- a/sources/us/sd/charles_mix.json
+++ b/sources/us/sd/charles_mix.json
@@ -14,29 +14,24 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://gis.districtiii.org/server/rest/services/CHARLES_MIX_WEB_LAYERS/MapServer/6",
+                "data": "https://gis.districtiii.org/server/rest/services/CHARLES_MIX_WEB_LAYERS2/MapServer/40",
                 "protocol": "ESRI",
                 "conform": {
-                    "number": {
-                        "function": "prefixed_number",
-                        "field": "TC_SITE_ADDRESS"
-                    },
-                    "street": {
-                        "function": "postfixed_street",
-                        "field": "TC_SITE_ADDRESS"
-                    },
-                    "format": "geojson"
+                    "format": "geojson",
+                    "number": "HOUSE__",
+                    "street": ["PRE_DIR", "STREET_NAME"],
+                    "city": "LOCATION_TN"
                 }
             }
         ],
         "parcels": [
             {
                 "name": "county",
-                "data": "https://gis.districtiii.org/server/rest/services/CHARLES_MIX_WEB_LAYERS/MapServer/10",
+                "data": "https://gis.districtiii.org/server/rest/services/CHARLES_MIX_WEB_LAYERS2/MapServer/6",
                 "protocol": "ESRI",
                 "conform": {
-                    "pid": "PARCEL_ID",
-                    "format": "geojson"
+                    "format": "geojson",
+                    "pid": "Parcelid"
                 }
             }
         ]


### PR DESCRIPTION
The `CHARLES_MIX_WEB_LAYERS/MapServer` service returns "Service not started". The service has been renamed to `CHARLES_MIX_WEB_LAYERS2` on the same server (`gis.districtiii.org`).

**Addresses**: switched from the parcels layer (where `TC_SITE_ADDRESS` was blank) to the dedicated `ADDRESS_POINTS` layer (layer 40) with explicit fields: `HOUSE__` (number), `PRE_DIR`, `STREET_NAME` (street), `LOCATION_TN` (city).

**Parcels**: layer 10 → layer 6; pid field `PARCEL_ID` → `Parcelid`.