### PR TITLE
fix us/tx/nacogdoches - migrate to ArcGIS Online

### DIFF
--- a/sources/us/tx/nacogdoches.json
+++ b/sources/us/tx/nacogdoches.json
@@ -14,27 +14,28 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://co.nacogdoches.tx.us/maps/public_geodata_downloads/datasets/AddressPointsSHP.zip",
-                "protocol": "http",
-                "compression": "zip",
+                "data": "https://services1.arcgis.com/z3DZ2dwxv2tyH8pc/arcgis/rest/services/Nacogdoches_County_Address_Points/FeatureServer/10",
+                "protocol": "ESRI",
                 "conform": {
-                    "format": "shapefile",
+                    "format": "geojson",
                     "number": [
-                        "NUMBER_PRE",
-                        "NUMBER",
-                        "NUMBER_SUF"
+                        "AddNum_Pre",
+                        "Add_Number",
+                        "AddNum_Suf"
                     ],
                     "street": [
-                        "PRE_MOD",
-                        "PRE_DIR",
-                        "PRE_TYPE",
-                        "ROAD_NAME",
-                        "POST_TYPE",
-                        "POST_DIR",
-                        "POST_MOD"
+                        "St_PreMod",
+                        "St_PreDir",
+                        "St_PreTyp",
+                        "St_PreSep",
+                        "StreetName",
+                        "St_PosTyp",
+                        "St_PosDir",
+                        "St_PosMod"
                     ],
-                    "city": "COMMUNITY",
-                    "unit": "SUBADDRESS"
+                    "unit": "Unit",
+                    "city": "PostComm",
+                    "postcode": "PostCode"
                 }
             }
         ]


### PR DESCRIPTION
The direct ZIP download at `co.nacogdoches.tx.us/maps/public_geodata_downloads/` returns 404 (the entire downloads path is gone). Nacogdoches County now publishes address points on ArcGIS Online (org `z3DZ2dwxv2tyH8pc`, service `Nacogdoches_County_Address_Points/FeatureServer/10`, 38,553 features).

Field names updated to NENA standard names used in the new service: `Add_Number`/`AddNum_Pre`/`AddNum_Suf` (number), `StreetName` with `St_Pre*`/`St_Pos*` components (street), `PostComm` (city), `PostCode` (postcode).