### PR TITLE
Fix broken Yavapai County, AZ source

### DIFF
--- a/sources/us/az/yavapai.json
+++ b/sources/us/az/yavapai.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://gis.yavapaiaz.gov/arcgis/rest/services/Property/FeatureServer/2",
+                "data": "https://services1.arcgis.com/BajuNXbtZNiBKFkx/arcgis/rest/services/Address_Points_for_Yavapai_County/FeatureServer/0",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
@@ -32,7 +32,7 @@
         "buildings": [
             {
                 "name": "county",
-                "data": "https://gis.yavapaiaz.gov/arcgis/rest/services/Property/FeatureServer/5",
+                "data": "https://services6.arcgis.com/Do88DoK2xjTUCXd1/arcgis/rest/services/Yavapai_County_AZ_Buildings/FeatureServer/0",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson"
@@ -42,7 +42,7 @@
         "parcels": [
             {
                 "name": "county",
-                "data": "https://gis.yavapaiaz.gov/arcgis/rest/services/Parcels/FeatureServer/0",
+                "data": "https://services1.arcgis.com/BajuNXbtZNiBKFkx/arcgis/rest/services/Parcels_in_Yavapai_County/FeatureServer/0",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
@@ -53,7 +53,7 @@
         "centerlines": [
             {
                 "name": "county",
-                "data": "https://gis.yavapaiaz.gov/ArcGIS/rest/services/Roads/MapServer/3",
+                "data": "https://services1.arcgis.com/BajuNXbtZNiBKFkx/arcgis/rest/services/Road_Centerlines/FeatureServer/0",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",


### PR DESCRIPTION
Yavapai County's own ArcGIS server (gis.yavapaiaz.gov) is now sitting behind a Cloudflare managed bot challenge and returns HTTP 403 "Just a moment..." to every request, including plain `?f=json` metadata calls, for the `addresses`, `buildings`, `parcels`, and `centerlines` layers alike. The last three weekly jobs for the `addresses` layer (job IDs 900795, 905693, 910643) all failed with this same `EsriDownloadError: ... HTTP 403` from `esridump`, and I confirmed directly with `curl` and `esri-explore.py` that the entire host currently 403s for every service (Property, Parcels, Roads, and the root services listing).

Found and verified county-authoritative replacements hosted on ArcGIS Online instead of the county's own blocked server:

- **addresses**: `https://services1.arcgis.com/BajuNXbtZNiBKFkx/arcgis/rest/services/Address_Points_for_Yavapai_County/FeatureServer/0` — same field names as the old source (`ADD_NUMBER`, `ADDNUM_SUF`, `L_NGFULLSTNAME`, `UNIT`, `POST_COMM`, `POST_CODE`), 166,662 features, no auth required, conform left unchanged.
- **buildings**: `https://services6.arcgis.com/Do88DoK2xjTUCXd1/arcgis/rest/services/Yavapai_County_AZ_Buildings/FeatureServer/0` — polygon geometry, 199,624 features.
- **parcels**: `https://services1.arcgis.com/BajuNXbtZNiBKFkx/arcgis/rest/services/Parcels_in_Yavapai_County/FeatureServer/0` — has `PARCEL_ID` matching the existing `pid` conform, 187,827 features.
- **centerlines**: `https://services1.arcgis.com/BajuNXbtZNiBKFkx/arcgis/rest/services/Road_Centerlines/FeatureServer/0` — has `NGUID`, `STD_NAME`, `ONEWAY` (FT/TF/B), `SPEEDLIMIT`, `POSTCODE_L`/`POSTCODE_R` matching the existing conform, 42,917 features.

All four are public, county-specific (not statewide), and verified via `esri-explore.py` (`layers`/`suggest`/`count`/`sample`) to have a non-empty `fields` array, feature counts > 0, and no auth errors before writing the conform. Field names matched the existing conform exactly in every layer, so no conform changes were needed — only the `data` URLs changed. Confirmed valid against the schema with `test/lib.js`.