### PR TITLE
Close unclosed polygon rings in WTH parcel scraper

### DIFF
--- a/scripts/us/il/wth/lib.js
+++ b/scripts/us/il/wth/lib.js
@@ -31,6 +31,14 @@ function decodeRing(polyText) {
     y += parseInt(coords[i * 2 + 1], 10);
     ring.push(z192LL(x, y));
   }
+  // the site draws these as polylines, not necessarily closed rings - GDAL
+  // rejects an unclosed LinearRing, so close it if the last point didn't
+  // land back on the first
+  if (ring.length >= 2) {
+    const [firstLon, firstLat] = ring[0];
+    const [lastLon, lastLat] = ring[ring.length - 1];
+    if (firstLon !== lastLon || firstLat !== lastLat) ring.push(ring[0]);
+  }
   return ring;
 }
 


### PR DESCRIPTION
The WTH ThinkGIS parcel viewer scraper (`scripts/us/il/wth/lib.js`, added in #8321) decodes each parcel's delta-encoded `<poly>` ring but never checked whether the ring actually closed. The site draws these as polylines for its own hover UI, so some don't loop back to the start point - GDAL then rejects them as invalid geometry (`Points of LinearRing do not form a closed linestring`), which is what broke CI on #8331 (richland, F=1138) and #8330 (pike, similar).

Fix: `decodeRing()` now appends the first point to close the ring if the last decoded point doesn't match it. Verified against richland's live service - re-scraping F=1..1140 (which includes the previously-failing F=1138) now produces 0 unclosed rings across 1140 parcels.

This only fixes the scraper going forward. #8331 and #8330 point at already-uploaded snapshots from before this fix, so they'll still need to be re-scraped and re-uploaded to pick it up.