### PR TITLE
Fix broken Dougherty County, GA addresses source

### DIFF
--- a/sources/us/ga/dougherty.json
+++ b/sources/us/ga/dougherty.json
@@ -14,11 +14,10 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://services6.arcgis.com/VKHi8CC6pMIyYUIs/ArcGIS/rest/services/Address_Point_Master_File/FeatureServer/1",
+                "data": "https://services6.arcgis.com/VKHi8CC6pMIyYUIs/ArcGIS/rest/services/Address_Point_Master_File_View_Layer/FeatureServer/1",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
-                    "id": "SITEADDID",
                     "number": "STNUM",
                     "street": [
                         "STDIR",


### PR DESCRIPTION
The Dougherty County addresses source (addresses/county) was failing with a "Token Required" (499) error — the `Address_Point_Master_File/FeatureServer/1` service became private.

Found a public replacement on the same ArcGIS server: `Address_Point_Master_File_View_Layer/FeatureServer/1`, a view layer exposing the same address point dataset (same layer name, same field names for number/street/unit). Verified:

- Fields present: STNUM, STDIR, STNAME, STSUF, SUBADD (matching original conform)
- Feature count: 41,046 (Georgia West state plane extent covering the Albany/Dougherty County area)
- No auth errors, sample records confirm correct data (e.g. 2521 CORDELE RD)

Dropped the `id` conform key (`SITEADDID`) since that field no longer exists on the view layer and `id` is optional in the schema.

Parcels and buildings layers in this source were not affected and are left unchanged.