### PR TITLE
Fix broken Juneau County, WI addresses source

### DIFF
--- a/sources/us/wi/juneau.json
+++ b/sources/us/wi/juneau.json
@@ -16,115 +16,13 @@
                 "name": "county",
                 "data": "https://gismap.co.juneau.wi.us/server/rest/services/JuneauCo_PublicGIS/MapServer/7",
                 "protocol": "ESRI",
-                "note": "ZIPCODE is a USPS town name that only has one ZIP Code. The county has a list of the names and ZIP Codes here: https://gismap.co.juneau.wi.us/server/rest/services/JuneauCo_PublicGIS/MapServer/21/query (I have no idea why they don't just use the ZIP Codes directly)",
                 "conform": {
                     "format": "geojson",
                     "number": "HOUSENUM",
                     "street": "STNAME",
                     "city": "COMMUNITY",
                     "region": "STATE",
-                    "postcode": {
-                        "function": "chain",
-                        "variable": "zip",
-                        "functions": [
-                            {
-                                "function": "regexp",
-                                "field": "ZIPCODE",
-                                "pattern": "NEKOOSA",
-                                "replace": "54457"
-                            },
-                            {
-                                "function": "regexp",
-                                "field": "zip",
-                                "pattern": "WARRENS",
-                                "replace": "54666"
-                            },
-                            {
-                                "function": "regexp",
-                                "field": "zip",
-                                "pattern": "BABCOCK",
-                                "replace": "54413"
-                            },
-                            {
-                                "function": "regexp",
-                                "field": "zip",
-                                "pattern": "NECEDAH",
-                                "replace": "54646"
-                            },
-                            {
-                                "function": "regexp",
-                                "field": "zip",
-                                "pattern": "NEW LISBON",
-                                "replace": "53950"
-                            },
-                            {
-                                "function": "regexp",
-                                "field": "zip",
-                                "pattern": "MAUSTON",
-                                "replace": "53948"
-                            },
-                            {
-                                "function": "regexp",
-                                "field": "zip",
-                                "pattern": "KENDALL",
-                                "replace": "54638"
-                            },
-                            {
-                                "function": "regexp",
-                                "field": "zip",
-                                "pattern": "ELROY",
-                                "replace": "53929"
-                            },
-                            {
-                                "function": "regexp",
-                                "field": "zip",
-                                "pattern": "LYNDON STATION",
-                                "replace": "53944"
-                            },
-                            {
-                                "function": "regexp",
-                                "field": "zip",
-                                "pattern": "HILLSBORO",
-                                "replace": "54634"
-                            },
-                            {
-                                "function": "regexp",
-                                "field": "zip",
-                                "pattern": "WISCONSIN DELLS",
-                                "replace": "53965"
-                            },
-                            {
-                                "function": "regexp",
-                                "field": "zip",
-                                "pattern": "LA VALLE",
-                                "replace": "53941"
-                            },
-                            {
-                                "function": "regexp",
-                                "field": "zip",
-                                "pattern": "HUSTLER",
-                                "replace": "54637"
-                            },
-                            {
-                                "function": "regexp",
-                                "field": "zip",
-                                "pattern": "CAMP DOUGLAS",
-                                "replace": "54618"
-                            },
-                            {
-                                "function": "regexp",
-                                "field": "zip",
-                                "pattern": "WONEWOC",
-                                "replace": "53968"
-                            },
-                            {
-                                "function": "regexp",
-                                "field": "zip",
-                                "pattern": "UNION CENTER",
-                                "replace": "53962"
-                            }
-                        ]
-                    }
+                    "postcode": "ZIPCODE"
                 }
             }
         ],


### PR DESCRIPTION
The `addresses`/`county` source has been failing every weekly run (jobs 907525, 902575, 897683) with `KeyError: 'zip'` during conform.

Root cause: the `postcode` conform used a chain of 16 `regexp` steps that assumed the `ZIPCODE` field sometimes contained a USPS town name (e.g. `NEKOOSA`) instead of a numeric ZIP, translating those names to ZIP codes. The county's ArcGIS service (`MapServer/7`) now always populates `ZIPCODE` with a plain numeric ZIP (confirmed via a distinct-values query against the live service — no town-name strings remain), so none of the regexp patterns ever match, the chain's `zip` variable is never initialized, and the second step in the chain throws a `KeyError` on every row, failing the whole conform.

Fix: since `ZIPCODE` already holds the correct ZIP code directly, simplify `postcode` to reference the field directly (`"postcode": "ZIPCODE"`) and drop the now-inaccurate note about town-name ZIP codes. The underlying ESRI service itself is healthy (13,768 features, no auth/availability issues) — this was a conform-logic bug, not a broken data source, so no coverage change was needed.

Validated with the schema compiler in `test/lib.js` (VALID).