### PR TITLE
Fix broken City of Emporia, VA addresses source

### DIFF
--- a/sources/us/va/city_of_emporia.json
+++ b/sources/us/va/city_of_emporia.json
@@ -21,7 +21,8 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://parcelviewer.geodecisions.com/arcgis/rest/services/Emporia/Public/MapServer/8",
+                "data": "https://maps.civ.quest/arcgis/rest/services/Emporia/Public/MapServer/8",
+                "website": "https://experience.arcgis.com/experience/a6afa193867c4fb9b137cbc648fce341/",
                 "protocol": "ESRI",
                 "conform": {
                     "number": "Add_Number",


### PR DESCRIPTION
The ESRI MapServer backing this source (parcelviewer.geodecisions.com) was decommissioned — the last three weekly jobs (907846, 902896, 898004) all failed with `Service Emporia/Public/MapServer not found`, and the `Emporia` folder no longer appears in that server's service listing at all.

The City of Emporia GIS site (parcelviewer.geodecisions.com/Emporia) now redirects to civquest.com, and the city's public ArcGIS web experience (CivQuest) references a new host serving the same layer structure: `https://maps.civ.quest/arcgis/rest/services/Emporia/Public/MapServer`. Layer 8, "Site Addresses" (Point), is the direct successor to the old layer 8 and uses the same field naming convention (`Add_Number`, `Str_PreDir`, `Str_Nam`, `Str_PosTyp`, `Post_Code`), so the existing conform maps over unchanged.

Verified before writing the conform:
- `?f=json` returns a valid fields array, no auth/token errors
- Feature count: 2770 (`County` attribute on sampled records reads "Emporia city", confirming city-only coverage, not merged with Greensville County)
- Layer extent (~-77.56 to -77.50 lon, ~36.6N lat) matches Emporia's coverage geometry
- Schema validated with `test/lib.js`

Updated the `data` URL to the new FeatureServer path and set `website` to the city's public ArcGIS experience page.