### PR TITLE
Fix broken City of Tacoma addresses source

### DIFF
--- a/sources/us/wa/city_of_tacoma.json
+++ b/sources/us/wa/city_of_tacoma.json
@@ -22,7 +22,7 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://staffmaps.cityoftacoma.org/server/rest/services/Referenced/Current_Addresses/FeatureServer/0",
+                "data": "https://staffmaps.tacoma.gov/server/rest/services/Referenced/Current_Addresses/FeatureServer/0",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",


### PR DESCRIPTION
The addresses/city source for City of Tacoma, WA was failing in the last 3 jobs (907715, 902765, 897873) with a DNS resolution error — the hostname `staffmaps.cityoftacoma.org` no longer resolves (NXDOMAIN).

Found the same ArcGIS Feature Service ("Current Addresses (Tacoma)") now hosted at `staffmaps.tacoma.gov` via an ArcGIS Online search for the item. Verified before writing this fix:

- New host resolves and the layer responds with matching metadata (same layer name "Current Addresses", same ATAMAP description, Point geometry)
- All original conform field names still exist with identical names/casing: AddressID, AddressNumber, Prefix, StreetName, StreetType, Suffix, UnitType, Unit, City, County, State, Zipcode
- Feature count: 106,116 (consistent with a city-level dataset, not county/statewide)
- Sample records confirm City=Tacoma, County=Pierce — coverage unchanged

Only the hostname in `data` changed; the conform mapping did not need updates. Schema validated locally.