### PR TITLE
Fix broken Greenville County, SC address source

### DIFF
--- a/sources/us/sc/greenville.json
+++ b/sources/us/sc/greenville.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://www.gcgis.org/arcgis/rest/services/GreenvilleJS/Map_Layers_JS/MapServer/36",
+                "data": "https://www.gcgis.org/arcgis/rest/services/GCGIA/Greenville_Base/MapServer/0",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",


### PR DESCRIPTION
The county addresses layer (\`sources/us/sc/greenville.json\`, layer \`addresses\`, name \`county\`) has failed its last 3 weekly jobs (908164, 903214, 898322) with:

\`\`\`
esridump.errors.EsriDownloadError: Could not retrieve layer metadata: Service GreenvilleJS/Map_Layers_JS/MapServer not started
\`\`\`

The \`GreenvilleJS\` folder on \`www.gcgis.org\` is now empty (no services), so the old service was removed rather than just stopped.

Found a same-coverage replacement on the same server: \`GCGIA/Greenville_Base/MapServer\`, layer 0 (\`Site Address\`). Verified before writing the conform:

- \`?f=json\` on the layer returns valid metadata with the same field names as the old service (\`ADDRESS\`, \`ZIPCODE\`, \`PIN\`), no auth error.
- Feature count query returns 307,184 features.
- Spatial extent matches Greenville County (SC State Plane, wkid 6570/103146).
- Sampled records confirm the \`ADDRESS\` field still combines house number, optional unit, and street name in the same format the existing \`prefixed_number\`/\`regexp\` conform was already built to handle (e.g. \`510 6 6TH ST\`, \`4307 1A EDWARDS RD\`), so the conform and acceptance tests were left unchanged — only the \`data\` URL was updated.

Only the \`addresses\`/\`county\` layer was touched, matching the scope of the confirmed failures. Note the \`parcels\` layer in this same file still points at the now-empty \`GreenvilleJS\` service and will likely need a separate fix.