### PR TITLE
Add BOSA Wallonia NL address source

### DIFF
--- a/sources/be/wal/bosa-region-wallonia-nl.json
+++ b/sources/be/wal/bosa-region-wallonia-nl.json
@@ -25,8 +25,7 @@
                         "function": "first_non_empty",
                         "fields": [
                             "streetname_nl",
-                            "streetname_fr",
-                            "streetname_de"
+                            "streetname_fr"
                         ]
                     },
                     "city": "municipality_name_nl",

--- a/sources/be/wal/bosa-region-wallonia-nl.json
+++ b/sources/be/wal/bosa-region-wallonia-nl.json
@@ -1,0 +1,63 @@
+{
+    "coverage": {
+        "ISO 3166": {
+            "alpha2": "BE-WAL",
+            "state": "Walloon Region",
+            "country": "Belgium"
+        },
+        "country": "be",
+        "state": "walloon region"
+    },
+    "schema": 2,
+    "layers": {
+        "addresses": [
+            {
+                "name": "state",
+                "data": "https://opendata.bosa.be/download/best/openaddress-bewal.zip",
+                "protocol": "http",
+                "conform": {
+                    "format": "csv",
+                    "srs": "EPSG:4326",
+                    "encoding": "utf-8",
+                    "accuracy": 3,
+                    "number": "house_number",
+                    "street": {
+                        "function": "first_non_empty",
+                        "fields": [
+                            "streetname_nl",
+                            "streetname_fr",
+                            "streetname_de"
+                        ]
+                    },
+                    "city": "municipality_name_nl",
+                    "postcode": "postcode",
+                    "id": {
+                        "function": "join",
+                        "fields": [
+                            "region_code",
+                            "address_id"
+                        ],
+                        "separator": ":"
+                    },
+                    "unit": "box_number",
+                    "lon": "EPSG:4326_lon",
+                    "lat": "EPSG:4326_lat"
+                },
+                "compression": "zip",
+                "language": "nl",
+                "website": "https://opendata.bosa.be",
+                "license": {
+                    "url": "https://creativecommons.org/licenses/by/4.0",
+                    "text": "CC BY 4.0",
+                    "attribution": true,
+                    "attribution name": "Service public de Wallonie"
+                },
+                "contact": {
+                    "name": "Federal Public Service Policy and Support",
+                    "email": "opendata@bosa.fgov.be",
+                    "address": "WTC III, Boulevard Simon Bolivar 30/1, 1000 Bruxelles, Belgium"
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Dutch-language variant of the Walloon Region address dataset from BOSA. Uses the same source as the existing FR layer.

- street: prefers streetname_nl (available in bilingual/facilities municipalities), falls back to streetname_fr
- city: municipality_name_nl (Dutch municipality names for all of Wallonia)
- language: nl