### PR TITLE
Fix broken Troy, MI address source

### DIFF
--- a/sources/us/mi/troy.json
+++ b/sources/us/mi/troy.json
@@ -21,21 +21,20 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://gis.troymi.gov/arcgis/rest/services/LandManagement/MapServer/12",
-                "website": "https://www.troymi.gov/Resources/Maps.aspx",
+                "data": "https://services1.arcgis.com/5rydOpQgATDeUJrt/arcgis/rest/services/Site_Address/FeatureServer/0",
+                "website": "https://troymi.gov/departments/maps/index.php",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
-                    "number": "PropAddressNumber",
+                    "number": "AddNum",
                     "street": [
-                        "PropAddressDir",
-                        "PropAddressStreet"
+                        "Prefix",
+                        "StreetName",
+                        "Suffix"
                     ],
-                    "unit": "PropAddressApt",
-                    "postcode": "PropAddressZip",
-                    "city": "PropAddressCity",
-                    "region": "PropAddressState",
-                    "id": "PIN88"
+                    "unit": "Suite",
+                    "postcode": "ZipCode",
+                    "city": "City"
                 }
             }
         ]


### PR DESCRIPTION
The old service `gis.troymi.gov/arcgis/rest/services/LandManagement/MapServer/12` now returns HTTP 404 (the entire `gis.troymi.gov` subdomain redirects to `troymi.gov`, and the old self-hosted ArcGIS Server is gone). The city has migrated its GIS to a hosted ArcGIS Online organization (`cityoftroy.maps.arcgis.com`).

Found a replacement hosted Feature Service scoped to the city: `Site_Address` (https://services1.arcgis.com/5rydOpQgATDeUJrt/arcgis/rest/services/Site_Address/FeatureServer/0), linked from the city's current Maps page. Verified before use:

- 33,107 features, all but 3 with `City = Troy` (default value is also `Troy`) — this is a city-scoped dataset, not a regional/multi-jurisdiction layer.
- Fields confirmed via a live sample query: `AddNum`, `Prefix` (N/S/E/W directional), `StreetName`, `Suffix` (street type), `Suite`, `City`, `ZipCode`.
- Public, no auth required, geometry is Point, extent matches Troy, MI.

Updated the `addresses`/`city` layer's `data`, `website`, and `conform` field names accordingly. Validated against the schema with `test/lib.js`.