### PR TITLE
Fix broken Hampton County, SC addresses source

### DIFF
--- a/sources/us/sc/hampton.json
+++ b/sources/us/sc/hampton.json
@@ -14,12 +14,13 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://smpesri.scdot.org/arcgis/rest/services/GISMapping/SC_Parcels/MapServer/25",
+                "data": "https://services8.arcgis.com/6eabNhFouHU5vuYk/arcgis/rest/services/Roads_and_Addresses/FeatureServer/0",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
-                    "number": "Street_Num",
-                    "street": "Street_Nam"
+                    "number": "HOUSE",
+                    "street": ["DIR", "STREET"],
+                    "city": "COMMUNITY"
                 }
             }
         ],


### PR DESCRIPTION
The Hampton County, SC addresses source was pointed at `https://smpesri.scdot.org/arcgis/rest/services/GISMapping/SC_Parcels/MapServer/25`, a layer on SCDOT's statewide parcels MapServer. The last 3 jobs (908160, 903210, 898318) all failed with `Token Required` — the service now requires authentication. Checking the server's service listing directly confirms `GISMapping/SC_Parcels` has been removed entirely (only `GISMapping/Bridges` and `GISMapping/SC_Contours` remain), so this is a dead/retired service, not a transient auth hiccup.

Replaced with Hampton County's own hosted ArcGIS Online service (owner `hamptoncountyscgis`): `Roads_and_Addresses/FeatureServer/0` ("Address Points"), which is public, returns 12,470 features, and has an extent matching Hampton County, SC. Field names were verified directly against the service (`HOUSE`, `DIR`, `STREET`, `COMMUNITY`) and spot-checked against the `FULLADD` field on sample records.

- Layer: addresses (name: county)
- New source: https://services8.arcgis.com/6eabNhFouHU5vuYk/arcgis/rest/services/Roads_and_Addresses/FeatureServer/0

The county's `parcels` layer in this same file also points at the now-dead SCDOT service, but that is out of scope for this fix and left untouched.