### PR TITLE
fix ca/bc/city_of_abbotsford - migrate to ArcGIS Online

### DIFF
--- a/sources/ca/bc/city_of_abbotsford.json
+++ b/sources/ca/bc/city_of_abbotsford.json
@@ -16,19 +16,14 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://maps.abbotsford.ca/arcgis/rest/services/GeocortexExt/WebMap/MapServer/2",
-                "website": "https://opendata-abbotsford.hub.arcgis.com/datasets/address-points",
-                "license": {
-                    "url": "https://opendata-abbotsford.hub.arcgis.com/pages/city-of-abbotsford-open-data-licence",
-                    "attribution": true,
-                    "text": "Contains information licenced under the Open Government Licence – City of Abbotsford.",
-                    "attribution name": "City of Abbotsford"
-                },
+                "data": "https://services8.arcgis.com/ZYlQy38aWlfDG1Qh/arcgis/rest/services/Address_Points/FeatureServer/0",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
-                    "number": "STREET_NUM",
-                    "street": "STREET_NAME"
+                    "number": "HOUSE",
+                    "street": "STREET",
+                    "unit": "UNIT",
+                    "postcode": "POSTAL_CODE"
                 }
             }
         ]


### PR DESCRIPTION
`maps.abbotsford.ca/arcgis/rest/services` now redirects to ArcGIS Experience — the city has migrated to AGOL. The new source is `Address_Points/FeatureServer/0` on the city's official AGOL org (`ZYlQy38aWlfDG1Qh`, owner: `Data_Abbotsford`), with 54,060 features. Conform updated: `HOUSE` (number), `STREET`, `UNIT`, `POSTAL_CODE`.