### PR TITLE
fix us/wv/harrison - migrate to ArcGIS Online

### DIFF
--- a/sources/us/wv/harrison.json
+++ b/sources/us/wv/harrison.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://psmapgis.harrisoncountywv.com/arcgis/rest/services/features/ftrSiteAddressPointsRaw/MapServer/0",
+                "data": "https://services7.arcgis.com/0ZKYVer0YcJFeX1E/arcgis/rest/services/HARRISON_AddressPoints/FeatureServer/80",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
@@ -28,7 +28,8 @@
                         "UNITID"
                     ],
                     "street": "FULLNAME",
-                    "city": "MUNICIPALITY"
+                    "city": "MUNICIPALI",
+                    "postcode": "Zip"
                 }
             }
         ]


### PR DESCRIPTION
`psmapgis.harrisoncountywv.com` fails DNS resolution consistently. Harrison County WV now publishes address points on ArcGIS Online (org `0ZKYVer0YcJFeX1E`, service `HARRISON_AddressPoints/FeatureServer/80`, 35,076 features). Same field names: `PREADDRNUM`, `ADDRNUM`, `ADDRNUMSUF`, `UNITTYPE`, `UNITID`, `FULLNAME`, `MUNICIPALI` (city), `Zip`.