### PR TITLE
Fix broken El Dorado County, CA addresses source

### DIFF
--- a/sources/us/ca/el_dorado.json
+++ b/sources/us/ca/el_dorado.json
@@ -15,21 +15,20 @@
             {
                 "name": "county",
                 "attribution": "El Dorando County",
-                "data": "https://see-eldorado.edcgov.us/arcgis/rest/services/uGOTNETandEXTRACTS/address/MapServer/0",
+                "data": "https://see-eldorado.edcgov.us/arcgis/rest/services/Parcels_Public/MapServer/0",
                 "website": "https://www.edcgov.us/Government/Surveyor/FAQs/G_I_S__FAQs.aspx",
                 "protocol": "ESRI",
                 "conform": {
                     "id": "PRCL_ID",
                     "format": "geojson",
-                    "number": {
-                        "function": "prefixed_number",
-                        "field": "PRCL_ADDR"
-                    },
-                    "street": {
-                        "function": "postfixed_street",
-                        "field": "PRCL_ADDR",
-                        "may_contain_units": true
-                    },
+                    "number": "ADDR_STR_NBR",
+                    "street": [
+                        "ADDR_STR_PRFX",
+                        "ADDR_STR_DIR",
+                        "ADDR_STR_NAME",
+                        "ADDR_STR_TYPE",
+                        "ADDR_STR_POST_DIR"
+                    ],
                     "unit": [
                         "ADDR_UNIT_TYPE",
                         "ADDR_UNIT_NBR"
@@ -41,7 +40,7 @@
             {
                 "name": "county",
                 "attribution": "El Dorando County",
-                "data": "https://see-eldorado.edcgov.us/arcgis/rest/services/uGOTNETandEXTRACTS/address/MapServer/0",
+                "data": "https://see-eldorado.edcgov.us/arcgis/rest/services/Parcels_Public/MapServer/0",
                 "website": "https://www.edcgov.us/Government/Surveyor/FAQs/G_I_S__FAQs.aspx",
                 "protocol": "ESRI",
                 "conform": {


### PR DESCRIPTION
El Dorado County's `addresses` (and `parcels`) source pointed at `uGOTNETandEXTRACTS/address/MapServer/0`, which now returns `Service uGOTNETandEXTRACTS/address/MapServer not started` (confirmed via job logs for the last 3 failed runs: 910502, 905552, 900656).

That folder no longer contains an address/parcel data service — it now only has a geocoder and facilities service. The county's parcel data with embedded address fields has moved to `Parcels_Public/MapServer/0` on the same county GIS server (see-eldorado.edcgov.us), confirmed via the service's root/folder listing.

Verified before writing the conform:
- Service responds with a valid `fields` array, no auth errors.
- Feature count: 114,581 (single-county scale, hosted on the county's own ArcGIS server — not a regional/multi-county dataset).
- Sampled records confirm exact field names/case: `ADDR_STR_NBR`, `ADDR_STR_PRFX`, `ADDR_STR_DIR`, `ADDR_STR_NAME`, `ADDR_STR_TYPE`, `ADDR_STR_POST_DIR`, `ADDR_UNIT_TYPE`, `ADDR_UNIT_NBR`, `PRCL_ID`.
- Spatial extent covers El Dorado County (sample geometry falls within the county near Placerville).

Updated the `addresses` conform to use the new, more structured fields (previously it parsed a single `PRCL_ADDR" string with `prefixed_number`/`postfixed_street`; the new service exposes already-parsed number/prefix/direction/name/type/post-direction/unit fields directly). Updated the `parcels` layer's `data` URL to match; its conform (`pid": "PRCL_ID"`) is unchanged.

Validated against `test/lib.js` schema compile — passes.