### PR TITLE
Fix broken Kershaw County SC addresses and parcels source

### DIFF
--- a/sources/us/sc/kershaw.json
+++ b/sources/us/sc/kershaw.json
@@ -14,21 +14,29 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://smpesri.scdot.org/arcgis/rest/services/GISMapping/SC_Parcels/MapServer/28",
+                "data": "https://services6.arcgis.com/kyYrMHheB5jkAnFA/arcgis/rest/services/Addresses_view/FeatureServer/0",
+                "website": "https://kershawcountydataportal-kershawcounty.hub.arcgis.com",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
-                    "number": "taxLocStre",
-                    "street": "taxlocSt1",
-                    "city": "taxLocCity",
-                    "postcode": "taxLocZip"
+                    "number": {
+                        "function": "prefixed_number",
+                        "field": "Full_Add"
+                    },
+                    "street": {
+                        "function": "postfixed_street",
+                        "field": "Full_Add"
+                    },
+                    "city": "Community",
+                    "postcode": "Zip_Code"
                 }
             }
         ],
         "parcels": [
             {
                 "name": "county",
-                "data": "https://smpesri.scdot.org/arcgis/rest/services/GISMapping/SC_Parcels/MapServer/28",
+                "data": "https://services6.arcgis.com/kyYrMHheB5jkAnFA/arcgis/rest/services/Parcels_view/FeatureServer/0",
+                "website": "https://kershawcountydataportal-kershawcounty.hub.arcgis.com",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",


### PR DESCRIPTION
The Kershaw County, SC `addresses`/`county` and `parcels`/`county` sources both pointed at a layer on SCDOT's statewide GIS server (`smpesri.scdot.org`), which now returns `Token Required` (499) for that service. The `GISMapping/SC_Parcels` MapServer has also been removed from that server's folder listing entirely, so this is not a transient auth issue.

Replaced both layers with Kershaw County's own ArcGIS Online feature services (org `kyYrMHheB5jkAnFA`, linked from the county's GIS Open Data Portal at https://kershawcountydataportal-kershawcounty.hub.arcgis.com):

- addresses: `Addresses_view` FeatureServer (38,075 features). The service only exposes a combined `Full_Add` field (e.g. "717 WELLINGTON DR"), so `number`/`street` use `prefixed_number`/`postfixed_street` against that field; `city`/`postcode` map from `Community`/`Zip_Code`.
- parcels: `Parcels_view` FeatureServer (43,646 features), `pid` from `PRSNTP_ID` (same field name as the old source).

Verified both replacement layers before writing the conform: fields present, feature counts > 0, no auth errors, and sampled coordinates fall within Kershaw County (lat ~34.2-34.5, lon ~-80.5 to -80.7). Schema validated with `test/lib.js`.

Closes broken source jobs 908150/908151 (and prior fails 903200/903201, 898308/898309).