### PR TITLE
Add --skip-preview to DEVELOPMENT.md's process-one examples

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -99,6 +99,7 @@ Inside the container, run a source with:
 
 ```bash
 openaddr-process-one \
+  --skip-preview \
   --layer addresses \
   --layersource county \
   /path/to/sources/us/ca/san_francisco.json \
@@ -107,6 +108,7 @@ openaddr-process-one \
 
 `--layer` is one of `addresses`, `parcels`, `buildings`, or `centerlines`.
 `--layersource` is the `name` field inside the layer array in the source JSON.
+`--skip-preview` skips rendering a map preview, which otherwise requires a Protomaps API key (`--protomaps-key`).
 
 To write output to your host machine, mount a volume:
 
@@ -115,7 +117,7 @@ docker run -it \
   -v /path/to/sources:/sources \
   -v /tmp/oa-output:/output \
   batch-machine \
-  openaddr-process-one --layer addresses --layersource county /sources/us/ca/san_francisco.json /output
+  openaddr-process-one --skip-preview --layer addresses --layersource county /sources/us/ca/san_francisco.json /output
 ```
 
 ### Running locally without Docker
@@ -127,7 +129,7 @@ cd /path/to/batch-machine
 python3 -m venv venv
 source venv/bin/activate
 pip install -e .
-openaddr-process-one --layer addresses --layersource county /path/to/source.json /tmp/output
+openaddr-process-one --skip-preview --layer addresses --layersource county /path/to/source.json /tmp/output
 ```
 
 ### Output files


### PR DESCRIPTION
## Summary
- `DEVELOPMENT.md`'s `openaddr-process-one` examples (both Docker and non-Docker) fail out of the box with `ERROR: Protomaps key is required to generate preview`, since `batch-machine`'s `--skip-preview`/`--render-preview` share a dest that defaults to rendering a preview.
- `batch-machine`'s own README already works around this by including `--skip-preview` in its example command.
- Added `--skip-preview` to all three example commands here and a short note on why it's needed, matching that precedent.

Fixes openaddresses/batch-machine#107

## Test plan
- [x] Manually diffed the doc changes; docs-only change, no code to test