### PR TITLE
Fix broken City of Huntington Beach, CA addresses source

### DIFF
--- a/sources/us/ca/city_of_huntington_beach.json
+++ b/sources/us/ca/city_of_huntington_beach.json
@@ -22,23 +22,26 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://gis.huntingtonbeachca.gov/arcgis/rest/services/WebAddresses/MapServer/47",
+                "data": "https://gis.huntingtonbeachca.gov/arcgis/rest/services/AddressEdits/FeatureServer/0",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
                     "number": [
-                        "huntington.DBO.AddressesPT.Address_Num",
-                        "huntington.DBO.AddressesPT.Fraction"
+                        "Address_Num",
+                        "Fraction"
                     ],
                     "street": [
-                        "huntington.DBO.AddressesPT.CnStPrefix",
-                        "huntington.DBO.AddressesPT.CnStNm",
-                        "huntington.DBO.AddressesPT.CnStSuffix"
+                        "CnStPrefix",
+                        "CnStNm",
+                        "CnStSuffix"
                     ],
-                    "unit": "huntington.DBO.AddressesPT.Unit",
-                    "city": "Huntington.dbo.W2_HB.SITECITY",
-                    "region": "Huntington.dbo.W2_HB.SITESTATE",
-                    "postcode": "huntington.DBO.AddressesPT.ZIP4"
+                    "unit": "Unit",
+                    "city": "MUN",
+                    "region": {
+                        "function": "constant",
+                        "value": "CA"
+                    },
+                    "postcode": "ZIP4"
                 }
             }
         ],


### PR DESCRIPTION
The addresses/city layer for Huntington Beach, CA was failing on every recent job (910588, 905638, 900740) with `esridump.errors.EsriDownloadError: Could not retrieve layer metadata: Layer not found` against `WebAddresses/MapServer/47` — that layer index no longer exists on the server.

Investigated the service:
- `WebAddresses/MapServer` still exists but the layer numbering changed; the address point layer is now index 3 (a join of `AddressesPT` and the `W2_HB` assessor table).
- Found a cleaner replacement: `AddressEdits/FeatureServer/0`, a dedicated address-point FeatureServer on the same server with unprefixed field names and 99,794 features, all within Huntington Beach, CA. Preferred this FeatureServer over the joined MapServer layer per repo convention.

Verified before writing the conform:
- `?f=json` returns a valid `fields` array, no auth errors.
- Feature count query returns 99,794 features.
- Sampled records confirm field values (city = "Huntington Beach", CA addresses/zips) and exact field names (`Address_Num`, `Fraction`, `CnStPrefix`, `CnStNm`, `CnStSuffix`, `Unit`, `ZIP4`, `MUN`) — none of the old `huntington.DBO.*` / `Huntington.dbo.*` prefixed names carried over.
- No state field exists on the new layer, so `region` is set via a `constant` function ("CA") instead.

Validated against the schema with the inline `test/lib.js` compile+validate check — passes.

Parcels and buildings layers in this file were not touched; only the addresses/city layer was confirmed broken.