### PR TITLE
Update Bogotá address source to live IDECA/Catastro ArcGIS service

### DIFF
--- a/sources/co/bogota.json
+++ b/sources/co/bogota.json
@@ -13,22 +13,20 @@
         "addresses": [
             {
                 "name": "state",
-                "data": "https://data.openaddresses.io/cache/uploads/thatdatabaseguy/f2d155/bogota.geojson.zip",
+                "data": "https://serviciosgis.catastrobogota.gov.co/arcgis/rest/services/catastro/placadomiciliaria/MapServer/0",
                 "website": "https://www.ideca.gov.co/es/proyectos/proyectos-geograficos-distrito/mapa-de-referencia-para-el-distrito-capital",
-                "note": "Technical information about the dataset at https://www.ideca.gov.co/sites/default/files/EI%20-%20Cat%C3%A1logo%20de%20Objetos%20MR%20V5.4.pdf",
-                "protocol": "http",
-                "compression": "zip",
+                "note": "Live 'Placa Domiciliaria' (address plate) layer from the Mapa de Referencia dataset, published by Catastro Bogotá/IDECA. Technical information about the dataset at https://www.ideca.gov.co/sites/default/files/EI%20-%20Cat%C3%A1logo%20de%20Objetos%20MR%20V5.4.pdf",
+                "protocol": "ESRI",
                 "license": {
-                    "url": "https://www.ideca.gov.co/es/licenciaabierta",
+                    "url": "https://creativecommons.org/licenses/by/4.0/",
                     "attribution": true,
-                    "attribution name": "IDECA Bogotá",
-                    "share-alike": true
+                    "attribution name": "Unidad Administrativa Especial de Catastro Distrital (Catastro Bogotá) / IDECA"
                 },
                 "conform": {
                     "format": "geojson",
-                    "number": "PDoTexto",
-                    "street": "PDoNVial",
-                    "unit": "PDoCInteri"
+                    "number": "PDOTEXTO",
+                    "street": "PDONVIAL",
+                    "unit": "PDOCINTERI"
                 }
             }
         ]


### PR DESCRIPTION
Replaces the existing Bogotá D.C. address source's static 2017 GeoJSON dump with a live ArcGIS service currently maintained by Catastro Bogotá / IDECA.

## What changed
- `data`: static cached zip (`data.openaddresses.io/.../bogota.geojson.zip`, containing data dated 2017-02-22) → live ArcGIS MapServer layer at `https://serviciosgis.catastrobogota.gov.co/arcgis/rest/services/catastro/placadomiciliaria/MapServer/0`
- `protocol`: `http` (zip) → `ESRI`
- `conform`: field names corrected to the service's actual casing (`PDOTEXTO`, `PDONVIAL`, `PDOCINTERI`) — same underlying fields as before, just live instead of a 9-year-old snapshot
- `license`: updated to CC-BY 4.0 per the current Datos Abiertos Bogotá dataset page (the old `licenciaabierta` URL now 404s); attribution updated to the Unidad Administrativa Especial de Catastro Distrital (Catastro Bogotá) / IDECA

## Verification
- Confirmed the live service today: 1,772,872 point records, Point geometry, fields present as expected (checked via `scripts/esri-explore.py layers`, `suggest`, `sample`, `count`)
- Source dataset ("Mapa de Referencia", which includes this "Placa Domiciliaria" layer) shows a last-updated date of 2026-07-28 on the Datos Abiertos Bogotá portal — i.e. actively maintained, unlike the static dump
- Validated against the schema (`test/lib.js`) — passes

## Related
This is unrelated to the long-stale #7186 ("Create bogota_addressforall.json"), which proposed adding a *second*, separate Bogotá source file pointing at a personal SharePoint export re-hosted by a third party (AddressForAll), itself sourced from the same Datos Abiertos Bogotá origin. That PR is superseded/duplicated by the fact that a Bogotá source already exists and is now current — no new file is needed, so it isn't referenced as "Closes" here.