### PR TITLE
Fix broken City of San Luis Obispo addresses source

### DIFF
--- a/sources/us/ca/city_of_san_luis_obispo.json
+++ b/sources/us/ca/city_of_san_luis_obispo.json
@@ -21,7 +21,7 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://maps.slocity.org/hosting/rest/services/GISLayers/gisLandManagement/FeatureServer/2",
+                "data": "https://mapsa.slocity.org/hosting/rest/services/sloGISlayers/gisLandManagementWM/FeatureServer/2",
                 "website": "https://gis-slocity.hub.arcgis.com/datasets/SLOCity::address-points/about",
                 "license": {
                     "url": "https://gis-slocity.hub.arcgis.com/"


### PR DESCRIPTION
The addresses/city source for San Luis Obispo, CA had been failing for at least 3 consecutive weekly jobs (910532, 905582, 900686) with `EsriDownloadError: Could not retrieve layer metadata: None`.

Root cause: the entire ArcGIS Server instance at `maps.slocity.org` is returning `500 9027$ERROR_GETTING_LICENSE_INFO` for every service and folder listing (confirmed server-wide, not just the address layer), so the old FeatureServer URL is dead.

Found a working replacement on a sibling city GIS host: `https://mapsa.slocity.org/hosting/rest/services/sloGISlayers/gisLandManagementWM/FeatureServer/2` — this is the same underlying City of San Luis Obispo dataset (found via the AGOL item still linked from the source's `website` hub page), verified with a feature count of 33,540 and identical field names (`streetNumber`, `streetName`, `streetType`, `suite`, `zipCode`) to the old conform, so no conform changes were needed — just the `data` URL.

- Layer: addresses, name: city
- Only the `data` URL changed; `conform` and `website` are unchanged and verified still valid
- Parcels/buildings layers on the old host were out of scope for this fix and were left untouched