### PR TITLE
Fix broken Midwest City, OK addresses source

### DIFF
--- a/sources/us/ok/city_of_midwest_city.json
+++ b/sources/us/ok/city_of_midwest_city.json
@@ -22,7 +22,7 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://maps.midwestcityok.org/arcgis/rest/services/OpenData/AddressPoints/MapServer/0",
+                "data": "https://maps.midwestcityok.org/arcgis/rest/services/AddressPoints/FeatureServer/0",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",


### PR DESCRIPTION
The addresses/city source for Midwest City, OK was failing every job with \`Service OpenData/AddressPoints/MapServer not found\`. The city's ArcGIS server (maps.midwestcityok.org) moved the AddressPoints service out of the OpenData folder to the server root, and now also publishes a FeatureServer for it.

- Old URL: https://maps.midwestcityok.org/arcgis/rest/services/OpenData/AddressPoints/MapServer/0
- New URL: https://maps.midwestcityok.org/arcgis/rest/services/AddressPoints/FeatureServer/0

Verified the replacement before committing:
- Service returns valid metadata with a fields array, no auth errors
- Feature count: 31,259 (consistent with a single-city address dataset)
- Field names are identical to the existing conform (AddressNumber, PreDirection, StreetName, StreetType, UnitType, UnitNumber, ZipCode) — confirmed via a sample query, not assumed
- Confirmed this is Midwest City's own dedicated GIS host, not a regional multi-jurisdiction service

Only the \`data\` URL changed; the conform did not need updates since the field schema carried over exactly.