### PR TITLE
Fix broken City of Lake Forest, CA addresses source

### DIFF
--- a/sources/us/ca/city_of_lake_forest.json
+++ b/sources/us/ca/city_of_lake_forest.json
@@ -9,17 +9,17 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://services.arcgis.com/ZNy8hnJqYHIKCiV1/ArcGIS/rest/services/LFGeotools/FeatureServer/0",
+                "data": "https://services.arcgis.com/ZNy8hnJqYHIKCiV1/ArcGIS/rest/services/Election_Districts_w_Address_Points_2025_map_layer/FeatureServer/0",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
                     "unit": [
-                        "UnitDesgnator",
+                        "UnitDesgna",
                         "Unit"
                     ],
-                    "number": "AddressNumber",
-                    "street": "StreetName",
-                    "city": "CommunityName",
+                    "number": "AddressNum",
+                    "street": "StreetNa_1",
+                    "city": "CommunityN",
                     "postcode": {
                         "function": "join",
                         "fields": ["ZIPCode", "ZIPPlus4"],


### PR DESCRIPTION
The `LFGeotools/FeatureServer/0` service backing this source now returns `Token Required` (HTTP 499) — it became private/deleted, causing the last 3 weekly jobs to fail (910580, 905630, 900732).

Searched the same ArcGIS Online host (`services.arcgis.com/ZNy8hnJqYHIKCiV1`) for a replacement and found `Election_Districts_w_Address_Points_2025_map_layer/FeatureServer/0`, a public, single-layer point service titled "Address Points 2025 w Election Districts" owned by the City of Lake Forest's own GIS account (`pward_lakeforestca`). Its extent (-117.72 to -117.62 lon, 33.607 to 33.703 lat) matches the city, and it returns 36,957 features with no auth required.

Verified field names directly from the service (they differ from the old ones) and updated the conform:
- `AddressNum` (was `AddressNumber`)
- `StreetNa_1` (was `StreetName` — that field is now a numeric street ID, not the name)
- `UnitDesgna` (was `UnitDesgnator`)
- `CommunityN` (was `CommunityName`)
- `ZIPCode`/`ZIPPlus4`/`State` unchanged

Schema-validated with `test/lib.js`.