### PR TITLE
Fix City of Tigard, OR addresses data URL

### DIFF
--- a/sources/us/or/city_of_tigard.json
+++ b/sources/us/or/city_of_tigard.json
@@ -21,7 +21,7 @@
         "addresses": [
             {
                 "name": "city",
-                "data": " https://svr.tigardmaps.com/arcgis/rest/services/Framework/tig_addresses/MapServer/0",
+                "data": "https://svr.tigardmaps.com/arcgis/rest/services/Framework/tig_addresses/MapServer/0",
                 "website": "https://public-tigard.opendata.arcgis.com/datasets/address-layer/about",
                 "license":{
                     "url": "https://creativecommons.org/licenses/by-sa/4.0/",


### PR DESCRIPTION
The addresses layer's `data` URL had a leading space (`" https://svr.tigardmaps.com/..."`), which is trimmed here.

Verified the underlying ArcGIS MapServer is still live and serving valid data:
- Addresses layer (`Framework/tig_addresses/0`): 29,208 point features; fields match the existing conform (`UNIQ`, `PRE_DIR`, `STR_NAME`, `STR_TYPE`, `CITY`, `ST`, `ZIP5`, `OBJECTID`).
- Parcels layer (`Framework/tig_taxlots_opt/0`): 69,806 polygon features; `TLID` field matches the existing `pid` conform.

No conform changes needed — only the stray whitespace in the URL.

Note for reviewers: the server's TLS stack rejects strict OpenSSL 3.x clients (fails with `unsafe legacy renegotiation disabled`), so Python's `requests` library (and possibly Node depending on its OpenSSL build) can't connect, even though curl/SecureTransport-based clients succeed. Worth keeping an eye on whether batch-machine can actually download from this endpoint; if not, this may need revisiting.

This supersedes #7109, which went stale.