### PR TITLE
Fix broken city of Cape Coral, FL addresses source

### DIFF
--- a/sources/us/fl/city_of_cape_coral.json
+++ b/sources/us/fl/city_of_cape_coral.json
@@ -21,7 +21,7 @@
     "layers": {
         "addresses": [{
             "name": "city",
-            "data": "https://capeims.capecoral.gov/arcgis/rest/services/OpenData/Addresses/FeatureServer/0",
+            "data": "https://capeims.capecoral.gov/arcgis/rest/services/OpenData/Addresses/MapServer/0",
             "website": "https://capecoral-capegis.opendata.arcgis.com/datasets/CapeGIS::addresses/about",
             "protocol": "ESRI",
             "conform": {


### PR DESCRIPTION
Job history for `sources/us/fl/city_of_cape_coral.json` (addresses/city) showed the last 3 runs (910202, 905252, 900356) all failing with:

```
esridump.errors.EsriDownloadError: Could not retrieve layer metadata: Error handling service request :Server object extension 'featureserver' not found.
```

The city disabled the FeatureServer capability on `OpenData/Addresses`, but the same service is still published as a MapServer at the same path. Verified the replacement before committing:

- `https://capeims.capecoral.gov/arcgis/rest/services/OpenData/Addresses/MapServer/0` returns valid metadata with a `fields` array (no error).
- Feature count query returns 191,409 features.
- No auth errors.
- Sample records have `City: "Cape Coral"`, `State_Abbr: "FL"`, matching the source's coverage.
- Field names (`Street_Number`, `Full_Street_Name`, `Unit_Number`, `City`, `State_Abbr`, `Zip`) are unchanged from the existing conform, so no conform changes were needed — only the `data` URL's `FeatureServer` -> `MapServer`.

Validated against the schema (`test/lib.js`) — passes.