### PR TITLE
fix us/wa/grays_harbor - county website moved, new GDB download

### DIFF
--- a/sources/us/wa/grays_harbor.json
+++ b/sources/us/wa/grays_harbor.json
@@ -12,10 +12,11 @@
                 "name": "county",
                 "protocol": "http",
                 "compression": "zip",
-                "data": "https://www.co.grays-harbor.wa.us/GIS/Data_Download/Parcels.zip",
-                "website": "https://www.co.grays-harbor.wa.us/departments/central_services/GISDataDownload.php",
+                "data": "https://www.graysharbor.us/Parcel.gdb.zip",
+                "website": "https://www.graysharbor.us/departments/central_services/GISDataDownload.php",
                 "conform": {
-                    "format": "shapefile",
+                    "format": "gdb",
+                    "layer": "Parcel_poly",
                     "number": {
                         "function": "prefixed_number",
                         "field": "SITUS"
@@ -32,10 +33,11 @@
                 "name": "county",
                 "protocol": "http",
                 "compression": "zip",
-                "data": "https://www.co.grays-harbor.wa.us/GIS/Data_Download/Parcels.zip",
-                "website": "https://www.co.grays-harbor.wa.us/departments/central_services/GISDataDownload.php",
+                "data": "https://www.graysharbor.us/Parcel.gdb.zip",
+                "website": "https://www.graysharbor.us/departments/central_services/GISDataDownload.php",
                 "conform": {
-                    "format": "shapefile",
+                    "format": "gdb",
+                    "layer": "Parcel_poly",
                     "pid": "PARCELATT"
                 }
             }


### PR DESCRIPTION
The county website moved from `co.grays-harbor.wa.us` to `graysharbor.us`. The data download changed from `Parcels.zip` (shapefile) to `Parcel.gdb.zip` (file geodatabase, layer `Parcel_poly`). Field names `SITUS` (address) and `PARCELATT` (parcel ID) are unchanged.