### PR TITLE
Fix broken Bristol Bay Borough AK addresses source

### DIFF
--- a/sources/us/ak/bristol_bay_borough.json
+++ b/sources/us/ak/bristol_bay_borough.json
@@ -14,22 +14,22 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://services2.arcgis.com/bmtnfSbBQqIXiln2/ArcGIS/rest/services/BBB_Addresses_1227_2022/FeatureServer/0",
-                "website": "https://www.arcgis.com/home/item.html?id=bfe52f1b60dc4512927bcb1971e146c1",
+                "data": "https://services2.arcgis.com/bmtnfSbBQqIXiln2/ArcGIS/rest/services/Addresspoints03212023/FeatureServer/0",
+                "website": "https://www.arcgis.com/home/item.html?id=ae463511163d40d5b6a91a312cd77f5c",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
                     "number": {
                         "function": "prefixed_number",
-                        "field": "REV_Street"
+                        "field": "REV_Stre_2"
                     },
                     "street": {
                         "function": "postfixed_street",
-                        "field": "REV_Street"
+                        "field": "REV_Stre_2"
                     },
-                    "city": "REV_City_1",
-                    "region": "REV_Stat_1",
-                    "postcode": "REV_ZIP_1"
+                    "city": "REV_City_3",
+                    "region": "REV_Stat_3",
+                    "postcode": "REV_ZIP_13"
                 }
             }
         ],


### PR DESCRIPTION
The ArcGIS FeatureServer used by this source (`BBB_Addresses_1227_2022`) has been deleted, causing the last 3 jobs to fail with `EsriDownloadError: Could not retrieve layer metadata: Invalid URL`.

Found a replacement service on the same ArcGIS Online org (`bmtnfSbBQqIXiln2`, owned by the borough's GIS contact `Ingrid.Eng@Alaska`): `Addresspoints03212023`. Verified before switching:

- 979 features, all in Naknek, King Salmon, and South Naknek — the three communities that make up Bristol Bay Borough (confirmed via distinct city values in the data).
- Service extent (~-157.08 to -156.45 lon, ~58.62 to 58.76 lat) matches the borough's location.
- Public access, no auth errors, fields array present.
- Field names re-verified directly from the service (they differ from the old service): `REV_Stre_2`, `REV_City_3`, `REV_Stat_3`, `REV_ZIP_13`.

Other similarly-named services on the same org (`Addresses_04112024`, `ADDRESSES_01222024`) were checked and rejected — their sample data is for Shaktoolik, AK, which is a different, unrelated jurisdiction hosted on the same shared ArcGIS org.

Parcels layer (`NN_MERGE_RALPH`) was checked and is still live, so it was left unchanged.