### PR TITLE
Fix broken Winnebago County, IL address source

### DIFF
--- a/sources/us/il/winnebago.json
+++ b/sources/us/il/winnebago.json
@@ -14,30 +14,15 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://maps.wingis.org/public/rest/services/NG911/MapServer/9",
+                "data": "https://services2.arcgis.com/Fh2bD9911cyi2gO2/arcgis/rest/services/Rockford_Addresses/FeatureServer/0",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
                     "number": "STNO",
-                    "street": "STNAME",
-                    "unit": [
-                        "UNITTYPE",
-                        "SUITE"
-                    ],
-                    "city": "MSAGComm",
-                    "region": "STATE",
+                    "street": ["PREFIX", "STNAME", "SUFFIX", "POSTDIR"],
+                    "unit": "SUITE",
+                    "city": "CITY",
                     "postcode": "ZIP"
-                }
-            }
-        ],
-        "parcels": [
-            {
-                "name": "county",
-                "data": "https://maps.wingis.org/public/rest/services/NG911/MapServer/1",
-                "protocol": "ESRI",
-                "conform": {
-                    "format": "geojson",
-                    "pid": "PIN"
                 }
             }
         ]


### PR DESCRIPTION
Replaces the broken wingis.org address service with the City of Rockford's public ArcGIS Online FeatureServer, which covers all of Winnebago County.

- Layer: addresses (78,148 points)
- Coverage: All of Winnebago County (Rockford, Cherry Valley, Davis Junction, Loves Park, Stillman Valley, Winnebago)
- New source: https://services2.arcgis.com/Fh2bD9911cyi2gO2/arcgis/rest/services/Rockford_Addresses/FeatureServer/0
- Provider: City of Rockford, IL

What was wrong: `https://maps.wingis.org/public/rest/services/NG911/MapServer/9` returns 404. The parcel layer at that same server is also gone, so the parcels layer has been removed too.