### PR TITLE
Add consolidated INCOG regional addresses source

### DIFF
--- a/sources/us/ok/creek.json
+++ b/sources/us/ok/creek.json
@@ -11,24 +11,6 @@
     },
     "schema": 2,
     "layers": {
-        "addresses": [
-            {
-                "name": "county",
-                "data": "https://map11.incog.org/arcgis11wa/rest/services/Address_Points/FeatureServer/2",
-                "protocol": "ESRI",
-                "conform": {
-                    "format": "geojson",
-                    "number": "Address",
-                    "street": {
-                        "function": "join",
-                        "fields": ["PreDir", "Street", "StreetType", "SufDir"],
-                        "separator": " "
-                    },
-                    "city": "City",
-                    "postcode": "Zipcode"
-                }
-            }
-        ],
         "parcels": [
             {
                 "name": "county",

--- a/sources/us/ok/incog-counties.json
+++ b/sources/us/ok/incog-counties.json
@@ -1,0 +1,52 @@
+{
+    "coverage": {
+        "country": "us",
+        "state": "ok",
+        "county": "Creek, Osage, Rogers, Tulsa, and Wagoner",
+        "geometry": {
+            "type": "Polygon",
+            "coordinates": [
+                [
+                    [
+                        -96.297627,
+                        35.85657
+                    ],
+                    [
+                        -95.328495,
+                        35.85657
+                    ],
+                    [
+                        -95.328495,
+                        36.598841
+                    ],
+                    [
+                        -96.297627,
+                        36.598841
+                    ],
+                    [
+                        -96.297627,
+                        35.85657
+                    ]
+                ]
+            ]
+        }
+    },
+    "schema": 2,
+    "layers": {
+        "addresses": [
+            {
+                "name": "county",
+                "data": "https://map11.incog.org/arcgis11wa/rest/services/Address_Points_V3/FeatureServer/2",
+                "protocol": "ESRI",
+                "conform": {
+                    "format": "geojson",
+                    "number": "AddNumber",
+                    "street": ["PreDir", "Street", "StreetType", "SufDir"],
+                    "city": "City",
+                    "postcode": "Zipcode"
+                },
+                "attribution": "INCOG (Indian Nations Council of Governments)"
+            }
+        ]
+    }
+}

--- a/sources/us/ok/osage.json
+++ b/sources/us/ok/osage.json
@@ -11,24 +11,6 @@
     },
     "schema": 2,
     "layers": {
-        "addresses": [
-            {
-                "name": "county",
-                "data": "https://map11.incog.org/arcgis11wa/rest/services/Address_Points/FeatureServer/2",
-                "protocol": "ESRI",
-                "conform": {
-                    "format": "geojson",
-                    "number": "Address",
-                    "street": {
-                        "function": "join",
-                        "fields": ["PreDir", "Street", "StreetType", "SufDir"],
-                        "separator": " "
-                    },
-                    "city": "City",
-                    "postcode": "Zipcode"
-                }
-            }
-        ],
         "parcels": [
             {
                 "name": "county",

--- a/sources/us/ok/rogers.json
+++ b/sources/us/ok/rogers.json
@@ -11,24 +11,6 @@
     },
     "schema": 2,
     "layers": {
-        "addresses": [
-            {
-                "name": "county",
-                "data": "https://map11.incog.org/arcgis11wa/rest/services/Address_Points/FeatureServer/2",
-                "protocol": "ESRI",
-                "conform": {
-                    "format": "geojson",
-                    "number": "Address",
-                    "street": {
-                        "function": "join",
-                        "fields": ["PreDir", "Street", "StreetType", "SufDir"],
-                        "separator": " "
-                    },
-                    "city": "City",
-                    "postcode": "Zipcode"
-                }
-            }
-        ],
         "parcels": [
             {
                 "name": "county",

--- a/sources/us/ok/tulsa.json
+++ b/sources/us/ok/tulsa.json
@@ -11,24 +11,6 @@
     },
     "schema": 2,
     "layers": {
-        "addresses": [
-            {
-                "name": "county",
-                "data": "https://map11.incog.org/arcgis11wa/rest/services/Address_Points/FeatureServer/2",
-                "protocol": "ESRI",
-                "conform": {
-                    "format": "geojson",
-                    "number": "Address",
-                    "street": {
-                        "function": "join",
-                        "fields": ["PreDir", "Street", "StreetType", "SufDir"],
-                        "separator": " "
-                    },
-                    "city": "City",
-                    "postcode": "Zipcode"
-                }
-            }
-        ],
         "parcels": [
             {
                 "name": "county",

--- a/sources/us/ok/wagoner.json
+++ b/sources/us/ok/wagoner.json
@@ -11,24 +11,6 @@
     },
     "schema": 2,
     "layers": {
-        "addresses": [
-            {
-                "name": "county",
-                "data": "https://map11.incog.org/arcgis11wa/rest/services/Address_Points/FeatureServer/2",
-                "protocol": "ESRI",
-                "conform": {
-                    "format": "geojson",
-                    "number": "Address",
-                    "street": {
-                        "function": "join",
-                        "fields": ["PreDir", "Street", "StreetType", "SufDir"],
-                        "separator": " "
-                    },
-                    "city": "City",
-                    "postcode": "Zipcode"
-                }
-            }
-        ],
         "parcels": [
             {
                 "name": "county",


### PR DESCRIPTION
## Background

Tulsa, Osage, Rogers, and Wagoner counties' `addresses` sources were broken after INCOG retired the old per-county sublayer `Address_Points/FeatureServer/2`. Four separate PRs (#8379, #8380, #8384, #8385) each pointed their county's source at the replacement layer, `Address_Points_V3/FeatureServer/2`.

Investigating a fifth broken source (Creek County) turned up the problem: `Address_Points_V3/FeatureServer/2` is a single unfiltered layer covering multiple counties at once (452,971 features total), and OA's ESRI pipeline has no supported way to scope a `data` URL to a subset via `where=`. Pointing each of those four county files directly at this layer would have made each one pull in every other county's addresses too, which is the "widening coverage" problem REVIEW.md warns against — just introduced by accident since none of the four fixes checked whether the new layer was actually county-scoped.

I closed PRs #8379, #8380, #8384, and #8385 with an explanation, and replaced them with this consolidated source.

## What's in this PR

Queried the layer's distinct `County` values via a grouped ESRI statistics query. Counts:

| County | Features |
|---|---|
| Tulsa | 370,137 |
| Rogers | 47,145 |
| Wagoner | 18,707 |
| Creek | 10,710 |
| Osage | 6,266 |
| Nowata | 4 |
| Pawnee | 2 |

The five counties with substantial coverage (Creek, Osage, Rogers, Tulsa, Wagoner) sum to 452,965 of the 452,971 total features, confirming the layer is INCOG's full regional address dataset. Nowata and Pawnee each have only a handful of stray points near the boundary and are not meaningfully covered, so they're left out of this source's `coverage`.

- **New file:** `sources/us/ok/incog-counties.json` — one `addresses` layer pointing at the full `Address_Points_V3/FeatureServer/2` layer, modeled on the existing `sources/us/ok/acog-counties.json` multi-county pattern (a `coverage.county` string naming all five counties plus a bounding-box `coverage.geometry`). Field mapping (`AddNumber`, `PreDir`/`Street`/`StreetType`/`SufDir`, `City`, `Zipcode`) verified directly against the live service's field list and a sample record.
- **Removed the `addresses` layer** from `sources/us/ok/tulsa.json`, `sources/us/ok/osage.json`, `sources/us/ok/rogers.json`, `sources/us/ok/wagoner.json` (all previously pointed at the dead `Address_Points/FeatureServer/2` layer), and `sources/us/ok/creek.json` (already broken, never fixed) — now superseded by the consolidated source. Their `parcels` and `centerlines` layers are untouched.

## Validation

All six changed/added files pass schema validation via `test/lib.js`, and `npm test` passes except for two pre-existing, unrelated failures in `test/schema_validation_v2.test.js` (synthetic `accuracy` field tests, not tied to any source file).