### PR TITLE
Add script for WTH sources in us/il

### DIFF
--- a/scripts/us/il/wth/README.md
+++ b/scripts/us/il/wth/README.md
@@ -1,0 +1,18 @@
+These scripts scrape parcel boundaries (and, where available, site addresses) from Illinois counties that use WTH Technology's ThinkGIS parcel viewer (e.g. https://gallatinil.wthgis.com/). `lib.js` holds the shared scraping/decoding logic; each subdirectory (`gallatin/`, `mason/`, `pike/`, `richland/`) is a thin per-county config that calls it.
+
+These viewers have no bulk export or REST API. Clicking a parcel calls `tgis/idftr.aspx` with the clicked screen pixel, which is impractical to script at scale. However the same viewer's hover/tooltip code also calls `tgis/getftr.aspx?D=<dsid>&F=<id>&Z=1`, which returns one parcel's attributes and geometry keyed by a small sequential integer id (not a pixel click). `lib.js` walks that id range for a county (probing for the upper bound automatically) and decodes each parcel's delta-encoded polygon (`<poly>` tag - documented inline in `lib.js`, reverse-engineered from `drawPoly5()`/`z192LL()` in the site's own `tgis/tgisProc2.js`) into GeoJSON.
+
+`dsid` is an arbitrary per-county id, not derivable from the subdomain - it only shows up embedded in a real parcel response (e.g. a `DSID=` link, or via a captured browser click). If you need to onboard another WTH-hosted IL county, the fastest way is to click one real parcel in that county's viewer and copy the request as curl (browser devtools → Network tab), same as was done for the 4 here.
+
+Field labels aren't consistent between counties either - some use a `<th class="leftheader">Label</th><td>Value</td>` table, others use `<td class=ftrfld>label</td><td class=ftrval>Value</td>` with different label names (e.g. `taxID` instead of `Parcel Number`). `lib.js`'s `parseFields()` handles both shapes generically; each county's `index.js` just names which label maps to `pid` and (if populated) address.
+
+Run `node index` in a county's directory (no dependencies, needs Node 18+ for global `fetch`) to produce `<county>-parcels.geojson` and, if that county has an `addressLabel` configured, `<county>-addresses.geojson`. Output goes to `$DATA_DIR` if set, otherwise the OS temp directory - the script prints the full output path(s) when it finishes.
+
+Address output is a single raw address string per feature (e.g. `"322 E WASHINGTON"`) plus the parcel polygon as geometry - split it into `number`/`street` in the source JSON's conform with `prefixed_number`/`postfixed_street` (see `sources/us/mi/mason.json` for the same pattern against a similar parcel-derived source).
+
+| County | dsid | Site/tax address field |
+| --- | --- | --- |
+| Gallatin | 10435 | none populated |
+| Mason | 7930 | `Site Address` |
+| Pike | 10340 | `Site Address` |
+| Richland | 823 | `taxPropAddress` (not scraped by default - see `richland/index.js`) |

