### PR TITLE
Fix broken City of Moore, OK addresses source

### DIFF
--- a/sources/us/ok/city_of_moore.json
+++ b/sources/us/ok/city_of_moore.json
@@ -15,18 +15,19 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://gis.cityofmoore.com/arcgis/rest/services/NG911/NG911_Address_Publish/FeatureServer/0",
+                "data": "https://gis.cityofmoore.com/arcgis/rest/services/Basemaps/Moore_General_Basemap/MapServer/148",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
-                    "number": "Address",
-                    "street": {
+                    "number": "ADDRNUM",
+                    "street": "FULLNAME",
+                    "unit": {
                         "function": "join",
-                        "fields": ["PreDir", "Street", "StreetType", "SufDir"],
+                        "fields": ["UNITTYPE", "UNITID"],
                         "separator": " "
                     },
-                    "city": "City",
-                    "postcode": "Zipcode"
+                    "city": "MUNICIPALITY",
+                    "postcode": "ZIPCODE"
                 }
             }
         ],


### PR DESCRIPTION
The addresses/city layer pointed to `NG911/NG911_Address_Publish/FeatureServer/0`, which no longer exists — the `NG911` folder on the server is now empty (service renamed/removed), causing every recent job to fail with `Service NG911/NG911_Address_Publish/MapServer not started` (jobs 908455, 903505, 898613).

Found a same-coverage replacement on the same server: the city's general basemap already backs the parcels and buildings layers in this file (`Basemaps/Moore_General_Basemap/MapServer`), and that service also has an address points layer at index 148 (`AddressPoints_1K`). Verified before writing the conform:

- `?f=json" returns valid fields, no auth error
- Feature count: 24,228 (query with `returnCountOnly=true`)
- Extent covers Moore, OK (~35.22–35.34N, -97.59– -97.42W)
- Data is actively maintained (max `LASTUPDATE` is August 2025)
- Sampled records to confirm exact field names/case: `ADDRNUM`, `FULLNAME` (full street name incl. type), `UNITTYPE`/`UNITID`, `MUNICIPALITY`, `ZIPCODE`

Updated the addresses/city conform to use these fields instead of the old `Address`/`PreDir`/`Street`/`StreetType`/`SufDir`/`City`/`Zipcode` fields, which no longer apply.

Left parcels and buildings layers unchanged since they were already working.