### PR TITLE
Fix broken Lake County, IN addresses source

### DIFF
--- a/sources/us/in/lake.json
+++ b/sources/us/in/lake.json
@@ -14,21 +14,22 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://services.arcgis.com/4YineAQdtmx0tv46/ArcGIS/rest/services/LakeINFeatures/FeatureServer/0",
+                "data": "https://services5.arcgis.com/8CXRnvSfSpwdf0R6/arcgis/rest/services/Lake_County_Address_Points/FeatureServer/0",
+                "website": "https://www.arcgis.com/home/item.html?id=669de11237c14fb1b14295e7497387d8",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
-                    "number": "Address",
+                    "number": "Add_Number",
                     "street": [
-                        "Prefix",
-                        "Name",
-                        "Type",
-                        "Suffix"
+                        "St_PreDir",
+                        "St_Name",
+                        "St_PosTyp",
+                        "St_PosDir"
                     ],
-                    "unit": "Apartment",
-                    "city": "City",
+                    "unit": "Unit_Id",
+                    "city": "Post_Comm",
                     "region": "State",
-                    "postcode": "Zipcode"
+                    "postcode": "Post_Code"
                 }
             }
         ]


### PR DESCRIPTION
The Lake County, IN addresses source (sources/us/in/lake.json) has been failing for its last 3 weekly runs with an ESRI \"Invalid URL\" error - the old service (LakeINFeatures on the 4YineAQdtmx0tv46 ArcGIS Online org) no longer exists under that name, and no similarly-named service could be found in that org's service listing.

Found a replacement: the county's own public ArcGIS Online feature service "Lake_County_Address_Points", hosted under the county's own org (owner: lakecountyod) and explicitly described as address points within Lake County, Indiana.

- Layer: addresses (name: county)
- New source: https://services5.arcgis.com/8CXRnvSfSpwdf0R6/arcgis/rest/services/Lake_County_Address_Points/FeatureServer/0
- Verified: fields array present, 201,193 features (reasonable for a single county), no auth errors, extent matches Lake County IN (state plane 2245), sampled records confirm County = "Lake County".
- Field names re-verified from the live service (`?f=json` and sample queries) rather than reused from the old conform - all field names changed (e.g. `Add_Number`, `St_Name`, `St_PosTyp`, `Unit_Id`, `Post_Comm`, `Post_Code`).
- Note for maintainers: the AGOL item's `licenseInfo` includes a standard county-GIS disclaimer requiring attribution to the Lake County Surveyor's Office on redistribution and stating the data "may not be used for commercial purposes." Flagging this for awareness since it wasn't previously recorded on this source; happy to add a `license` block if desired.

Schema validated locally with the inline `test/lib.js` compile+validate check (VALID) and `npm test` (only 2 pre-existing, unrelated failures in accuracy-value edge case tests).