### PR TITLE
Update us/mi/semcog (fix #4551) - 1.8m buildings

### DIFF
--- a/sources/us/mi/semcog.json
+++ b/sources/us/mi/semcog.json
@@ -2,33 +2,720 @@
     "coverage": {
         "country": "us",
         "state": "mi",
-        "county": "Livingston, Macomb, Monroe, Oakland, Saint Clair, Washtenaw, Wayne"
+        "county": "Livingston, Macomb, Monroe, Oakland, Saint Clair, Washtenaw, Wayne",
+        "geometry": {
+            "type": "MultiPolygon",
+            "coordinates": [
+                [
+                    [
+                        [
+                            -83.21437,
+                            42.04237
+                        ],
+                        [
+                            -83.19345,
+                            42.02643
+                        ],
+                        [
+                            -83.20003,
+                            42.01838
+                        ],
+                        [
+                            -83.21158,
+                            42.01916
+                        ],
+                        [
+                            -83.20927,
+                            41.99951
+                        ],
+                        [
+                            -83.23849,
+                            41.99432
+                        ],
+                        [
+                            -83.22323,
+                            41.98919
+                        ],
+                        [
+                            -83.25157,
+                            41.97237
+                        ],
+                        [
+                            -83.25817,
+                            41.95252
+                        ],
+                        [
+                            -83.25317,
+                            41.94524
+                        ],
+                        [
+                            -83.26388,
+                            41.93129
+                        ],
+                        [
+                            -83.29191,
+                            41.94509
+                        ],
+                        [
+                            -83.3195,
+                            41.93345
+                        ],
+                        [
+                            -83.3423,
+                            41.8796
+                        ],
+                        [
+                            -83.3818,
+                            41.8711
+                        ],
+                        [
+                            -83.40825,
+                            41.82797
+                        ],
+                        [
+                            -83.43892,
+                            41.8134
+                        ],
+                        [
+                            -83.44335,
+                            41.7974
+                        ],
+                        [
+                            -83.44146,
+                            41.78084
+                        ],
+                        [
+                            -83.44344,
+                            41.77403
+                        ],
+                        [
+                            -83.44694,
+                            41.79278
+                        ],
+                        [
+                            -83.46264,
+                            41.78525
+                        ],
+                        [
+                            -83.46242,
+                            41.77916
+                        ],
+                        [
+                            -83.44791,
+                            41.77996
+                        ],
+                        [
+                            -83.43811,
+                            41.75932
+                        ],
+                        [
+                            -83.43836,
+                            41.7514
+                        ],
+                        [
+                            -83.4403,
+                            41.75887
+                        ],
+                        [
+                            -83.4721,
+                            41.764
+                        ],
+                        [
+                            -83.47916,
+                            41.75265
+                        ],
+                        [
+                            -83.46671,
+                            41.74882
+                        ],
+                        [
+                            -83.47963,
+                            41.74901
+                        ],
+                        [
+                            -83.47308,
+                            41.74533
+                        ],
+                        [
+                            -83.48281,
+                            41.73218
+                        ],
+                        [
+                            -83.76313,
+                            41.72354
+                        ],
+                        [
+                            -83.77392,
+                            42.08243
+                        ],
+                        [
+                            -84.13196,
+                            42.07158
+                        ],
+                        [
+                            -84.13113,
+                            42.42457
+                        ],
+                        [
+                            -84.14071,
+                            42.42461
+                        ],
+                        [
+                            -84.14174,
+                            42.54727
+                        ],
+                        [
+                            -84.15818,
+                            42.77664
+                        ],
+                        [
+                            -83.68649,
+                            42.78326
+                        ],
+                        [
+                            -83.68938,
+                            42.87126
+                        ],
+                        [
+                            -82.98364,
+                            42.89374
+                        ],
+                        [
+                            -82.99625,
+                            43.1541
+                        ],
+                        [
+                            -82.50316,
+                            43.16895
+                        ],
+                        [
+                            -82.48604,
+                            43.10239
+                        ],
+                        [
+                            -82.42582,
+                            43.01611
+                        ],
+                        [
+                            -82.42729,
+                            42.99189
+                        ],
+                        [
+                            -82.41837,
+                            42.9755
+                        ],
+                        [
+                            -82.45797,
+                            42.92991
+                        ],
+                        [
+                            -82.47441,
+                            42.89102
+                        ],
+                        [
+                            -82.47254,
+                            42.85144
+                        ],
+                        [
+                            -82.48593,
+                            42.80907
+                        ],
+                        [
+                            -82.47101,
+                            42.76406
+                        ],
+                        [
+                            -82.51375,
+                            42.66952
+                        ],
+                        [
+                            -82.5181,
+                            42.62712
+                        ],
+                        [
+                            -82.54382,
+                            42.60758
+                        ],
+                        [
+                            -82.56979,
+                            42.62006
+                        ],
+                        [
+                            -82.64737,
+                            42.6299
+                        ],
+                        [
+                            -82.65212,
+                            42.6333
+                        ],
+                        [
+                            -82.63326,
+                            42.64028
+                        ],
+                        [
+                            -82.62068,
+                            42.65649
+                        ],
+                        [
+                            -82.6232,
+                            42.67001
+                        ],
+                        [
+                            -82.65289,
+                            42.67213
+                        ],
+                        [
+                            -82.6855,
+                            42.69008
+                        ],
+                        [
+                            -82.72676,
+                            42.68276
+                        ],
+                        [
+                            -82.75584,
+                            42.66849
+                        ],
+                        [
+                            -82.76037,
+                            42.65652
+                        ],
+                        [
+                            -82.8056,
+                            42.64876
+                        ],
+                        [
+                            -82.82053,
+                            42.61593
+                        ],
+                        [
+                            -82.78781,
+                            42.60415
+                        ],
+                        [
+                            -82.79449,
+                            42.60193
+                        ],
+                        [
+                            -82.78924,
+                            42.59558
+                        ],
+                        [
+                            -82.76909,
+                            42.59336
+                        ],
+                        [
+                            -82.7873,
+                            42.59256
+                        ],
+                        [
+                            -82.78323,
+                            42.56391
+                        ],
+                        [
+                            -82.79921,
+                            42.57145
+                        ],
+                        [
+                            -82.83426,
+                            42.56784
+                        ],
+                        [
+                            -82.87437,
+                            42.52354
+                        ],
+                        [
+                            -82.88432,
+                            42.47793
+                        ],
+                        [
+                            -82.87655,
+                            42.47114
+                        ],
+                        [
+                            -82.88172,
+                            42.47174
+                        ],
+                        [
+                            -82.87646,
+                            42.47072
+                        ],
+                        [
+                            -82.87527,
+                            42.46791
+                        ],
+                        [
+                            -82.88442,
+                            42.46839
+                        ],
+                        [
+                            -82.86729,
+                            42.45315
+                        ],
+                        [
+                            -82.8874,
+                            42.39724
+                        ],
+                        [
+                            -82.91749,
+                            42.3763
+                        ],
+                        [
+                            -82.92842,
+                            42.35809
+                        ],
+                        [
+                            -82.98668,
+                            42.35508
+                        ],
+                        [
+                            -83.01412,
+                            42.3364
+                        ],
+                        [
+                            -83.07804,
+                            42.31349
+                        ],
+                        [
+                            -83.09955,
+                            42.2941
+                        ],
+                        [
+                            -83.11863,
+                            42.2583
+                        ],
+                        [
+                            -83.12585,
+                            42.26096
+                        ],
+                        [
+                            -83.1198,
+                            42.25634
+                        ],
+                        [
+                            -83.14781,
+                            42.23542
+                        ],
+                        [
+                            -83.14166,
+                            42.21413
+                        ],
+                        [
+                            -83.16488,
+                            42.1739
+                        ],
+                        [
+                            -83.19153,
+                            42.09247
+                        ],
+                        [
+                            -83.20025,
+                            42.08772
+                        ],
+                        [
+                            -83.18654,
+                            42.04401
+                        ],
+                        [
+                            -83.19737,
+                            42.04638
+                        ],
+                        [
+                            -83.19822,
+                            42.03945
+                        ],
+                        [
+                            -83.21137,
+                            42.04784
+                        ],
+                        [
+                            -83.20642,
+                            42.04214
+                        ],
+                        [
+                            -83.21437,
+                            42.04237
+                        ]
+                    ]
+                ],
+                [
+                    [
+                        [
+                            -82.52208,
+                            42.61562
+                        ],
+                        [
+                            -82.57962,
+                            42.57039
+                        ],
+                        [
+                            -82.5927,
+                            42.55158
+                        ],
+                        [
+                            -82.64174,
+                            42.55752
+                        ],
+                        [
+                            -82.62945,
+                            42.5649
+                        ],
+                        [
+                            -82.60873,
+                            42.56067
+                        ],
+                        [
+                            -82.61508,
+                            42.56505
+                        ],
+                        [
+                            -82.60879,
+                            42.56959
+                        ],
+                        [
+                            -82.61573,
+                            42.56702
+                        ],
+                        [
+                            -82.63008,
+                            42.58647
+                        ],
+                        [
+                            -82.63512,
+                            42.57762
+                        ],
+                        [
+                            -82.64334,
+                            42.5801
+                        ],
+                        [
+                            -82.64014,
+                            42.57845
+                        ],
+                        [
+                            -82.63342,
+                            42.57249
+                        ],
+                        [
+                            -82.63025,
+                            42.56865
+                        ],
+                        [
+                            -82.63147,
+                            42.5663
+                        ],
+                        [
+                            -82.64377,
+                            42.57891
+                        ],
+                        [
+                            -82.65068,
+                            42.5673
+                        ],
+                        [
+                            -82.66635,
+                            42.56978
+                        ],
+                        [
+                            -82.63988,
+                            42.5901
+                        ],
+                        [
+                            -82.60542,
+                            42.59562
+                        ],
+                        [
+                            -82.59268,
+                            42.6131
+                        ],
+                        [
+                            -82.56495,
+                            42.6148
+                        ],
+                        [
+                            -82.54735,
+                            42.60409
+                        ],
+                        [
+                            -82.52208,
+                            42.61562
+                        ]
+                    ]
+                ],
+                [
+                    [
+                        [
+                            -83.14284,
+                            42.18419
+                        ],
+                        [
+                            -83.13804,
+                            42.13159
+                        ],
+                        [
+                            -83.15058,
+                            42.09638
+                        ],
+                        [
+                            -83.1696,
+                            42.08938
+                        ],
+                        [
+                            -83.17376,
+                            42.12467
+                        ],
+                        [
+                            -83.16083,
+                            42.1668
+                        ],
+                        [
+                            -83.14284,
+                            42.18419
+                        ]
+                    ]
+                ],
+                [
+                    [
+                        [
+                            -82.6432,
+                            42.62642
+                        ],
+                        [
+                            -82.58995,
+                            42.61716
+                        ],
+                        [
+                            -82.59813,
+                            42.6121
+                        ],
+                        [
+                            -82.60244,
+                            42.6028
+                        ],
+                        [
+                            -82.60562,
+                            42.59891
+                        ],
+                        [
+                            -82.6097,
+                            42.59697
+                        ],
+                        [
+                            -82.64147,
+                            42.59425
+                        ],
+                        [
+                            -82.64743,
+                            42.59861
+                        ],
+                        [
+                            -82.63746,
+                            42.60987
+                        ],
+                        [
+                            -82.64568,
+                            42.61462
+                        ],
+                        [
+                            -82.66167,
+                            42.61011
+                        ],
+                        [
+                            -82.66727,
+                            42.59689
+                        ],
+                        [
+                            -82.67126,
+                            42.60237
+                        ],
+                        [
+                            -82.66209,
+                            42.61247
+                        ],
+                        [
+                            -82.67036,
+                            42.61006
+                        ],
+                        [
+                            -82.64547,
+                            42.6186
+                        ],
+                        [
+                            -82.6432,
+                            42.62642
+                        ]
+                    ]
+                ]
+            ]
+        }
     },
     "schema": 2,
     "layers": {
         "addresses": [
             {
                 "name": "county",
-                "data": "https://www.arcgis.com/sharing/rest/content/items/bd933a44f945480a84bad873dc29f81d/data",
-                "website": "https://maps-semcog.opendata.arcgis.com/datasets/bd933a44f945480a84bad873dc29f81d",
-                "protocol": "http",
-                "compression": "zip",
+                "data": "https://gis.semcog.org/server/rest/services/Hosted/Buildings_2024/FeatureServer/2",
+                "website": "https://maps-semcog.opendata.arcgis.com/datasets/c9bd1139cb15497084c328315a2c0c84",
+                "license": {
+                    "url": "https://maps-semcog.opendata.arcgis.com/pages/copyright-license-agreement",
+                    "text": "SEMCOG Copyright License Agreement: perpetual, non-exclusive, royalty-free license to use, reproduce, modify, distribute, publish, transmit, display and create derivative works, provided the SEMCOG copyright notice is displayed: Copyright (c) 2024 SEMCOG. All Rights Reserved. Reproduction or Use Without Permission is Prohibited.",
+                    "attribution": true,
+                    "attribution name": "SEMCOG",
+                    "share-alike": false
+                },
+                "protocol": "ESRI",
                 "conform": {
-                    "format": "gdb",
-                    "layer": "Buildings",
-                    "number": "LOADD1",
+                    "format": "geojson",
+                    "number": {
+                        "function": "prefixed_number",
+                        "field": "address"
+                    },
                     "street": {
-                        "function": "regexp",
-                        "field": "STREET1",
-                        "pattern": "^(.+?)(?:\\b(?:UNIT|APT|SUITE|BLDG|LOT|#)\\b.*)?$",
-                        "replace": "$1"
+                        "function": "postfixed_street",
+                        "field": "address"
                     },
-                    "unit": {
-                        "function": "regexp",
-                        "field": "STREET1",
-                        "pattern": "(\\b(?:UNIT|APT|SUITE|BLDG|LOT|#)\\b.*)$"
-                    },
-                    "postcode": "ZIPCODE"
+                    "postcode": "zipcode",
+                    "accuracy": 1
+                }
+            },
+            {
+                "name": "condos",
+                "data": "https://gis.semcog.org/server/rest/services/Hosted/Condos_2024/FeatureServer/0",
+                "website": "https://maps-semcog.opendata.arcgis.com/datasets/583caf5e0d1d420aac47d3c32eccf265",
+                "license": {
+                    "url": "https://maps-semcog.opendata.arcgis.com/pages/copyright-license-agreement",
+                    "text": "SEMCOG Copyright License Agreement: perpetual, non-exclusive, royalty-free license to use, reproduce, modify, distribute, publish, transmit, display and create derivative works, provided the SEMCOG copyright notice is displayed: Copyright (c) 2024 SEMCOG. All Rights Reserved. Reproduction or Use Without Permission is Prohibited.",
+                    "attribution": true,
+                    "attribution name": "SEMCOG",
+                    "share-alike": false
+                },
+                "protocol": "ESRI",
+                "conform": {
+                    "format": "geojson",
+                    "number": "loadd1",
+                    "street": "street1",
+                    "unit": "unit1",
+                    "postcode": "zipcode",
+                    "accuracy": 1
+                }
+            }
+        ],
+        "buildings": [
+            {
+                "name": "county",
+                "data": "https://gis.semcog.org/server/rest/services/Hosted/Buildings_2024/FeatureServer/2",
+                "website": "https://maps-semcog.opendata.arcgis.com/datasets/c9bd1139cb15497084c328315a2c0c84",
+                "license": {
+                    "url": "https://maps-semcog.opendata.arcgis.com/pages/copyright-license-agreement",
+                    "text": "SEMCOG Copyright License Agreement: perpetual, non-exclusive, royalty-free license to use, reproduce, modify, distribute, publish, transmit, display and create derivative works, provided the SEMCOG copyright notice is displayed: Copyright (c) 2024 SEMCOG. All Rights Reserved. Reproduction or Use Without Permission is Prohibited.",
+                    "attribution": true,
+                    "attribution name": "SEMCOG",
+                    "share-alike": false
+                },
+                "protocol": "ESRI",
+                "conform": {
+                    "format": "geojson",
+                    "levels": "stories"
                 }
             }
         ]


### PR DESCRIPTION
Restores SEMCOG's (Southeast Michigan Council of Governments) data. The old ArcGIS item no longer exists and returns HTTP 400, so the source has been failing to download. See notes from #4551.

This repoint both layers at SEMCOG's [current ArcGIS site](https://maps-semcog.opendata.arcgis.com/).

- addresses/county: [Buildings_2024](https://maps-semcog.opendata.arcgis.com/datasets/SEMCOG::building-footprints-2024/about) (1,742,760 footprints). The combined `address` field is split with prefixed_number/postfixed_street, which handles the hyphenated ranges (3.7% of rows) correctly. Old regexes cleaned up (see notes below).
- addresses/condos: [Condos_2024](https://maps-semcog.opendata.arcgis.com/datasets/SEMCOG::condominium-units-2024/about) (153,764 unit-level points), new. These are the individual unit addresses that Buildings_2024 collapses into range addresses, so they are additive rather than duplicates.
- buildings/county: Buildings_2024 footprints with `levels`.

### Also:

- Adds the SEMCOG Copyright License Agreement to each layer (attribution required, not share-alike): https://maps-semcog.opendata.arcgis.com/pages/copyright-license-agreement
- Set accuracy 1: both layers are building-footprint geometry.

### Coverage

Added a multipolygon `geometry` to the layer coverage, since this is a seven-county regional source. Following examples from `us/ok/acog-counties.json` and `us/tx/texoma-counties.json`, which are the equivalent multi-county COG sources. The actual seven-county list is unchanged and matches SEMCOG's County Boundaries. Here's a preview of what that polygon looks like, in case this PR reviewer is a human :)

<img width="970" height="588" alt="image" src="https://github.com/user-attachments/assets/be6db913-922d-4d5f-966f-a866db160b09" />

### Notes from on the regex removal:
The new feed has a single combined `address` field instead of the old `LOADD1` / `STREET1` pair, so it's split with
`prefixed_number` / `postfixed_street`. Verified against a 12,000-row sample spread across the table: 0.07% yield an empty house number and no row fails to start with a digit. Hyphenated ranges (63,694 rows, 3.7%) come through intact —
`40-48 CRANFORD LN` → number `40-48`, street `CRANFORD LN` — because the regex has an explicit `\d+-\d+` branch. The old `UNIT|APT|SUITE|BLDG|LOT|#` regexes are dropped: word-boundary counts in the new field are APT 0, UNIT 9, STE 4, and all four STE hits are false positives from "LAC STE CLAIRE DR".