### PR TITLE
fix broken AU-NSW dataset

### DIFF
--- a/sources/au/nsw/statewide.json
+++ b/sources/au/nsw/statewide.json
@@ -35,7 +35,7 @@
                     "number": {
                         "function": "regexp",
                         "field": "housenumber",
-                        "pattern": "^(?:.*/)(.*)",
+                        "pattern": "^(?:.*/)?(.*)",
                         "replace": "$1"
                     },
                     "street": {


### PR DESCRIPTION
the [dataset for `au/nsw/statewide`](https://batch.openaddresses.io/job/907114) is currently unusable, because the `number` field is missing from over 2 million addresses. 

The regex currently assumes that every housenumber contains a `/`, which is wrong. only appartment buildings have this character.

test cases for the regex here: https://regexr.com/8ocsq


cc @andrewharvey 