### PR TITLE
fix us/co/summit - remove empty buildings layer

### DIFF
--- a/sources/us/co/summit.json
+++ b/sources/us/co/summit.json
@@ -256,16 +256,6 @@
                     "pid": "PPI"
                 }
             }
-        ],
-        "buildings": [
-            {
-                "name": "county",
-                "data": "https://gis.summitcountyco.gov/arcgis/rest/services/GIS_Base_Data/Building_Outlines_2022/MapServer/11",
-                "protocol": "ESRI",
-                "conform": {
-                    "format": "geojson"
-                }
-            }
         ]
     }
 }


### PR DESCRIPTION
The `GIS_Base_Data/Building_Outlines_2022/MapServer/11` layer returns 'Layer not found'. Investigated replacement options:

- Both `Building_Outlines_2022` and `Building_Outlines_2019` services on `gis.summitcountyco.gov` have 0 layers
- All other folders on the same server (EagleviewPictometry, Hosted, AGO_GIS, CommunityDevelopment, etc.) contain no building services
- No public building footprint service found on the county's ArcGIS Online org (`summitcounty.maps.arcgis.com`)
- No Summit County-specific buildings dataset found via AGOL search
- Microsoft Building Footprints (MSBFP2) covers CO but has no county filter, making it inappropriate as a county-specific source

No county-specific replacement found. Removing the broken layer.