### PR TITLE
Fix broken City of Garland, TX addresses source

### DIFF
--- a/sources/us/tx/city_of_garland.json
+++ b/sources/us/tx/city_of_garland.json
@@ -21,16 +21,17 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://services2.arcgis.com/g3rbttPStUJTjAz2/ArcGIS/rest/services/AddressPoints/FeatureServer/0",
+                "data": "https://maps2.garlandtx.gov/server1/rest/services/BASEMAP/ADDRESS/MapServer/0",
+                "website": "https://data-garland.hub.arcgis.com",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
                     "number": "STREETNUM",
                     "street": [
-                        "STREETPREF",
+                        "STREETPREFIX",
                         "STREETNAME",
                         "STREETTYPE",
-                        "STREETSUFF"
+                        "STREETSUFFIX"
                     ],
                     "unit": "UNIT",
                     "city": "CITY",


### PR DESCRIPTION
The AddressPoints FeatureServer on services2.arcgis.com started requiring a token (499 Token Required), so the last 3 weekly jobs (907970, 903020, 898128) all failed.

Replaced with the City of Garland's own hosted ArcGIS server (maps2.garlandtx.gov), layer BASEMAP/ADDRESS/MapServer/0:
- Public, no auth required
- 74,107 features, verified scoped to Garland (74,105 CITY=GARLAND, only 2 CITY=DALLAS at the city boundary)
- Field names re-verified from the layer metadata and re-mapped in conform (STREETNUM, STREETPREFIX, STREETNAME, STREETTYPE, STREETSUFFIX, UNIT, CITY, COUNTY, STATE, ZIPCODE)

Schema validated with the inline test/lib.js compile+validate check (VALID).