### PR TITLE
Fix broken St. Joseph County, IN addresses source

### DIFF
--- a/sources/us/in/st_joseph.json
+++ b/sources/us/in/st_joseph.json
@@ -14,23 +14,16 @@
         "addresses": [
             {
                 "name": "county",
-                "website": "https://sjcgis-stjocogis.hub.arcgis.com/datasets/d0b95019cb834cfc85862a87cb0e6610_0",
-                "data": "https://services.arcgis.com/OjftlhRHkAABcyiF/arcgis/rest/services/Address/FeatureServer/0",
+                "website": "https://sjcgis-stjocogis.hub.arcgis.com/datasets/c87332939da6463ea36f582de850fb77_0",
+                "data": "https://services.arcgis.com/OjftlhRHkAABcyiF/arcgis/rest/services/address_pt/FeatureServer/0",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
-                    "number": {
-                        "function": "prefixed_number",
-                        "field": "FullStreet"
-                    },
-                    "street": {
-                        "function": "postfixed_street",
-                        "field": "FullStreet"
-                    },
-                    "unit": {
-                        "function": "postfixed_unit",
-                        "field": "FullStreet"
-                    }
+                    "number": "HouseNumbe",
+                    "street": ["PreDirecti", "StreetName", "PostType", "PostDirect"],
+                    "unit": "UNIT",
+                    "city": "PostalCity",
+                    "postcode": "Zip"
                 }
             }
         ],


### PR DESCRIPTION
The county addresses source for St. Joseph County, IN was failing on every recent job (909456, 904506, 899614) with:

```
esridump.errors.EsriDownloadError: Could not retrieve layer metadata: Invalid URL Invalid URL
```

The old `Address` FeatureServer on `services.arcgis.com/OjftlhRHkAABcyiF` no longer exists (the service was removed/renamed on the county's ArcGIS Online org).

I checked the org's service listing and found `address_pt`, a currently-maintained county-wide address point FeatureServer (last edited within the last two days, 130,189 features, extent matching St. Joseph County, IN). Verified via `?f=json` and sample queries:
- Fields array present, no auth errors
- Feature count: 130,189
- `HouseNumbe` is populated on 100% of records (0 null/blank)
- Spatial extent covers St. Joseph County (roughly 41.43–41.76N, -86.53– -86.06W)
- ArcGIS Online item description: "Address points for parcels in St. Joseph County," owner SJCGIS

Since discrete address component fields are reliably populated, I replaced the old `FullStreet` regex-parsing conform with direct field mappings (`HouseNumbe`, `PreDirecti`/`StreetName`/`PostType`/`PostDirect`, `UNIT`, `PostalCity`, `Zip`), verified against sample records.

The parcels layer on this source was not reported broken and is left unchanged.