### PR TITLE
Fix broken New Kent County, VA addresses and parcels sources

### DIFF
--- a/sources/us/va/new_kent.json
+++ b/sources/us/va/new_kent.json
@@ -14,8 +14,8 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://parcelviewer.geodecisions.com/arcgis/rest/services/NewKent/Public/MapServer/30",
-                "website": "https://www.co.newkent.state.va.us/297/GIS",
+                "data": "https://services2.arcgis.com/wRTEaR3VIVeAhJdr/arcgis/rest/services/AddressBPs/FeatureServer/0",
+                "website": "https://newkentgis.maps.arcgis.com/apps/instant/basic/index.html?appid=2e178d86fad342519f25c8a3a7661868",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
@@ -35,8 +35,8 @@
         "parcels": [
             {
                 "name": "county",
-                "data": "https://parcelviewer.geodecisions.com/arcgis/rest/services/NewKent/Public/MapServer/18",
-                "website": "https://www.co.newkent.state.va.us/297/GIS",
+                "data": "https://services2.arcgis.com/wRTEaR3VIVeAhJdr/arcgis/rest/services/Parcels_Vision/FeatureServer/0",
+                "website": "https://newkentgis.maps.arcgis.com/apps/instant/basic/index.html?appid=2e178d86fad342519f25c8a3a7661868",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",


### PR DESCRIPTION
The New Kent County, VA `addresses` and `parcels` sources were failing every job for the last several weeks (`addresses` job IDs 907781, 902831, 897939; `parcels` job IDs 907782, 902832, 897940) with:

```
esridump.errors.EsriDownloadError: Could not retrieve layer metadata: Service NewKent/Public/MapServer not found
```

Root cause: the county's old GeoDecisions-hosted ArcGIS server (`parcelviewer.geodecisions.com`) no longer has a `NewKent` folder at all — the county has migrated its GIS to its own ArcGIS Online organization (`newkentgis.maps.arcgis.com`).

Fixes:
- `addresses`: now points to `AddressBPs` FeatureServer (owned by New Kent County GIS Office, tags/extent confirm New Kent-only coverage, extent `-77.24,37.38` to `-76.75,37.63` matches the county bounds, 13,190 features). Field names (`SAN`, `PRD`, `STN`, `STS`, `POD`, `MCN`, `ZIP`, `Apartment`) are unchanged from the old service, so the `conform` block is unchanged apart from the `data` URL.
- `parcels`: now points to `Parcels_Vision` FeatureServer (same New Kent GIS org, same county extent, 18,879 features, `GPIN` field preserved for `pid`).
- `website` updated to the county's current GIS viewer (`newkentgis.maps.arcgis.com`), since the old `co.newkent.state.va.us` domain no longer resolves.

`buildings` layer left untouched: it hit the same dead-server error, but I searched the full New Kent County GIS ArcGIS Online organization (97 public items — parcels, addresses, roads, water/sewer, fire, schools, etc.) and found no building footprint layer to replace it with. Per REVIEW.md, leaving it broken rather than fabricating a replacement.

Both replacements verified via `esri-explore.py` (fields present, feature counts > 0, no auth errors, extent matches New Kent County) before writing the conform, and the file validates against the schema.