--- a/scripts/us/il/wth/README.md
+++ b/scripts/us/il/wth/README.md
@@ -6,13 +6,13 @@ These viewers have no bulk export or REST API. Clicking a parcel calls `tgis/idf
 
 Field labels aren't consistent between counties either - some use a `<th class="leftheader">Label</th><td>Value</td>` table, others use `<td class=ftrfld>label</td><td class=ftrval>Value</td>` with different label names (e.g. `taxID` instead of `Parcel Number`). `lib.js`'s `parseFields()` handles both shapes generically; each county's `index.js` just names which label maps to `pid` and (if populated) address.
 
-Run `node index` in a county's directory (no dependencies, needs Node 18+ for global `fetch`) to produce `<county>-parcels.geojson` and, if that county has an `addressLabel` configured, `<county>-addresses.geojson`. Output goes to `$DATA_DIR` if set, otherwise the OS temp directory - the script prints the full output path(s) when it finishes.
+Run `node index` in a county's directory (no dependencies, needs Node 18+ for global `fetch`) to produce a single `<county>.geojson`. Output goes to `$DATA_DIR` if set, otherwise the OS temp directory - the script prints the full output path when it finishes.
 
-Address output is a single raw address string per feature (e.g. `"322 E WASHINGTON"`) plus the parcel polygon as geometry - split it into `number`/`street` in the source JSON's conform with `prefixed_number`/`postfixed_street` (see `sources/us/mi/mason.json` for the same pattern against a similar parcel-derived source).
+Each feature is a parcel polygon carrying both `pid` and, where that county has an `addressLabel` configured, `address`/`city`/`postcode`. This is one file per county rather than separate parcels/addresses files on purpose: upload it once, then point both the source JSON's `parcels` and `addresses` layers at the same uploaded URL, each with its own `conform` pulling out what it needs - this repo already does that in plenty of sources (e.g. `sources/au/qld/logan_city.json`). Split `address` into `number`/`street` with `prefixed_number`/`postfixed_street` (see `sources/us/mi/mason.json` for the same pattern against a similar parcel-derived source).
 
-| County | dsid | Site/tax address field |
-| --- | --- | --- |
-| Gallatin | 10435 | none populated |
-| Mason | 7930 | `Site Address` |
-| Pike | 10340 | `Site Address` |
-| Richland | 823 | `taxPropAddress` (not scraped by default - see `richland/index.js`) |
+| County | dsid | pid field | Site/tax address field |
+| --- | --- | --- | --- |
+| Gallatin | 10435 | `Parcel Number` | none populated |
+| Mason | 7930 | `Parcel Number` | `Site Address` |
+| Pike | 10340 | `Parcel Number` | `Site Address` |
+| Richland | 823 | `taxID` | `taxPropAddress` + `taxPropCityStZip` (no postcode - Richland's property-address record never carries one, only the owner's mailing zip, which is a different location) |

--- a/scripts/us/il/wth/gallatin/index.js
+++ b/scripts/us/il/wth/gallatin/index.js
@@ -1,0 +1,9 @@
+'use strict';
+
+require('../lib').run({
+  name: 'gallatin',
+  host: 'https://gallatinil.wthgis.com',
+  dsid: 10435,
+  pidLabel: 'Parcel Number'
+  // no addressLabel: Site Address is empty for every parcel in this county
+});

--- a/scripts/us/il/wth/gallatin/package.json
+++ b/scripts/us/il/wth/gallatin/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "gallatin-il-parcels",
+  "version": "1.0.0",
+  "description": "Dumps parcel boundaries + parcel numbers for Gallatin County, IL from its WTH/ThinkGIS viewer",
+  "main": "index.js",
+  "scripts": {
+    "dump": "node index"
+  },
+  "license": "MIT"
+}

--- a/scripts/us/il/wth/lib.js
+++ b/scripts/us/il/wth/lib.js
@@ -1,0 +1,210 @@
+'use strict';
+
+// Shared scraper for counties running WTH Technology / ThinkGIS parcel
+// viewers (e.g. https://gallatinil.wthgis.com/). See README.md in this
+// directory for how the site works and why this approach is needed.
+
+function z192LL(x19, y19) {
+  const x = x19 / Math.pow(2, 19);
+  const y = y19 / Math.pow(2, 19);
+  const originX = 128.0;
+  const originY = 128.0;
+  const pixelsPerLon = 256.0 / 360.0;
+  const pixelsPerLonRadian = 256.0 / (2 * Math.PI);
+  const lon = (x - originX) / pixelsPerLon;
+  const latRadians = (y - originY) / (-pixelsPerLonRadian);
+  const lat = (2 * Math.atan(Math.exp(latRadians)) - Math.PI / 2) * (180 / Math.PI);
+  return [lon, lat];
+}
+
+// mirrors drawPoly5() in tgis/tgisProc2.js: first pair is an absolute point,
+// every pair after that is a delta from the running position
+function decodeRing(polyText) {
+  const parts = polyText.split(',');
+  const coords = parts.slice(2); // parts[0]=color, parts[1]=width, both unused here
+  const ptCount = Math.floor(coords.length / 2);
+  let x = 0;
+  let y = 0;
+  const ring = [];
+  for (let i = 0; i < ptCount; i++) {
+    x += parseInt(coords[i * 2], 10);
+    y += parseInt(coords[i * 2 + 1], 10);
+    ring.push(z192LL(x, y));
+  }
+  return ring;
+}
+
+function decodeGeometry(xml) {
+  const rings = [];
+  const polyRe = /<poly>([^<]*)<\/poly>/g;
+  let m;
+  while ((m = polyRe.exec(xml)) !== null) {
+    const ring = decodeRing(m[1]);
+    if (ring.length >= 3) rings.push(ring);
+  }
+  if (rings.length === 0) return null;
+  return rings.length === 1
+    ? { type: 'Polygon', coordinates: [rings[0]] }
+    : { type: 'MultiPolygon', coordinates: rings.map((r) => [r]) };
+}
+
+// The parcel record HTML isn't consistent between counties - some use
+// `<th class="leftheader">Label</th><td>Value</td>`, others use
+// `<td class=ftrfld>label</td><td class=ftrval>Value</td>`. This pulls
+// every label/value pair out of either shape into a plain object, keyed
+// by the human-readable label (e.g. "Parcel Number", "taxID"). Values that
+// span multiple lines (e.g. "322 E WASHINGTON<br>HAVANA IL 62644") come
+// back as a "\n"-joined string - callers decide how to split that.
+function parseFields(xml) {
+  const fields = {};
+  const re =
+    /<(?:th class="leftheader"|td class=ftrfld)>([^<]*)<\/(?:th|td)>\s*<td(?: class=ftrval)?>([\s\S]*?)<\/td>/g;
+  let m;
+  while ((m = re.exec(xml)) !== null) {
+    const label = m[1].replace(/&nbsp;/g, ' ').trim();
+    const value = m[2]
+      .replace(/<br\s*\/?>/gi, '\n')
+      .replace(/<[^>]*>/g, '')
+      .replace(/&nbsp;/g, ' ')
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0)
+      .join('\n');
+    fields[label] = value;
+  }
+  return fields;
+}
+
+function parseFeature(xml) {
+  if (/none found/i.test(xml)) return null;
+  const geometry = decodeGeometry(xml);
+  if (!geometry) return null;
+  return { fields: parseFields(xml), geometry };
+}
+
+async function fetchFeature(host, dsid, featureId, attempt = 1) {
+  const url = `${host}/tgis/getftr.aspx?D=${dsid}&F=${featureId}&Z=1`;
+  try {
+    const res = await fetch(url, {
+      headers: {
+        'user-agent': 'openaddresses-import (parcels; contact: rmartin@rmart.in)',
+        referer: `${host}/`,
+        accept: '*/*'
+      }
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return parseFeature(await res.text());
+  } catch (err) {
+    if (attempt >= 3) {
+      console.warn(`F=${featureId} failed after ${attempt} attempts: ${err.message}`);
+      return null;
+    }
+    await new Promise((r) => setTimeout(r, 500 * attempt));
+    return fetchFeature(host, dsid, featureId, attempt + 1);
+  }
+}
+
+// Feature ids are a small sequential range per county with no published
+// upper bound, so probe for it: double up from 1 until a whole window
+// comes back empty, then binary-search the boundary.
+async function findMaxFeatureId(host, dsid) {
+  const windowSize = 200;
+  const hasAnyHit = async (start, end) => {
+    for (let id = start; id <= end; id += 1) {
+      if (await fetchFeature(host, dsid, id)) return true;
+    }
+    return false;
+  };
+
+  let lo = 1;
+  let hi = windowSize;
+  while (await hasAnyHit(hi - windowSize + 1, hi)) {
+    lo = hi;
+    hi *= 2;
+  }
+
+  // binary search for the last id at which a forward window still has a hit
+  while (hi - lo > windowSize) {
+    const mid = Math.floor((lo + hi) / 2);
+    if (await hasAnyHit(mid - windowSize + 1, mid)) {
+      lo = mid;
+    } else {
+      hi = mid;
+    }
+  }
+  return hi;
+}
+
+async function scrapeCounty({ host, dsid, concurrency = 5, maxFeatureId }) {
+  const max = maxFeatureId || (await findMaxFeatureId(host, dsid));
+  console.log(`scanning F=1..${max} on ${host} (D=${dsid})`);
+
+  const features = [];
+  let nextId = 1;
+  let done = 0;
+
+  async function worker() {
+    while (nextId <= max) {
+      const id = nextId++;
+      const feature = await fetchFeature(host, dsid, id);
+      if (feature) features.push(feature);
+      done++;
+      if (done % 500 === 0) {
+        console.log(`processed ${done}/${max}, ${features.length} parcels found`);
+      }
+    }
+  }
+
+  await Promise.all(Array.from({ length: concurrency }, worker));
+  return features;
+}
+
+function toParcelsGeoJSON(features, pidLabel) {
+  const out = [];
+  for (const f of features) {
+    const pid = f.fields[pidLabel];
+    if (!pid) continue;
+    out.push({ type: 'Feature', properties: { pid }, geometry: f.geometry });
+  }
+  return { type: 'FeatureCollection', features: out };
+}
+
+// address is left as a single raw string (e.g. "322 E WASHINGTON") - the
+// source JSON's conform should split it with prefixed_number/postfixed_street,
+// same as sources/us/mi/mason.json does for a similar parcel-derived source.
+// Geometry is left as the parcel polygon; use "format": "shapefile-polygon"
+// equivalent (batch-machine centroids polygon address sources) in conform.
+function toAddressesGeoJSON(features, addressLabel) {
+  const out = [];
+  for (const f of features) {
+    const raw = f.fields[addressLabel];
+    if (!raw) continue;
+    const address = raw.split('\n')[0].trim(); // drop any trailing city/state/zip line
+    if (!address) continue;
+    out.push({ type: 'Feature', properties: { address }, geometry: f.geometry });
+  }
+  return { type: 'FeatureCollection', features: out };
+}
+
+async function run({ name, host, dsid, pidLabel, addressLabel, maxFeatureId }) {
+  const os = require('os');
+  const path = require('path');
+  const fs = require('fs');
+  const outDir = process.env.DATA_DIR || os.tmpdir();
+
+  const features = await scrapeCounty({ host, dsid, maxFeatureId });
+
+  const parcels = toParcelsGeoJSON(features, pidLabel);
+  const parcelsPath = path.join(outDir, `${name}-parcels.geojson`);
+  fs.writeFileSync(parcelsPath, JSON.stringify(parcels));
+  console.log(`wrote ${parcels.features.length} parcels to ${parcelsPath}`);
+
+  if (addressLabel) {
+    const addresses = toAddressesGeoJSON(features, addressLabel);
+    const addressesPath = path.join(outDir, `${name}-addresses.geojson`);
+    fs.writeFileSync(addressesPath, JSON.stringify(addresses));
+    console.log(`wrote ${addresses.features.length} addresses to ${addressesPath}`);
+  }
+}
+
+module.exports = { scrapeCounty, toParcelsGeoJSON, toAddressesGeoJSON, run };

--- a/scripts/us/il/wth/lib.js
+++ b/scripts/us/il/wth/lib.js
@@ -159,16 +159,6 @@ async function scrapeCounty({ host, dsid, concurrency = 5, maxFeatureId }) {
   return features;
 }
 
-function toParcelsGeoJSON(features, pidLabel) {
-  const out = [];
-  for (const f of features) {
-    const pid = f.fields[pidLabel];
-    if (!pid) continue;
-    out.push({ type: 'Feature', properties: { pid }, geometry: f.geometry });
-  }
-  return { type: 'FeatureCollection', features: out };
-}
-
 // e.g. "HAVANA IL 62644" or "OLNEY, IL" -> { city: "HAVANA", postcode: "62644" }
 // (state is dropped - every county here is IL)
 function parseCityStateZip(text) {
@@ -182,7 +172,12 @@ function parseCityStateZip(text) {
   return result;
 }
 
-// street is left as a single raw string (e.g. "322 E WASHINGTON") - the
+// One feature per parcel, carrying both parcel and address attributes -
+// the parcels and addresses layers in the source JSON can point at the
+// same uploaded file and each conform pull out what they need (this repo
+// already does that in plenty of sources, e.g. sources/au/qld/logan_city.json).
+//
+// address is left as a single raw string (e.g. "322 E WASHINGTON") - the
 // source JSON's conform should split it with prefixed_number/postfixed_street,
 // same as sources/us/mi/mason.json does for a similar parcel-derived source.
 // Geometry is left as the parcel polygon; use "format": "shapefile-polygon"
@@ -191,20 +186,28 @@ function parseCityStateZip(text) {
 // city/zip come either from a second line within addressLabel itself (e.g.
 // Mason/Pike's "322 E WASHINGTON<br>HAVANA IL 62644") or, if cityStateZipLabel
 // is given, from that separate field (e.g. Richland's "taxPropCityStZip").
-function toAddressesGeoJSON(features, addressLabel, cityStateZipLabel) {
+function toGeoJSON(features, { pidLabel, addressLabel, cityStateZipLabel }) {
   const out = [];
   for (const f of features) {
-    const raw = f.fields[addressLabel];
-    if (!raw) continue;
-    const lines = raw.split('\n');
-    const address = lines[0].trim();
-    if (!address) continue;
+    const pid = f.fields[pidLabel];
+    if (!pid) continue;
 
-    const properties = { address };
-    const cszText = cityStateZipLabel ? f.fields[cityStateZipLabel] : lines[1];
-    const csz = parseCityStateZip(cszText);
-    if (csz.city) properties.city = csz.city;
-    if (csz.postcode) properties.postcode = csz.postcode;
+    const properties = { pid };
+
+    if (addressLabel) {
+      const raw = f.fields[addressLabel];
+      if (raw) {
+        const lines = raw.split('\n');
+        const address = lines[0].trim();
+        if (address) {
+          properties.address = address;
+          const cszText = cityStateZipLabel ? f.fields[cityStateZipLabel] : lines[1];
+          const csz = parseCityStateZip(cszText);
+          if (csz.city) properties.city = csz.city;
+          if (csz.postcode) properties.postcode = csz.postcode;
+        }
+      }
+    }
 
     out.push({ type: 'Feature', properties, geometry: f.geometry });
   }
@@ -218,18 +221,17 @@ async function run({ name, host, dsid, pidLabel, addressLabel, cityStateZipLabel
   const outDir = process.env.DATA_DIR || os.tmpdir();
 
   const features = await scrapeCounty({ host, dsid, maxFeatureId });
+  const collection = toGeoJSON(features, { pidLabel, addressLabel, cityStateZipLabel });
 
-  const parcels = toParcelsGeoJSON(features, pidLabel);
-  const parcelsPath = path.join(outDir, `${name}-parcels.geojson`);
-  fs.writeFileSync(parcelsPath, JSON.stringify(parcels));
-  console.log(`wrote ${parcels.features.length} parcels to ${parcelsPath}`);
+  const outPath = path.join(outDir, `${name}.geojson`);
+  fs.writeFileSync(outPath, JSON.stringify(collection));
 
-  if (addressLabel) {
-    const addresses = toAddressesGeoJSON(features, addressLabel, cityStateZipLabel);
-    const addressesPath = path.join(outDir, `${name}-addresses.geojson`);
-    fs.writeFileSync(addressesPath, JSON.stringify(addresses));
-    console.log(`wrote ${addresses.features.length} addresses to ${addressesPath}`);
-  }
+  const withAddress = addressLabel
+    ? collection.features.filter((f) => f.properties.address).length
+    : 0;
+  console.log(
+    `wrote ${collection.features.length} parcels (${withAddress} with an address) to ${outPath}`
+  );
 }
 
-module.exports = { scrapeCounty, toParcelsGeoJSON, toAddressesGeoJSON, run };
+module.exports = { scrapeCounty, toGeoJSON, run };

--- a/scripts/us/il/wth/lib.js
+++ b/scripts/us/il/wth/lib.js
@@ -169,24 +169,49 @@ function toParcelsGeoJSON(features, pidLabel) {
   return { type: 'FeatureCollection', features: out };
 }
 
-// address is left as a single raw string (e.g. "322 E WASHINGTON") - the
+// e.g. "HAVANA IL 62644" or "OLNEY, IL" -> { city: "HAVANA", postcode: "62644" }
+// (state is dropped - every county here is IL)
+function parseCityStateZip(text) {
+  if (!text) return {};
+  const cleaned = text.replace(/,/g, ' ').replace(/\s+/g, ' ').trim();
+  const m = cleaned.match(/^(.*)\s+[A-Z]{2}(?:\s+(\d{5}(?:-\d{4})?))?$/);
+  if (!m) return {};
+  const result = {};
+  if (m[1].trim()) result.city = m[1].trim();
+  if (m[2]) result.postcode = m[2];
+  return result;
+}
+
+// street is left as a single raw string (e.g. "322 E WASHINGTON") - the
 // source JSON's conform should split it with prefixed_number/postfixed_street,
 // same as sources/us/mi/mason.json does for a similar parcel-derived source.
 // Geometry is left as the parcel polygon; use "format": "shapefile-polygon"
 // equivalent (batch-machine centroids polygon address sources) in conform.
-function toAddressesGeoJSON(features, addressLabel) {
+//
+// city/zip come either from a second line within addressLabel itself (e.g.
+// Mason/Pike's "322 E WASHINGTON<br>HAVANA IL 62644") or, if cityStateZipLabel
+// is given, from that separate field (e.g. Richland's "taxPropCityStZip").
+function toAddressesGeoJSON(features, addressLabel, cityStateZipLabel) {
   const out = [];
   for (const f of features) {
     const raw = f.fields[addressLabel];
     if (!raw) continue;
-    const address = raw.split('\n')[0].trim(); // drop any trailing city/state/zip line
+    const lines = raw.split('\n');
+    const address = lines[0].trim();
     if (!address) continue;
-    out.push({ type: 'Feature', properties: { address }, geometry: f.geometry });
+
+    const properties = { address };
+    const cszText = cityStateZipLabel ? f.fields[cityStateZipLabel] : lines[1];
+    const csz = parseCityStateZip(cszText);
+    if (csz.city) properties.city = csz.city;
+    if (csz.postcode) properties.postcode = csz.postcode;
+
+    out.push({ type: 'Feature', properties, geometry: f.geometry });
   }
   return { type: 'FeatureCollection', features: out };
 }
 
-async function run({ name, host, dsid, pidLabel, addressLabel, maxFeatureId }) {
+async function run({ name, host, dsid, pidLabel, addressLabel, cityStateZipLabel, maxFeatureId }) {
   const os = require('os');
   const path = require('path');
   const fs = require('fs');
@@ -200,7 +225,7 @@ async function run({ name, host, dsid, pidLabel, addressLabel, maxFeatureId }) {
   console.log(`wrote ${parcels.features.length} parcels to ${parcelsPath}`);
 
   if (addressLabel) {
-    const addresses = toAddressesGeoJSON(features, addressLabel);
+    const addresses = toAddressesGeoJSON(features, addressLabel, cityStateZipLabel);
     const addressesPath = path.join(outDir, `${name}-addresses.geojson`);
     fs.writeFileSync(addressesPath, JSON.stringify(addresses));
     console.log(`wrote ${addresses.features.length} addresses to ${addressesPath}`);

--- a/scripts/us/il/wth/mason/index.js
+++ b/scripts/us/il/wth/mason/index.js
@@ -1,0 +1,9 @@
+'use strict';
+
+require('../lib').run({
+  name: 'mason',
+  host: 'https://masonil.wthgis.com',
+  dsid: 7930,
+  pidLabel: 'Parcel Number',
+  addressLabel: 'Site Address'
+});

--- a/scripts/us/il/wth/mason/package.json
+++ b/scripts/us/il/wth/mason/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "mason-il-parcels",
+  "version": "1.0.0",
+  "description": "Dumps parcel boundaries, parcel numbers, and site addresses for Mason County, IL from its WTH/ThinkGIS viewer",
+  "main": "index.js",
+  "scripts": {
+    "dump": "node index"
+  },
+  "license": "MIT"
+}

--- a/scripts/us/il/wth/package.json
+++ b/scripts/us/il/wth/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/scripts/us/il/wth/pike/index.js
+++ b/scripts/us/il/wth/pike/index.js
@@ -1,0 +1,9 @@
+'use strict';
+
+require('../lib').run({
+  name: 'pike',
+  host: 'https://pikeil.wthgis.com',
+  dsid: 10340,
+  pidLabel: 'Parcel Number',
+  addressLabel: 'Site Address'
+});

--- a/scripts/us/il/wth/pike/package.json
+++ b/scripts/us/il/wth/pike/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "pike-il-parcels",
+  "version": "1.0.0",
+  "description": "Dumps parcel boundaries, parcel numbers, and site addresses for Pike County, IL from its WTH/ThinkGIS viewer",
+  "main": "index.js",
+  "scripts": {
+    "dump": "node index"
+  },
+  "license": "MIT"
+}

--- a/scripts/us/il/wth/richland/index.js
+++ b/scripts/us/il/wth/richland/index.js
@@ -1,0 +1,11 @@
+'use strict';
+
+require('../lib').run({
+  name: 'richland',
+  host: 'https://richlandil.wthgis.com',
+  dsid: 823,
+  // Richland's own field names differ from the other 3 counties (taxID
+  // instead of "Parcel Number", etc).
+  pidLabel: 'taxID',
+  addressLabel: 'taxPropAddress'
+});

--- a/scripts/us/il/wth/richland/index.js
+++ b/scripts/us/il/wth/richland/index.js
@@ -7,5 +7,6 @@ require('../lib').run({
   // Richland's own field names differ from the other 3 counties (taxID
   // instead of "Parcel Number", etc).
   pidLabel: 'taxID',
-  addressLabel: 'taxPropAddress'
+  addressLabel: 'taxPropAddress',
+  cityStateZipLabel: 'taxPropCityStZip'
 });

--- a/scripts/us/il/wth/richland/package.json
+++ b/scripts/us/il/wth/richland/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "richland-il-parcels",
+  "version": "1.0.0",
+  "description": "Dumps parcel boundaries + parcel numbers for Richland County, IL from its WTH/ThinkGIS viewer",
+  "main": "index.js",
+  "scripts": {
+    "dump": "node index"
+  },
+  "license": "MIT"
+}


### PR DESCRIPTION
## Summary

Adds `scripts/us/il/wth/`, a scraper for the four Illinois counties that publish their parcel data through WTH Technology's ThinkGIS viewer (Gallatin, Mason, Pike, Richland) instead of a bulk download or ArcGIS REST endpoint.

This PR is scripts only — no `sources/*.json` files yet. I don't have upload permissions for https://batch.openaddresses.io/upload, so I can't produce the stable URLs those source files need to point at. I'll open a follow-up PR with the source JSON once I have upload access (tracked in #<issue-number>).

## Why a custom scraper

These four counties' viewers have no bulk export and no discoverable REST API — the only way to get parcel data out is the same click-to-identify request the browser makes when you click a parcel on the map. That endpoint (`tgis/getftr.aspx?D=<dsid>&F=<id>`) turns out to be keyed by a small sequential integer id rather than the clicked pixel, so it's practical to walk the whole id range and reassemble every parcel in the county. Full mechanics — the per-county dataset id (`dsid`), the two different attribute-table markups these installs use, and the delta-encoded polygon format — are documented in `scripts/us/il/wth/README.md`.

## What this produces

Running `node index.js` in a county's directory (Node 18+, no dependencies) writes a single `<county>.geojson` to `$DATA_DIR` (or the OS temp dir). Each feature is a parcel polygon carrying `pid`, and, where that county's data has it, `address` + `city` + `postcode`:

| County | Parcels | With address |
| --- | --- | --- |
| Gallatin | 8,046 | 0 (Site Address field is empty for every parcel) |
| Mason | 16,272 | 7,480 |
| Pike | 21,173 | 6,081 |
| Richland | 13,317 | 9,594 (no `postcode` - Richland's property-address record never carries one, only the owner's mailing zip, which is a different location) |

This is one file per county rather than separate parcels/addresses files on purpose: upload it once, then point both the source JSON's `parcels` and `addresses` layers at the same uploaded URL, each with its own `conform`. This repo already does that in plenty of existing sources (e.g. `sources/au/qld/logan_city.json`). `address` is left as a single raw string (e.g. `"322 E WASHINGTON"`) — conform splits it into `number`/`street` with `prefixed_number`/`postfixed_street`, same pattern as `sources/us/mi/mason.json` for a similar parcel-derived address source, with the polygon centroided by the pipeline for the addresses layer.

## Notes for reviewers

- `scripts/us/il/wth/lib.js` holds the shared fetch/decode/parse logic; each county's `index.js` is just a config object (host, dataset id, and which field name holds the parcel id / address on that install — these aren't consistent across counties).
- `scripts/us/il/wth/package.json` sets `"type": "commonjs"` to override the repo root's `"type": "module"` — without it, `require()`-ing `lib.js` from a county script silently resolves to an empty module.
- The parcel-id enumeration range is probed automatically per county (doubling search + binary search for the upper bound) rather than hardcoded, since the four counties have very different parcel counts (~8k–23k).
- All four counties' output has been smoke-tested and fully scraped locally; geometry decoding was cross-checked against the original browser-rendered response.
