### PR TITLE
Fix broken Wisconsin statewide parcels endpoint, add parcels layer

### DIFF
--- a/sources/us/wi/statewide.json
+++ b/sources/us/wi/statewide.json
@@ -12,7 +12,7 @@
         "addresses": [
             {
                 "name": "state",
-                "data": "https://services3.arcgis.com/n6uYoouQZW75n5WI/arcgis/rest/services/Wisconsin_Statewide_Parcels/FeatureServer/0",
+                "data": "https://services3.arcgis.com/n6uYoouQZW75n5WI/arcgis/rest/services/Wisconsin_Statewide_Parcels_DB/FeatureServer/0",
                 "website": "https://www.sco.wisc.edu/parcels/data/",
                 "license": {
                     "text": "No restrictions",
@@ -36,6 +36,24 @@
                     ],
                     "city": "PLACENAME",
                     "postcode": "ZIPCODE"
+                }
+            }
+        ],
+        "parcels": [
+            {
+                "name": "state",
+                "data": "https://services3.arcgis.com/n6uYoouQZW75n5WI/arcgis/rest/services/Wisconsin_Statewide_Parcels_DB/FeatureServer/0",
+                "website": "https://www.sco.wisc.edu/parcels/data/",
+                "license": {
+                    "text": "No restrictions",
+                    "attribution": false,
+                    "share-alike": false,
+                    "attribution name": "The Wisconsin State Cartographer's Office"
+                },
+                "protocol": "ESRI",
+                "conform": {
+                    "format": "geojson",
+                    "pid": "PARCELID"
                 }
             }
         ]


### PR DESCRIPTION
The Wisconsin statewide source's addresses layer pointed at an ArcGIS FeatureServer (`Wisconsin_Statewide_Parcels`) that no longer exists on the SCO's org - it now returns `{"error":{"code":400,"message":"Invalid URL"}}`. The service was renamed to `Wisconsin_Statewide_Parcels_DB` (2026 parcel vintage). Verified with `scripts/esri-explore.py`:

- Layer 0 (`V1200_WisconsinParcels_2026`, Polygon), 3,574,646 features
- Same field schema as before (ADDNUMPREFIX/ADDNUM/ADDNUMSUFFIX, PREFIX/STREETNAME/STREETTYPE/SUFFIX, PLACENAME, ZIPCODE, PARCELID, etc.), so the existing `addresses` conform needed no changes beyond the URL

Also added a `parcels` layer for the same corrected endpoint (`pid: PARCELID`) - this statewide parcel dataset from the Wisconsin State Cartographer's Office wasn't represented as a parcels source at all, despite already being used for the addresses layer. License unchanged: "No restrictions" per SCO's parcels page (https://www.sco.wisc.edu/parcels/data/).

This closes out stale PR #6942, which proposed adding a parcels layer against the old (now-broken) service URL and was never merged.