### PR TITLE
fix website url for city of new york addresses source

### DIFF
--- a/sources/us/ny/city_of_new_york.json
+++ b/sources/us/ny/city_of_new_york.json
@@ -22,7 +22,7 @@
             {
                 "name": "city",
                 "data": "https://services6.arcgis.com/yG5s3afENB5iO9fj/arcgis/rest/services/AddressPoint_view/FeatureServer/0",
-                "website": "https://data.cityofnewyork.us/City-Government/NYC-Address-Points/g6pj-hd8k",
+                "website": "https://data.cityofnewyork.us/City-Government/AddressPoint/uf93-f8nk",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",


### PR DESCRIPTION
## Summary
- The `website` URL for the `us/ny/city_of_new_york.json` addresses source returned a 404. Updated it to the working NYC Open Data page for the AddressPoint dataset.
- The `data` (ESRI) URL was already correct and unchanged.

Fixes #8352