### PR TITLE
Fix broken Berks County, PA addresses source

### DIFF
--- a/sources/us/pa/berks.json
+++ b/sources/us/pa/berks.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "website": "https://www.co.berks.pa.us/Dept/GIS/Pages/default.aspx",
+                "website": "https://www.berkspa.gov/departments/gis",
                 "contact": {
                     "name": "Brad Shirey",
                     "title": "GIS Manager",
@@ -22,23 +22,15 @@
                     "email": "gis@countyofberks.com",
                     "address": "Berks County Services Center, 633 Court Street, 12th Floor, Reading, PA 19601"
                 },
-                "data": "https://gis.co.berks.pa.us/arcgis/rest/services/Assess/ParcelBase4/MapServer/3",
+                "data": "https://services3.arcgis.com/dGYe1jDYrTw1wwpc/arcgis/rest/services/Berks_County_SSAP_Public/FeatureServer/0",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
-                    "number": {
-                        "function": "prefixed_number",
-                        "field": "FULLSITEADDRESS"
-                    },
-                    "street": {
-                        "function": "postfixed_street",
-                        "field": "FULLSITEADDRESS"
-                    },
-                    "unit": {
-                        "function": "postfixed_unit",
-                        "field": "FULLSITEADDRESS"
-                    },
-                    "city": "MUNICIPALNAME"
+                    "number": "BLDG_NUM",
+                    "street": ["ST_PREFIX", "ST_NAME", "ST_TYPE", "ST_SUFFIX"],
+                    "unit": "UNIT",
+                    "city": "CITY",
+                    "postcode": "ZIP_CODE"
                 }
             }
         ],


### PR DESCRIPTION
The addresses/county source for Berks County, PA (`sources/us/pa/berks.json`) has been failing for at least 3 weeks (jobs 908300, 903350, 898458). The old service host `gis.co.berks.pa.us` (Assess/ParcelBase4/MapServer) is dead — its TLS cert now identifies as `gis.berkspa.gov`, and the old ArcGIS Server folder no longer responds (connection resets / "Service not started").

The county has migrated its web presence to berkspa.gov and now publishes address data via ArcGIS Online. Found and verified a public, actively-maintained replacement feature service:

- New source: `https://services3.arcgis.com/dGYe1jDYrTw1wwpc/arcgis/rest/services/Berks_County_SSAP_Public/FeatureServer/0` ("Site Structure Address Point", owner `BerksCountyGIS`)
- 164,909 features confirmed, no auth required
- Field names re-verified via `?f=json` and a sample query (not carried over from the old service): `BLDG_NUM`, `ST_PREFIX`, `ST_NAME`, `ST_TYPE`, `ST_SUFFIX`, `UNIT`, `CITY`, `ZIP_CODE`
- Coverage confirmed county-wide (`COUNTY: BERKS`, sampled municipalities like Robesonia, Lenhartsville)
- Updated `website` to the county's current GIS page (`https://www.berkspa.gov/departments/gis`), since the old one 404s
- Validated against the schema via `test/lib.js`

Note: the `parcels` layer in this same file still points at the same dead `gis.co.berks.pa.us` host. Left it untouched since this fix is scoped to the `addresses` layer, but it will need a similar follow-up (a public `Berks_County_Parcels` FeatureServer exists on the same new ArcGIS Online org and looks like a viable replacement).