### PR TITLE
Fix broken City of Kharkiv, UA address source

### DIFF
--- a/sources/ua/63/city_of_kharkiv.json
+++ b/sources/ua/63/city_of_kharkiv.json
@@ -16,22 +16,23 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://cdr.citynet.kharkov.ua/arcgis/rest/services/gis_ort_stat_general/MapServer/1",
+                "data": "https://smart.khmr.gov.ua/arcgis/rest/services/gis_ort_stat_general/MapServer/1",
+                "website": "https://smart.khmr.gov.ua/opendataportal",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
                     "number": {
                         "function": "regexp",
-                        "field": "FULLADDRRU",
-                        "pattern": "^(?:[^,]+, )(.+)$",
+                        "field": "FULLADDRUA",
+                        "pattern": "^(?:[^,]+, )(.+?)\\s*$",
                         "replace": "$1"
                     },
                     "street": {
                         "function": "regexp",
-                        "field": "FULLADDRRU",
+                        "field": "FULLADDRUA",
                         "pattern": "^([^,]+)"
                     },
-                    "srs": "EPSG:28467"
+                    "postcode": "POST_CODE"
                 }
             }
         ]


### PR DESCRIPTION
The previous endpoint (\`cdr.citynet.kharkov.ua\`) no longer resolves at all — that subdomain is gone. This replaces it with Kharkiv's current geoportal endpoint, found by tracing the underlying ArcGIS service reference out of the new "Відкрита мапа" portal's own JS bundle.

- Layer: addresses (point), same \`gis_ort_stat_general\` service / layer index 1 as before, now hosted at \`smart.khmr.gov.ua\` instead of the dead \`cdr.citynet.kharkov.ua\`
- Verified live via \`esri-explore.py\`: 78,817 features, correct Kharkiv geography/postcodes (61xxx)
- Switched address parsing from the Russian-language \`FULLADDRRU\` field to the Ukrainian \`FULLADDRUA\` field, consistent with the convention used in \`sources/ua/12/city_of_dnipropetrovsk.json\`
- Added \`postcode\` conform using the now-available \`POST_CODE\` field
- Dropped the old \`srs\` key, which was a no-op for ESRI/geojson sources per CONTRIBUTING.md

No license information is published on the new portal, same as before, so no \`license\` key was added.