### PR TITLE
fix us/va/franklin - migrate to ArcGIS Online

### DIFF
--- a/sources/us/va/franklin.json
+++ b/sources/us/va/franklin.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://gis.franklincountyva.gov/arcgis/rest/services/PublicServices/LandBaseLayers/MapServer/1",
+                "data": "https://services9.arcgis.com/AzdpqVmJ5GjGWCoI/arcgis/rest/services/FranklinCoVA_911Addresses/FeatureServer/0",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
@@ -32,7 +32,7 @@
         "parcels": [
             {
                 "name": "county",
-                "data": "https://gis.franklincountyva.gov/arcgis/rest/services/PublicServices/LandBaseLayers/MapServer/3",
+                "data": "https://services9.arcgis.com/AzdpqVmJ5GjGWCoI/arcgis/rest/services/FranklinCoVA_TaxParcels/FeatureServer/0",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",


### PR DESCRIPTION
`gis.franklincountyva.gov` times out consistently. Franklin County VA now publishes data on ArcGIS Online (org `AzdpqVmJ5GjGWCoI`).

- Addresses: `FranklinCoVA_911Addresses/FeatureServer/0` — 33,769 features, same field names (`ADDRESS`, `NAME`, `EXTENSION`, `OCCUNIT`, `COMMUNITY`, `ZipCode`)
- Parcels: `FranklinCoVA_TaxParcels/FeatureServer/0` — same `Parcel_No` field