### PR TITLE
fix us/ca/riverside - update addresses layer and centerlines URL

### DIFF
--- a/sources/us/ca/riverside.json
+++ b/sources/us/ca/riverside.json
@@ -46,7 +46,7 @@
         "centerlines": [
             {
                 "name": "county",
-                "data": "https://content.rcflood.org/arcgis/rest/services/PermitTracker/Centerlines/MapServer/0",
+                "data": "https://gis.countyofriverside.us/arcgis_mapping/rest/services/OpenData/General/MapServer/70",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",


### PR DESCRIPTION
Addresses: OpenData/General/MapServer layer 1 no longer found; moved to layer 10 (ADDRESS_POINTS, 938k features) with updated field names. Centerlines: content.rcflood.org now Cloudflare-blocked; moved to OpenData/General/MapServer/70 on the county server (same fields).