### PR TITLE
us/az/statewide: Convert field names to lowercase

### DIFF
--- a/sources/us/az/statewide.json
+++ b/sources/us/az/statewide.json
@@ -20,25 +20,25 @@
                     "format": "gdb",
                     "layer": "AZ911_AddressPoints",
                     "number": [
-                        "AddNum_Pre",
-                        "Add_Number",
-                        "AddNum_Suf"
+                        "addnum_pre",
+                        "add_number",
+                        "addnum_suf"
                     ],
                     "street": [
-                        "St_PreMod",
-                        "St_PreDir",
-                        "St_PreTyp",
-                        "St_PreSep",
-                        "St_Name",
-                        "St_PosTyp",
-                        "St_PosDir",
-                        "St_PosMod"
+                        "st_premod",
+                        "st_predir",
+                        "st_pretyp",
+                        "st_presep",
+                        "st_name",
+                        "st_postyp",
+                        "st_posdir",
+                        "st_posmod"
                     ],
-                    "unit": "Unit",
-                    "city": "Post_Comm",
-                    "district": "County",
-                    "region": "State",
-                    "postcode": "Post_Code"
+                    "unit": "unit",
+                    "city": "post_comm",
+                    "district": "county",
+                    "region": "state",
+                    "postcode": "post_code"
                 }
             }
         ],


### PR DESCRIPTION
us/az/statewide source has lost all attributes since May 29.  Appears the column names have been converted to lowercase.
<img width="1311" height="368" alt="image" src="https://github.com/user-attachments/assets/0cdd31e8-ca01-4f42-a331-d8f861e290bf" />
