### PR TITLE
Add Berrien County, MI addresses

### DIFF
--- a/sources/us/mi/berrien.json
+++ b/sources/us/mi/berrien.json
@@ -1,0 +1,31 @@
+{
+    "coverage": {
+        "US Census": {
+            "geoid": "26021",
+            "name": "Berrien County",
+            "state": "Michigan"
+        },
+        "country": "us",
+        "state": "mi",
+        "county": "Berrien"
+    },
+    "schema": 2,
+    "layers": {
+        "addresses": [
+            {
+                "name": "county",
+                "data": "https://gis.berriencountymi.gov/server/rest/services/Hosted/AddressPoints/FeatureServer/0",
+                "website": "https://gis.berriencountymi.gov",
+                "protocol": "ESRI",
+                "conform": {
+                    "format": "geojson",
+                    "number": "housenumbe",
+                    "street": "full_stree",
+                    "unit": "unit",
+                    "city": "postal_com",
+                    "postcode": "postal_cod"
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Adds address point layer from Berrien County's ArcGIS FeatureServer.

- Layer: addresses
- Source: https://gis.berriencountymi.gov/server/rest/services/Hosted/AddressPoints/FeatureServer/0
- 76,381 records confirmed via esri-explore.py
- Conform: number=housenumbe, street=full_stree, unit=unit, city=postal_com, postcode=postal_cod