### PR TITLE
fix(no/countrywide): use large disk tier

### DIFF
--- a/sources/no/21/statewide.json
+++ b/sources/no/21/statewide.json
@@ -100,19 +100,13 @@
         ]
     },
     "coverage": {
-        "geometry": {
-            "type": "Point",
-            "coordinates": [
-                20.9752,
-                77.8750
-            ]
-        },
+        "state": "21",
+        "county": "Svalbard",
         "country": "no",
-        "region": "Svalbard",
         "ISO 3166": {
             "alpha2": "NO-21",
             "country": "Norway",
-            "region": "Svalbard"
+            "subdivision": "Svalbard"
         }
     }
 }

--- a/sources/no/countrywide.json
+++ b/sources/no/countrywide.json
@@ -1,12 +1,5 @@
 {
     "coverage": {
-        "geometry": {
-            "type": "Point",
-            "coordinates": [
-                8.4689,
-                60.4720
-            ]
-        },
         "ISO 3166": {
             "alpha2": "NO",
             "country": "Norway"

--- a/sources/no/countrywide.json
+++ b/sources/no/countrywide.json
@@ -292,6 +292,7 @@
                 },
                 "conform": {
                     "format": "gdb",
+                    "size": "large",
                     "srs": "EPSG:25833",
                     "layer": "Teig",
                     "pid": "teigid"


### PR DESCRIPTION
Adds `"size": "large"` to the `parcels` conform in `sources/no/countrywide.json`.

`no/countrywide - parcels - country` has failed every weekly run since 2026-06-19.
The last success (job 852798, 2026-06-12) produced 3,816,606 parcels; every run since
outputs 0 features and dies with:

```
OSError: [Errno 28] No space left on device
```

The 5.2 GB `MatrikkelenEiendomskartTeig` FGDB downloads and unzips fine, then the
`Teig` layer (millions of complex polygons, some with >100 parts) overflows the default
~30 GB scratch disk while the intermediate extract CSV is written.