### PR TITLE
Update City of Palo Alto, CA — addresses, parcels, buildings

### DIFF
--- a/sources/us/ca/city_of_palo_alto.json
+++ b/sources/us/ca/city_of_palo_alto.json
@@ -22,18 +22,44 @@
             {
                 "name": "city",
                 "attribution": "City of Palo Alto",
-                "data": "https://openaddresses.s3.amazonaws.com/manual/Palo%20Alto%20Location.csv",
-                "website": "https://www.cityofpaloalto.org/gov/depts/it/open_data/terms_of_use.asp",
-                "protocol": "http",
+                "data": "https://services6.arcgis.com/evmyRZRrsopdeog7/ArcGIS/rest/services/Address_Points_Share/FeatureServer/0",
+                "website": "https://opengis.cityofpaloalto.org/OpenGisData/",
+                "protocol": "ESRI",
                 "conform": {
-                    "lon": "LONGITUDE",
-                    "lat": "LATITUDE",
+                    "format": "geojson",
                     "number": "SNO",
-                    "street": "STREET_NAME",
-                    "postcode": "SZIP",
-                    "format": "csv",
-                    "headers": 2,
-                    "skiplines": 2
+                    "street": "STREET",
+                    "unit": [
+                        "TYPE",
+                        "UNIT_NO"
+                    ],
+                    "city": "CITY_NAME",
+                    "postcode": "SZIP"
+                }
+            }
+        ],
+        "parcels": [
+            {
+                "name": "city",
+                "attribution": "City of Palo Alto",
+                "data": "https://services6.arcgis.com/evmyRZRrsopdeog7/ArcGIS/rest/services/AssessorsParcels/FeatureServer/0",
+                "website": "https://opengis.cityofpaloalto.org/OpenGisData/",
+                "protocol": "ESRI",
+                "conform": {
+                    "format": "geojson",
+                    "pid": "APN"
+                }
+            }
+        ],
+        "buildings": [
+            {
+                "name": "city",
+                "attribution": "City of Palo Alto",
+                "data": "https://services6.arcgis.com/evmyRZRrsopdeog7/ArcGIS/rest/services/BuildingRoofOutLine/FeatureServer/0",
+                "website": "https://opengis.cityofpaloalto.org/OpenGisData/",
+                "protocol": "ESRI",
+                "conform": {
+                    "format": "geojson"
                 }
             }
         ]


### PR DESCRIPTION
Resolves the blocker on #6394: the addresses layer used `STREETID`, a foreign-key-style ID into a lookup table rather than actual street name text, which `batch-machine` cannot currently resolve.

This PR switches the addresses layer to a different ArcGIS service on the same city server — `Address_Points_Share/FeatureServer/0` — which has a plain-text `STREET` field (e.g. `"Abel Av"`) along with `NAME_FULL`/`NAME_BASE`/`NAME_TYPE`, so no lookup resolution is needed. Verified via `esri-explore.py`: 48,307 features, with `SNO` (house number), `STREET`, `TYPE`+`UNIT_NO` (unit), `CITY_NAME`, and `SZIP` all populated.

This also replaces the old manual CSV upload (`Palo Alto Location.csv`) currently on master with a live ArcGIS source.

- `addresses`: `Address_Points_Share/FeatureServer/0` — `number: SNO`, `street: STREET`, `unit: [TYPE, UNIT_NO]`, `city: CITY_NAME`, `postcode: SZIP`
- `parcels`: `AssessorsParcels/FeatureServer/0` — `pid: APN` (25,520 features)
- `buildings`: `BuildingRoofOutLine/FeatureServer/0` (23,000 features)

The parcels and buildings layers were originally proposed by @arch0345 in #6394, and confirmed working there via data-please's CI job runs (25,520 parcel features, 23,000 building features). Credit to that work — this PR carries it forward alongside the new addresses fix.

Validated against `test/lib.js` (`VALID`).

Closes #6394