### PR TITLE
Use direct .zip filename for NAD download URL

### DIFF
--- a/sources/us/countrywide.json
+++ b/sources/us/countrywide.json
@@ -12,7 +12,7 @@
             {
                 "name": "country",
                 "protocol": "http",
-                "data": "https://data.transportation.gov/download/yw36-suxr/application%2Fx-zip-compressed",
+                "data": "https://data.transportation.gov/download/yw36-suxr/NAD.zip",
                 "website": "https://www.transportation.gov/gis/national-address-database",
                 "compression": "zip",
                 "language": "en",


### PR DESCRIPTION
## Summary
- NAD (`sources/us/countrywide.json`) has been failing on every weekly run. The current `data` URL has no file extension, which makes `batch-machine`'s `guess_url_file_extension()` fully download the response body just to sniff the file type — then the real cache step downloads the same multi-GB zip again. Two full downloads with no retry logic anywhere in the pipeline gives an occasional mid-transfer connection reset from the Socrata endpoint enough of a window to reliably kill the job (`IncompleteRead`/`ChunkedEncodingError`).
- The same Socrata resource is reachable at `.../download/yw36-suxr/NAD.zip` (verified this redirects to the identical file — Socrata ignores the trailing filename). Using that URL gives `guess_url_file_extension()` a `.zip` it can trust immediately, skipping the vulnerable pre-flight download entirely and halving the job's total transfer size.

## Test plan
- [x] `data` URL manually verified to redirect to the same NAD zip (`PK\x03\x04 ... NAD_r23.gdb/...` bytes) as the previous URL
- [x] Schema validated against `schema/source_schema_v2.json`
- [x] `pre-commit run --files sources/us/countrywide.json` passes
- [ ] Confirm the next scheduled NAD run completes successfully