### PR TITLE
Fix broken city of Lawrence, KS addresses source

### DIFF
--- a/sources/us/ks/city_of_lawrence.json
+++ b/sources/us/ks/city_of_lawrence.json
@@ -21,7 +21,7 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://gis2.lawrenceks.org/arcgis/rest/services/AddressPoints/MapServer/0",
+                "data": "https://gis.lawrenceks.org/server/rest/services/EPL/EPL_Operational_Layers/FeatureServer/6",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
@@ -34,13 +34,9 @@
                         "UNIT"
                     ],
                     "street": [
-                        "PRM",
                         "PRD",
-                        "STP",
                         "RD",
-                        "STS",
-                        "POD",
-                        "POM"
+                        "STS"
                     ],
                     "city": "MUNI",
                     "postcode": "ZIP"


### PR DESCRIPTION
The `addresses`/`city` job for this source has failed for the last 8 consecutive weekly runs (since 2026-07-17), all with `ConnectTimeout` connecting to `gis2.lawrenceks.org` — that host no longer responds at all (connection times out on any path).

The city's GIS platform has migrated to a new ArcGIS Enterprise deployment at `gis.lawrenceks.org`. The old `AddressPoints/MapServer/0` layer is now published as layer 6 ("Address Point") in the `EPL_Operational_Layers` feature service on that new server, with the same field schema (`HNO`, `HNS`, `PRD`, `RD`, `STS`, `MUNI`, `ZIP`, `UNIT_TYPE`, `UNIT`) as before, minus a couple of unused fields (`PRM`, `STP`, `POD`, `POM`) that are no longer present, so the `street` conform is trimmed to `["PRD", "RD", "STS"]`.

Verified before writing the conform:
- Service responds with a valid `fields` array, no auth errors
- Feature count: 62,964 (matches the prior source's scale)
- Sampled records for both the county-at-large and `MUNI='LAWRENCE'` (51,355 of the 62,964 records) confirm field values and formatting match the `LABEL` field exactly
- This is the same authoritative shared Lawrence/Douglas County address-point dataset the source has always pointed at (the original 2017 source already carried non-Lawrence `MUNI` values), just migrated to the new server — not a widening of coverage.

Updated `data` URL: `https://gis.lawrenceks.org/server/rest/services/EPL/EPL_Operational_Layers/FeatureServer/6`