### PR TITLE
Fix broken City of Brookline, MA addresses source

### DIFF
--- a/sources/us/ma/city_of_brookline.json
+++ b/sources/us/ma/city_of_brookline.json
@@ -21,7 +21,8 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://gisweb.brooklinema.gov/arcgis/rest/services/OpenDataPortal/OpenDataPortal_Address_Building_Parcel/MapServer/0",
+                "data": "https://services1.arcgis.com/Oknk0tvfHOElpgGU/arcgis/rest/services/AddressPoint/FeatureServer/1",
+                "website": "https://maps.brooklinema.gov/datasets/Brookline::addresspoint/about",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",


### PR DESCRIPTION
The addresses/city source for Brookline, MA has been failing for 9+ consecutive weekly runs (jobs 870552 through 909303, spanning ~63 days) with a connection timeout to \`gisweb.brooklinema.gov\`. That on-prem ArcGIS server is now completely unreachable (times out on connect, does not even respond to ping), while the town's public-facing \`brooklinema.gov\` site is unaffected.

Replaced the dead \`gisweb.brooklinema.gov/.../OpenDataPortal_Address_Building_Parcel/MapServer/0\` endpoint with the Town of Brookline's current publicly hosted ArcGIS Online FeatureServer at \`services1.arcgis.com/Oknk0tvfHOElpgGU/.../AddressPoint/FeatureServer/1\`, found via the town's new GIS Hub (maps.brooklinema.gov / ArcGIS Hub owner Town-of-Brookline.MA).

Verified before writing the conform:
- Layer returns a valid \`fields\` array, no auth errors
- Feature count: 32,424
- Sample records have City=BROOKLINE, County=NORFOLK, State=MASSACHUSETTS, matching the existing coverage
- Field names (\`AddNum\`, \`StPreDir\`, \`StPreType\`, \`StName\`, \`StType\`, \`StDir\`, \`City\`, \`County\`, \`StateAbbr\`, \`ZIP\`, \`Unit\`, \`ADDRESS_ID\`) are identical to the old service, so the conform block is unchanged aside from the \`data\` URL; also added a \`website\` link to the new Hub dataset page.

Schema-validated with the inline \`test/lib.js\` check and \`npm test\` (the only 2 failures in the full suite are pre-existing, unrelated schema edge-case tests).