### PR TITLE
Fix broken Saint Francois County, MO addresses source

### DIFF
--- a/sources/us/mo/saint_francois.json
+++ b/sources/us/mo/saint_francois.json
@@ -15,14 +15,18 @@
             {
                 "name": "county",
                 "protocol": "ESRI",
-                "data": "https://maps.semogis.com/server/rest/services/StFrancois_CO/StFrancoisCo_911/MapServer/0",
+                "data": "https://maps.semogis.com/server/rest/services/Region/Public_911/MapServer/10",
                 "conform": {
                     "format": "geojson",
-                    "number": "NEW_ADD",
-                    "street": "RDNAME",
-                    "city": "CITY",
-                    "region": "STATE",
-                    "postcode": "ZIP"
+                    "number": {
+                        "function": "prefixed_number",
+                        "field": "FullAddress"
+                    },
+                    "street": {
+                        "function": "postfixed_street",
+                        "field": "FullAddress"
+                    },
+                    "unit": "SubUnit"
                 }
             }
         ],


### PR DESCRIPTION
The addresses layer's ArcGIS service (`StFrancois_CO/StFrancoisCo_911/MapServer/0`) has been failing for at least the last 3 weekly batch runs (job 908962, 904012, 899120) with `Service ... not started`. The service has been removed from the server entirely — it's no longer listed among `StFrancois_CO`'s services on maps.semogis.com.

The county's data is still published, just consolidated into a regional multi-county 911 service: `Region/Public_911/MapServer`, layer 10 (`StFrancois_County > Addresses`). Verified via esri-explore.py:
- 42,709 features, geometry Point, extent matches St. Francois County, MO
- `DataSource` field is `SFC 911` for the vast majority of records, with the remainder `ADDRESS ADDED BY CLIENT DURING REMEDIATION` (still county data, no cross-county contamination)
- No discrete house-number/street fields, but `FullAddress` (e.g. \"118 N SPRUCE ST\") combines them, so conform uses `prefixed_number`/`postfixed_street` against `FullAddress`, plus `SubUnit` for unit

Updated `sources/us/mo/saint_francois.json` addresses layer to point at the new service and conform. Left the parcels layer untouched since it's out of scope here (its service, `StFrancoisCo_Assessment`, also looks to have moved but that's a separate fix).