### PR TITLE
Fix broken Accomack County, VA addresses source

### DIFF
--- a/sources/us/va/accomack.json
+++ b/sources/us/va/accomack.json
@@ -14,22 +14,24 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://parcelviewer.geodecisions.com/arcgis/rest/services/accomack/Public/MapServer/7",
-                "protocol": "ESRI",
+                "data": "https://www.arcgis.com/sharing/rest/content/items/ec6c2375786e4b28b748504d961e83fd/data",
+                "website": "https://accomack-county-virginia-open-data-portal-accomack.hub.arcgis.com/datasets/ec6c2375786e4b28b748504d961e83fd",
+                "protocol": "http",
+                "compression": "zip",
                 "conform": {
+                    "format": "shapefile",
                     "number": [
-                        "add_number",
-                        "addnum_suf"
+                        "Add_Number",
+                        "AddNum_Suf"
                     ],
                     "street": [
-                        "st_predir",
-                        "st_name",
-                        "st_postyp",
-                        "st_posdir"
+                        "St_PreDir",
+                        "St_Name",
+                        "St_PosTyp",
+                        "St_PosDir"
                     ],
-                    "region":"post_comm",
-                    "format": "geojson",
-                    "postcode":"post_code"
+                    "city": "Post_Comm",
+                    "postcode": "Post_Code"
                 }
             }
         ]


### PR DESCRIPTION
The county's ArcGIS server (parcelviewer.geodecisions.com) removed the `accomack/Public` MapServer that the source pointed to. The last 3 weekly jobs (907874, 902924, 898032) all failed with `Could not find service. Service may be stopped or it may not be configured.`

Checked the server's root services listing — the `accomack` folder now only contains `accomack/Chincoteague`, a town-only service covering just Chincoteague (not the whole county), so it's not a valid same-coverage replacement.

Found a proper county-wide replacement on Accomack County's own ArcGIS Hub open data portal: an actively-maintained "Accomack County Addresses" shapefile dataset (last updated 2026-09-09, 27,328 points), covering the unincorporated county and all incorporated towns except Chincoteague, Wachapreague, and Onancock (which issue their own addresses — same limitation the old ESRI layer had).

- Layer: addresses
- Switched from ESRI protocol to `http` + zipped shapefile, pointing at the AGOL item's stable download endpoint
- Verified field names directly from the downloaded shapefile's DBF header and sample records (all field names changed case/naming from the old service, e.g. `Add_Number`, `St_PreDir`, `St_Name`, `St_PosTyp`, `St_PosDir`, `Post_Comm`, `Post_Code`)
- Fixed the old conform's `region: post_comm` mapping (which put a city name into the state/region field) to `city: Post_Comm`, matching the convention used by neighboring VA county sources (e.g. `campbell.json`)
- Validated against the schema with the `test/lib.js` compile+validate snippet: `VALID`