### PR TITLE
fix us/pa/lawrence - switch to LAWRENCEGIS/Address/MapServer

### DIFF
--- a/sources/us/pa/lawrence.json
+++ b/sources/us/pa/lawrence.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://gis.leoc.net:6443/arcgis/rest/services/AssessmentInfo/MapServer/0",
+                "data": "https://gis.leoc.net:6443/arcgis/rest/services/LAWRENCEGIS/Address/MapServer/0",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
@@ -24,7 +24,7 @@
                         "ADDRNUMSUF"
                     ],
                     "street": "FULLNAME",
-                    "city": "ZIPCODE",
+                    "city": "POSTCOMM",
                     "postcode": "ZIPCODE"
                 }
             }


### PR DESCRIPTION
AssessmentInfo/MapServer/0 (service stopped). LAWRENCEGIS/Address/MapServer/0 on the same server has 40,133 features with the same fields (PREADDRNUM, ADDRNUM, ADDRNUMSUF, FULLNAME, ZIPCODE). Also corrected city field from ZIPCODE to POSTCOMM.