### PR TITLE
Fix dead data URL for Boundary County, ID

### DIFF
--- a/sources/us/id/boundary.json
+++ b/sources/us/id/boundary.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://www2.boundarycountyid.org/gis/data/Boundary_StructurePnts_CurrentExportSummary.zip",
+                "data": "https://boundarycountyid.org/wp-content/uploads/2026/05/Boundary_StructurePnts_CurrentExportSummary.zip",
                 "protocol": "http",
                 "compression": "zip",
                 "conform": {


### PR DESCRIPTION
## Summary
- The existing `sources/us/id/boundary.json` source pointed to `www2.boundarycountyid.org`, which no longer resolves.
- Issue #8254 supplies a working replacement URL on the county's current site with the same shapefile schema, so only the `data` URL needed to change.

Closes #8254