### PR TITLE
Fix broken White Pine County NV addresses and parcels source

### DIFF
--- a/sources/us/nv/white_pine.json
+++ b/sources/us/nv/white_pine.json
@@ -10,7 +10,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://services.arcgis.com/4YineAQdtmx0tv46/ArcGIS/rest/services/TaxParcelJoined_WhitePineNV/FeatureServer/0",
+                "data": "https://services9.arcgis.com/ihyPHe2KRRmOsTPa/arcgis/rest/services/TaxParcelJoined_WhitePineNV/FeatureServer/0",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
@@ -28,7 +28,7 @@
         "parcels": [
             {
                 "name": "county",
-                "data": "https://services.arcgis.com/4YineAQdtmx0tv46/ArcGIS/rest/services/TaxParcelJoined_WhitePineNV/FeatureServer/0",
+                "data": "https://services9.arcgis.com/ihyPHe2KRRmOsTPa/arcgis/rest/services/TaxParcelJoined_WhitePineNV/FeatureServer/0",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",


### PR DESCRIPTION
The last 3 addresses/county batch jobs (908535, 903585, 898693) all failed with `esridump.errors.EsriDownloadError: Could not retrieve layer metadata: Invalid URL Invalid URL` when hitting the ArcGIS service at `services.arcgis.com/4YineAQdtmx0tv46/.../TaxParcelJoined_WhitePineNV/FeatureServer/0`.

Root cause: the county's Sidwell-hosted parcel/address layer was migrated to a different ArcGIS Online organization. The old org (`4YineAQdtmx0tv46`) no longer hosts a service by that name; I traced the county's current published web map ("White Pine County - Parcel Viewer - New") to find the layer now lives under org `ihyPHe2KRRmOsTPa` at the same service/layer name and index.

Verified the replacement before writing the conform:
- Fields array present, same field names as before (`TSC_Site_Address`, `GIS_Parcel_Number`)
- Feature count: 7765 (reasonable for a single county, not a merged multi-county dataset)
- `maxRecordCount` is 2000, so pagination is ~4 requests — not a walltime/timeout risk
- Sampled records confirm real site addresses (e.g. "1047 WEST 900 NORTH STREET") parse correctly with the existing `prefixed_number`/`postfixed_street` conform functions
- Spatial extent matches White Pine County, NV

Both the `addresses` and `parcels` layers pointed at the same broken URL, so both were updated to the new service URL; field names and conform logic are unchanged.

Validated with the schema compiler in `test/lib.js` (VALID) and `npm test`.