### PR TITLE
Add City of Champaign, IL addresses

### DIFF
--- a/sources/us/il/city_of_champaign.json
+++ b/sources/us/il/city_of_champaign.json
@@ -1,0 +1,29 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "1712385",
+            "name": "City of Champaign",
+            "state": "Illinois"
+        },
+        "country": "us",
+        "state": "il",
+        "city": "Champaign"
+    },
+    "schema": 2,
+    "layers": {
+        "addresses": [
+            {
+                "name": "city",
+                "data": "https://gisportal.champaignil.gov/ms/rest/services/Open_Data/Open_Data/MapServer/7",
+                "protocol": "ESRI",
+                "conform": {
+                    "format": "geojson",
+                    "number": "AddNum",
+                    "street": ["StreetPreDir", "StreetName", "StreetPostType"],
+                    "city": "City",
+                    "postcode": "ZipCode"
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Adds address point layer from the City of Champaign's public GIS portal.

- Layer: addresses (55,166 points)
- Coverage: City of Champaign only (city is the addressing authority)
- Source: https://gisportal.champaignil.gov/ms/rest/services/Open_Data/Open_Data/MapServer/7
- Provider: City of Champaign Information Technologies

Note: The existing `champaign.json` county source is broken (`skip: true`) — the CCGISC consortium server at maps.ccgisc.org now requires authentication. This city source fills the gap for Champaign city addresses.