### PR TITLE
Add City of Rochelle, IL addresses

### DIFF
--- a/sources/us/il/city_of_rochelle.json
+++ b/sources/us/il/city_of_rochelle.json
@@ -31,8 +31,8 @@
                         "FULLNAME",
                         "ALTUNITID"
                     ],
-                    "city": "MUNICIPALITY",
-                    "postcode": "PLACENAME"
+                    "unit": "UNITTYPE",
+                    "city": "MUNICIPALITY"
                 }
             }
         ]

--- a/sources/us/il/city_of_rochelle.json
+++ b/sources/us/il/city_of_rochelle.json
@@ -1,0 +1,40 @@
+{
+    "coverage": {
+        "geometry": {
+            "type": "Point",
+            "coordinates": [
+                -89.067,
+                41.921
+            ]
+        },
+        "US Census": {
+            "geoid": "1765247",
+            "name": "City of Rochelle",
+            "state": "Illinois"
+        },
+        "country": "us",
+        "state": "il",
+        "city": "Rochelle"
+    },
+    "schema": 2,
+    "layers": {
+        "addresses": [
+            {
+                "name": "city",
+                "data": "https://services1.arcgis.com/tay44YrGmsTQKyNI/arcgis/rest/services/addresspoints2/FeatureServer/23",
+                "protocol": "ESRI",
+                "conform": {
+                    "format": "geojson",
+                    "number": "ADDRNUM",
+                    "street": [
+                        "ALTUNITTYPE",
+                        "FULLNAME",
+                        "ALTUNITID"
+                    ],
+                    "city": "MUNICIPALITY",
+                    "postcode": "PLACENAME"
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Adds address point layer from the City of Rochelle's publicly hosted ArcGIS FeatureServer.

- Layer: addresses
- Source: https://services1.arcgis.com/tay44YrGmsTQKyNI/arcgis/rest/services/addresspoints2/FeatureServer/23
- Records: ~5,870 address points
- Coverage: Rochelle and surrounding communities in Ogle County (Chana, Creston, Kings, Ashton, Esmond)
- Published publicly by the City of Rochelle GIS (Rochelle_Publisher)

Note: The attribute names in this dataset don't match their actual contents — likely a metadata error on the publisher's side. Specifically: `ALTUNITTYPE` holds directional prefixes (E, S, W), `ALTUNITID` holds street type suffixes (Rd, St), `UNITTYPE` holds unit identifiers (`#1`, `A`, `B`), and `PLACENAME` holds ZIP codes. The conform maps to the actual values, not the field names.

Note: No county-wide Ogle County address data was found publicly accessible. The Ogle County GIS Partnership maintains county-wide data but it requires organization authentication.