### PR TITLE
fix us/az/gila - switch to AZ statewide parcels FeatureServer

### DIFF
--- a/sources/us/az/gila.json
+++ b/sources/us/az/gila.json
@@ -14,27 +14,27 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://gis.gilacountyaz.gov/arcgis/rest/services/ParcelService/AddressService/MapServer/0",
+                "data": "https://services.arcgis.com/C34zQ7veRS0V1t04/arcgis/rest/services/Parcels/FeatureServer/3",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
-                    "number": "HOUSE_NUM",
-                    "street": [
-                        "PREFIX",
-                        "ROAD_NAME",
-                        "SUFFIX"
-                    ],
-                    "unit": "UNIT",
-                    "postcode": "ZIP",
-                    "city": "CITY",
-                    "region": "STATE"
+                    "number": {
+                        "function": "prefixed_number",
+                        "field": "SITE_ADDRESS"
+                    },
+                    "street": {
+                        "function": "postfixed_street",
+                        "field": "SITE_ADDRESS"
+                    },
+                    "city": "SITE_CITY",
+                    "postcode": "SITE_ZIP"
                 }
             }
         ],
         "parcels": [
             {
                 "name": "county",
-                "data": "https://gis.gilacountyaz.gov/arcgis/rest/services/ParcelService/ParcelService/MapServer/0",
+                "data": "https://services.arcgis.com/C34zQ7veRS0V1t04/arcgis/rest/services/Parcels/FeatureServer/3",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",


### PR DESCRIPTION
`gis.gilacountyaz.gov` returns HTTP 503 consistently across multiple weekly runs. The AZ statewide parcels service (`services.arcgis.com/C34zQ7veRS0V1t04/…/Parcels/FeatureServer/3`) covers Gila County with 39,656 features. `SITE_ADDRESS` is used for addresses via `prefixed_number`/`postfixed_street`. `APN` for parcel ID is unchanged.