### PR TITLE
Document dead-end search for LaSalle, ON address source

### DIFF
--- a/sources/ca/on/lasalle.json
+++ b/sources/ca/on/lasalle.json
@@ -17,7 +17,7 @@
                     "street": "STR_NAME",
                     "postcode": "POSTAL"
                 },
-                "note": "Token Required - https://gisweb.countyofessex.on.ca/svllasalle24/Viewer.html?Viewer=Public && gisservices.countyofessex.on.ca/arcgis/rest/services/LaSalle/LaSalleREST/MapServer/158"
+                "note": "2026-08 checked: original endpoints dead (gisweb/gisservices.countyofessex.on.ca no longer resolve; the .ca-domain Geocortex 'essex' site no longer lists a LaSalle site, and gisservices.countyofessex.ca/arcgis/rest/services has no LaSalle folder). infolasalle.ca still redirects to a live LaSalle-specific Geocortex viewer (gisweb.countyofessex.ca/LaSalleLaunch/Launch.htm -> LaSalleGE site), but its public viewer exposes no geocoding/search endpoint and its terms of use forbid reproducing its maps without written authority from the Town of LaSalle - unsuitable even if data could be extracted. County's official open data portal (opendata.countyofessex.ca, covers all 7 Essex County municipalities) has no address/civic/parcel dataset. County's ArcGIS Online address layers (SDEAddressPts, Parcels_CIVIC) only cover Leamington/Point Pelee, not LaSalle. Town's own ArcGIS server (gis.lasalle.ca) has no address layers. No viable open address source found; data field points at OpenAddresses' own frozen cache from ~2016-2019."
             }
         ]
     }


### PR DESCRIPTION
No data change — updates the `note` field on `sources/ca/on/lasalle.json` to record a fresh, exhaustive search for a live replacement, so the next person doesn't have to redo the legwork.

This follows up on the stale PR #5393 (opened 2020, never resolved), which itself couldn't find a better source.

What was checked (all as of 2026-08):
- The endpoints named in the old `note` are fully dead: `gisweb.countyofessex.on.ca` and `gisservices.countyofessex.on.ca` no longer resolve (NXDOMAIN).
- The county's migrated domain (`countyofessex.ca`) has an active Geocortex "essex" site, but it now lists only a `Test` site — the old LaSalle-specific site is gone.
- `gisservices.countyofessex.ca/arcgis/rest/services` is live but has no `LaSalle` folder.
- `infolasalle.ca` still redirects to a live LaSalle-specific Geocortex viewer (`gisweb.countyofessex.ca/LaSalleLaunch/Launch.htm` → `LaSalleGE` site), but its public viewer has no geocoding/search endpoint, and its terms of use forbid reproducing its maps without written authority from the Town of LaSalle — a repackaging restriction that would disqualify it from OpenAddresses even if address data could be extracted from it.
- The county's official open data portal (`opendata.countyofessex.ca`, covering all 7 Essex County municipalities) has no address, civic address, or parcel dataset among its ~100 published datasets.
- The county's ArcGIS Online org hosts an "Address Point Lookup" app, but its backing layers (`SDEAddressPts`, `Parcels_CIVIC`) only cover Leamington/Point Pelee (confirmed via sample records and spatial extent), not LaSalle.
- The Town's own ArcGIS server (`gis.lasalle.ca`) has no address-related services, only parks/transportation layers.

No viable open, appropriately-licensed address source was found for LaSalle. The `data` field currently points at OpenAddresses' own cached copy from roughly 2016–2019, which still returns 200 but is a frozen snapshot disconnected from any live upstream. Leaving the source as-is per the "broken source, no replacement found" guidance — this PR only documents the search.