### PR TITLE
fix us/il/logan - switch to Logan_PropertyAnno/MapServer/1

### DIFF
--- a/sources/us/il/logan.json
+++ b/sources/us/il/logan.json
@@ -14,21 +14,18 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://www.centralilmaps.com/arcgis/rest/services/Logan_Flex_Property/MapServer/4",
+                "data": "https://www.centralilmaps.com/arcgis/rest/services/Logan/Logan_PropertyAnno/MapServer/1",
                 "protocol": "ESRI",
                 "conform": {
+                    "format": "geojson",
                     "number": {
-                        "function": "regexp",
-                        "field": "site_address",
-                        "pattern": "^([0-9]+)"
+                        "function": "prefixed_number",
+                        "field": "Address"
                     },
                     "street": {
-                        "function": "regexp",
-                        "field": "site_address",
-                        "pattern": "^(?:[0-9]+ +)(.*)",
-                        "replace": "$1"
-                    },
-                    "format": "geojson"
+                        "function": "postfixed_street",
+                        "field": "Address"
+                    }
                 }
             }
         ]


### PR DESCRIPTION
Logan_Flex_Property/MapServer/4 (service stopped). Logan/Logan_PropertyAnno/MapServer/1 on the same server has 3,766 rural address points. Simplified conform using prefixed_number/postfixed_street on the Address field.