### PR TITLE
Fix broken City of Greeley addresses source

### DIFF
--- a/sources/us/co/city_of_greeley.json
+++ b/sources/us/co/city_of_greeley.json
@@ -22,7 +22,7 @@
             {
                 "name": "city",
                 "attribution": "City of Greeley",
-                "data": "https://gis.greeleygov.com/arcgis_svr/rest/services/Data_Services/GreeleyAddresses/MapServer/0",
+                "data": "https://gis.greeleygov.com/arcgis_svr/rest/services/Data_Services/GreeleyAddresses/FeatureServer/1",
                 "protocol": "ESRI",
                 "website": "https://greeleygis2017-02-01t212304815z-greeley.opendata.arcgis.com/maps/7632c71fd2da40b4bcc28506d528a643/explore",
                 "conform": {


### PR DESCRIPTION
The addresses/city source for Greeley, CO was failing with `EsriDownloadError: Could not retrieve layer metadata: Layer not found` — the last 3 jobs (910356, 905406, 900510) all failed.

Root cause: the GreeleyAddresses service still exists on the same server, but the address layer's ID moved from 0 to 1 (checked via `?f=json` on the MapServer root, which now lists a single layer, id 1, named "Greeley Addresses").

Fix: point `data` at layer 1, and switch from MapServer to the sibling FeatureServer endpoint (preferred for reliability). All fields referenced in the existing conform (HOUSENUM, PREDIRECTION, STREETPRETYPE, STREETNAME, STREETTYPE, UNITTYPE, UNITNUM, CITY, STATE, ZIP) are still present on the layer, verified via `esri-explore.py suggest` and `sample`. Feature count is 48,216.