### PR TITLE
Update Kingston, ON address source

### DIFF
--- a/sources/ca/on/city_of_kingston.json
+++ b/sources/ca/on/city_of_kingston.json
@@ -16,24 +16,22 @@
         "addresses": [
             {
                 "name": "city",
-                "protocol": "http",
-                "compression": "zip",
-                "data": "https://apps.cityofkingston.ca/data/gis/Civic_Address_SHP.zip",
-                "website": "https://www.cityofkingston.ca/explore/data-catalogue",
+                "data": "https://utility.arcgis.com/usrsvcs/servers/d76e1fe447e84cb1983c76e1cb9dadb4/rest/services/Planning/Civic_Address_Point_Public/FeatureServer/0",
+                "website": "https://opendatakingston.cityofkingston.ca/datasets/civic-address-point-public/about",
+                "license": {
+                    "url": "https://www.cityofkingston.ca/documents/10180/144997/CityofKingston_OpenDataLicense.pdf",
+                    "text": "Contains information licensed under the Open Data Licence - City of Kingston",
+                    "attribution": true,
+                    "share-alike": false
+                },
+                "protocol": "ESRI",
                 "conform": {
-                    "format": "shapefile",
-                    "number": {
-                        "function": "format",
-                        "fields": [
-                            "ADDR_NUM",
-                            "A_NUM_SUF"
-                        ],
-                        "format": "$1$2"
-                    },
+                    "format": "geojson",
+                    "number": "ADDRESS_NUMBER",
                     "street": "STREET",
                     "unit": "UNIT",
-                    "postcode": "POSTAL_COD",
-                    "city": "MUNICIP"
+                    "city": "MUNICIPALITY",
+                    "postcode": "POSTAL_CODE"
                 }
             }
         ]


### PR DESCRIPTION
The existing address source for Kingston, ON pointed at a shapefile ZIP download that now returns a 404 (`https://apps.cityofkingston.ca/data/gis/Civic_Address_SHP.zip`).

This replaces it with the city's current, actively maintained ArcGIS Feature Service ("Civic Address Points"), found through the City of Kingston's new ArcGIS Hub open data portal at `opendatakingston.cityofkingston.ca`. Verified with `esri-explore.py`:

- Point geometry, 77,519 records
- Fields: `ADDRESS_NUMBER`, `STREET` (already composed with type + direction suffix, e.g. "KING ST W"), `UNIT`, `MUNICIPALITY`, `POSTAL_CODE`
- License: City of Kingston Open Data Licence (attribution required, not share-alike)

This replaces/fixes the issue behind #6943, a stale PR (last touched Nov 2024, no CI history) that tried to point at the city's old OpenDataSoft CSV export API — that API is also gone now, since the city has since migrated its whole open data portal to ArcGIS Hub. #6943 was closed without merging; this is a fresh, independent fix rather than a resurrection of that diff.

Closes #5382