### PR TITLE
fix us/va/campbell - update centerlines to Public_Data/Road_Centerlines

### DIFF
--- a/sources/us/va/campbell.json
+++ b/sources/us/va/campbell.json
@@ -34,7 +34,7 @@
         "centerlines": [
             {
                 "name": "county",
-                "data": "https://gis.co.campbell.va.us/arcgis/rest/services/Open_Data/StreetCenterline/MapServer/0",
+                "data": "https://gis.co.campbell.va.us/arcgis/rest/services/Public_Data/Road_Centerlines/MapServer/9",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",


### PR DESCRIPTION
`Open_Data/StreetCenterline/MapServer` on `gis.co.campbell.va.us` returns 404. The service has moved to `Public_Data/Road_Centerlines/MapServer/9` on the same server. All field names (`FULLNAME`, `ONEWAYDIR`, `ROADCLASS`, `FROMLEFT`, `TOLEFT`, `FROMRIGHT`, `TORIGHT`, `ZIPLEFT`, `ZIPRIGHT`) are unchanged.