### PR TITLE
Fix broken City of Houston addresses source

### DIFF
--- a/sources/us/tx/city_of_houston.json
+++ b/sources/us/tx/city_of_houston.json
@@ -21,7 +21,7 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://mycity2.houstontx.gov/pubgis02/rest/services/HoustonMap/Planning_and_Development/MapServer/33",
+                "data": "https://mycity2.houstontx.gov/gisweb01/rest/services/HoustonMap/Planning_and_Development/MapServer/33",
                 "website": "https://cohgis-mycity.opendata.arcgis.com/datasets/341d9a73b80941dbb514c5ce6051d55f_33/explore",
                 "protocol": "ESRI",
                 "conform": {


### PR DESCRIPTION
The `addresses`/`city` layer for City of Houston has been failing for at least three consecutive weekly runs (jobs 907968, 903018, 898126) with:

```
esridump.errors.EsriDownloadError: Could not retrieve layer metadata: Service HoustonMap/Planning_and_Development/MapServer not found
```

The `pubgis02` host no longer serves the `HoustonMap/Planning_and_Development` MapServer folder.

I found the same service, same layer (33, "PDD Address Points"), still live on a sibling host, `gisweb01`, by looking up the ArcGIS Online item behind the source's `website` link (item `341d9a73b80941dbb514c5ce6051d55f`), whose registered service URL now points to `https://mycity2.houstontx.gov/gisweb01/rest/services/HoustonMap/Planning_and_Development/MapServer/33`.

Verified before committing:
- `?f=json` on the new URL returns a full `fields` array with no error, and the field names (`addrnum`, `fraction`, `prefix`, `roadname`, `roadtype`, `suffix`, `unittype`, `unitid`, `municipality`, `county`, `zipcode`, `siteaddid`) are identical to what the existing `conform` already expects, so no conform changes were needed.
- Feature count query returns 1,550,187 features.
- Sampled records show Houston/Harris-County addresses (e.g. zip codes 77007, 77083, 77346) with `municipality` values of `HOUSTON`/`UNINCORPORATED`, matching the expected city coverage.
- No auth errors.

Only the `data` host changed (`pubgis02` → `gisweb01`); layer number, conform, and coverage are unchanged. Validated against the schema with `test/lib.js` (VALID).