### PR TITLE
Fix broken McKinley County NM addresses source

### DIFF
--- a/sources/us/nm/mckinley.json
+++ b/sources/us/nm/mckinley.json
@@ -14,12 +14,12 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://gis.gallupnm.us/server/rest/services/City_of_Gallup_Roads_and_Addresses/FeatureServer/4",
+                "data": "https://gis.gallupnm.us/server/rest/services/City_of_Gallup_Roads_and_Address_GIS/FeatureServer/4",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
-                    "number": "num",
-                    "street": ["road", "suffix"]
+                    "number": "NUM",
+                    "street": "ROADNAME"
                 }
             }
         ]


### PR DESCRIPTION
The ArcGIS service backing this source (`City_of_Gallup_Roads_and_Addresses`) was renamed on the server, causing the last 3 jobs to fail with `User couldn't access this resource`.

- The service is now published as `City_of_Gallup_Roads_and_Address_GIS`, with the county addresses at layer 4, now named `MCKINLEY_COUNTY_ADDRESS_POINTS` (12,220 features, extent spans the full county, not just the city of Gallup).
- Field names changed on the republished layer: `number` now maps to `NUM` (was `num`) and `street` now maps to `ROADNAME`, which already includes the street suffix (was `["road", "suffix"]`).
- Verified the layer returns a non-empty `fields` array, feature count > 0, no auth errors, and the projected extent (roughly 90 miles across) matches McKinley County rather than just the city.