### PR TITLE
Fix broken City of Moorhead, MN addresses source

### DIFF
--- a/sources/us/mn/city_of_moorhead.json
+++ b/sources/us/mn/city_of_moorhead.json
@@ -21,24 +21,19 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://gis.cityofmoorhead.com/arcgis/rest/services/Public/Addresses/MapServer/0",
-                "website": "https://opendata.arcgis.com/datasets/487e6858140e420c9310d1b488ca2fd0_15",
+                "data": "https://gis.moorheadmn.gov/arcgis/rest/services/EAM/Addresses_EAM/FeatureServer/0",
+                "website": "https://www.moorheadmn.gov/",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
                     "number": "ANUMBER",
-                    "street": [
-                        "ST_PRE_MOD",
-                        "ST_PRE_DIR",
-                        "ST_PRE_TYP",
-                        "ST_NAME",
-                        "ST_POS_TYP",
-                        "ST_POS_DIR",
-                        "ST_POS_MOD"
-                    ],
+                    "street": {
+                        "function": "postfixed_street",
+                        "field": "Address"
+                    },
                     "unit": "SUB_ID1",
-                    "city": "POSTCOMM",
-                    "region": "STATE_CODE",
+                    "city": "CITY",
+                    "region": "STATE",
                     "postcode": "ZIP",
                     "id": "ADD_ID"
                 }


### PR DESCRIPTION
The old host `gis.cityofmoorhead.com` no longer resolves (DNS dead), confirmed by the last three job runs (899264, 904156, 909106) all failing with `NameResolutionError`.

The city's GIS server has moved to `gis.moorheadmn.gov` (found via ArcGIS Online search and the new city website moorheadmn.gov, which the old cityofmoorhead.com domain now redirects to). Replaced with the `EAM/Addresses_EAM` FeatureServer's "Address Point" layer, a city-specific address point service (22,071 features, verified public with no auth required, extent matches Moorhead's coordinates).

Field names changed on the new service, so the conform was rebuilt from scratch:
- `number`: `ANUMBER` (unchanged)
- `street`: no separate street field exists anymore, so it's derived from the combined `Address` field (e.g. "424 11 ST N") via `postfixed_street`
- `unit`: `SUB_ID1` (unchanged)
- `city`: `CITY` (was `POSTCOMM`)
- `region`: `STATE` (was `STATE_CODE`)
- `postcode`: `ZIP` (unchanged)
- `id`: `ADD_ID` (unchanged)

Validated with `test/lib.js` schema compile — passes.