### PR TITLE
Fix broken Minnehaha County, SD source

### DIFF
--- a/sources/us/sd/minnehaha.json
+++ b/sources/us/sd/minnehaha.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://gis.minnehahacounty.org/minnemap/rest/services/Planning/AddressPoints/MapServer/0",
+                "data": "https://gis.minnehahacounty.gov/minnemap/rest/services/Planning/AddressPoints/MapServer/0",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
@@ -36,7 +36,7 @@
         "parcels": [
             {
                 "name": "county",
-                "data": "https://gis.minnehahacounty.org/minnemap/rest/services/OpenData/MinnehahaParcels/MapServer/0",
+                "data": "https://gis.minnehahacounty.gov/minnemap/rest/services/OpenData/MinnehahaParcels/MapServer/0",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",


### PR DESCRIPTION
Minnehaha County's GIS server domain (`gis.minnehahacounty.org`) stopped resolving in DNS (NXDOMAIN), causing the last several `addresses`/`county` jobs to fail (job IDs 908041, 903091, 898199). The county's main website moved from `.org` to `.gov`, and the GIS server moved along with it to `gis.minnehahacounty.gov`, with the same REST service path and field names.

- Verified the new address points service (`Planning/AddressPoints/MapServer/0`) returns the same fields (HOUSENUM, PR1, STNM1, TYP1, PD1, ADDRESSNUM_SUF, MUNICIPALITY, ZIPCODE, COUNTY, STATE) with 15,847 features, and sampled records confirm correct South Dakota coordinates and municipality names.
- The parcels layer on the same server (`OpenData/MinnehahaParcels/MapServer/0`) was also broken by the same DNS issue and is fixed the same way (23,044 features confirmed).
- No conform changes were needed — only the domain in the `data` URLs.
- Schema-validated with the inline `test/lib.js` compile+validate check.