### PR TITLE
fix us/wi/la_crosse - update buildings URL to web.s3.wisc.edu

### DIFF
--- a/sources/us/wi/la_crosse.json
+++ b/sources/us/wi/la_crosse.json
@@ -46,6 +46,7 @@
                 "protocol": "http",
                 "compression": "zip",
                 "year": "2023",
+                "note": "gisdata.wisc.edu is down as of 2026-06; no replacement URL found",
                 "conform": {
                     "format": "shapefile",
                     "pid": "PARCELID"
@@ -55,7 +56,7 @@
         "buildings": [
             {
                 "name": "county",
-                "data": "https://gisdata.wisc.edu/public/LaCrosse_Buildings_2018.zip",
+                "data": "https://web.s3.wisc.edu/rml-gisdata/LaCrosse_Buildings_2018.zip",
                 "website": "https://geodata.wisc.edu/catalog/EFF12EFD-BD43-4E83-AFCC-26E46089DFD3",
                 "protocol": "http",
                 "compression": "zip",


### PR DESCRIPTION
`gisdata.wisc.edu` is no longer reachable. The buildings download (`LaCrosse_Buildings_2018.zip`) has moved to `web.s3.wisc.edu/rml-gisdata/` with the same filename, confirmed accessible. The parcels layer (`LaCrosse_Parcels_2023_SHP.zip`) is also down on the old host with no replacement found at this time; a note has been added.