### PR TITLE
Fix broken Utah County UT addresses source

### DIFF
--- a/sources/us/ut/utah.json
+++ b/sources/us/ut/utah.json
@@ -35,6 +35,11 @@
                     "city": "CITY",
                     "region": "STATE",
                     "postcode": "ZIPCODE"
+                },
+                "request": {
+                    "headers": {
+                        "User-Agent": "OpenAddresses/1.0 (https://openaddresses.io)"
+                    }
                 }
             }
         ],


### PR DESCRIPTION
The addresses/county source for Utah County, UT (`sources/us/ut/utah.json`) has been failing for at least 3 consecutive weekly runs (job IDs 898038, 902930, 907880) with:

```
openaddr.cache.DownloadError: 401 response from https://maps.utahcounty.gov/data4export/AddressPoints.zip
```

Investigation:

- The county's `maps.utahcounty.gov` host now returns a 401 for requests without a `User-Agent` header (a WAF/bot-blocking rule), while the same URL returns 200 with a valid shapefile ZIP when any explicit `User-Agent` is sent. Confirmed with `curl` both with and without the header.
- The 401 error page itself links to a new bulk-download portal (`is.utahcounty.gov/gis/downloads`), which lists the exact same download URLs — confirming the URL itself is still correct and current, this is purely a header/bot-blocking issue.
- Downloaded and inspected the shapefile with `ogrinfo`: 246,542 point features, correct Utah County extent, and all fields referenced by the existing `conform` (`ADDRESSID`, `ADDRNUM`, `ROADPREDIR`, `ROADNAME`, `ROADTYPE`, `ROADPOSTDI`, `UNITTYPE`, `UNITID`, `CITY`, `STATE`, `ZIPCODE`) are unchanged.
- Considered replacing with the UGRC statewide `UtahAddressPoints` ArcGIS FeatureServer (used by `sources/us/ut/statewide.json`), but rejected it since it's a statewide/multi-county service already covered by the existing statewide source, not a county-specific replacement.

Fix: added a `request.headers.User-Agent` override to the addresses/county layer (same pattern already used in `sources/us/il/champaign.json`) so the download passes the county's bot filter. No conform or URL changes needed.

Note: `parcels` and `buildings` layers on this same host likely have the same 401 issue, but they're out of scope for this fix and left untouched.