### PR TITLE
Fix broken Cook County, IL addresses source

### DIFF
--- a/sources/us/il/cook.json
+++ b/sources/us/il/cook.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://gis12.cookcountyil.gov/arcgis/rest/services/addressZipCode/MapServer/0",
+                "data": "https://gis.cookcountyil.gov/traditional/rest/services/addressZipCode/MapServer/0",
                 "website": "https://hub-cookcountyil.opendata.arcgis.com/datasets/cookcountyil::address-points/about",
                 "note": "All Cook County addresses including the city of Chicago",
                 "protocol": "ESRI",


### PR DESCRIPTION
The `addresses`/`county` source for Cook County, IL (`sources/us/il/cook.json`) had been failing for at least the last 3 weekly runs (job IDs 909628, 904678, 899782) with HTTP 404 on `https://gis12.cookcountyil.gov/arcgis/rest/services/addressZipCode/MapServer/0?f=json`.

Root cause: the `gis12.cookcountyil.gov` ArcGIS REST endpoint has been decommissioned — the host now 307-redirects to `hub-cookcountyil.opendata.arcgis.com`, and its `/arcgis/rest/services` listing 404s entirely.

Fix: found the same "Address Points" service still hosted by Cook County GIS, now published at `https://gis.cookcountyil.gov/traditional/rest/services/addressZipCode/MapServer/0` (via ArcGIS Online search for the official `Cook_County_GIS` item). Verified before writing the change:

- `?f=json` returns valid metadata with no error, layer 0 is "Address Points" (Point geometry), matching the original layer.
- Feature count: 1,381,000 (> 0).
- No auth error.
- Spatial extent (IL State Plane East, EPSG:3435) matches Cook County's geography and sample point coordinates fall within Chicago/Cook County as expected.
- All conform field names (`ADDRNOCOM`, `STNAMECOM`, `Unit`, `Post_Comm`, `Post_Code`, `County`, `State`) are unchanged on the new endpoint, confirmed via a live sample query — no conform changes needed.

Note: the new endpoint also exposes an `Add_Number`/`St_Name` field set that `esri-explore.py suggest` recommends, but sampled records show `Add_Number` is stale/unreliable (e.g. several unrelated records all share `Add_Number: 2300`), so the existing composite `ADDRNOCOM`/`STNAMECOM` fields (which do match each record's real address) were kept instead.

Only the `data` URL changed; `parcels` and `centerlines` layers in this file were not touched (out of scope for this fix).