### PR TITLE
Fix broken Burke County, NC addresses source

### DIFF
--- a/sources/us/nc/burke.json
+++ b/sources/us/nc/burke.json
@@ -14,13 +14,13 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://gis.burkenc.org/arcgis/rest/services/PublicAccessMain/MapServer/13",
+                "data": "https://gis.burkenc.org/arcgis/rest/services/PublicAccessMainPro/MapServer/0",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
                     "street": [
                         "PREDIR",
-                        "STREET_NAME",
+                        "STREET_NAM",
                         "TYPE",
                         "POSTDIR"
                     ],


### PR DESCRIPTION
The ESRI service backing this source (`PublicAccessMain/MapServer/13`) has been shut down (`Service PublicAccessMain/MapServer not started`), confirmed by the last 3 job failures (908862, 903912, 899020).

Found that the county's GIS server (`gis.burkenc.org`) republished the same map under a new service name, `PublicAccessMainPro/MapServer`, with the address layer now at index 0 (named "Address") instead of 13.

Verified before writing the fix:
- `PublicAccessMainPro/MapServer/0?f=json" returns valid metadata with a full fields array, no auth error.
- Feature count query returns 53,676 features.
- Sample records confirm `COUNTY: BURKE`, `STATE: NC` and the same address structure as before, at the same extent as Burke County.
- One field was renamed in the republished service: `STREET_NAME` -> `STREET_NAM`. All other conform fields (`STNUM`, `PREDIR`, `TYPE`, `POSTDIR`, `UNITTYPE`, `UNIT`, `ZIPCODE`, `CITY`, `COUNTY`, `STATE`) are unchanged and verified present with populated values.
- No FeatureServer equivalent exists on this server (extension not enabled), so protocol/format (ESRI/geojson) stay the same, only the service name, layer index, and one field name changed.
- Schema validated with `test/lib.js` (VALID).