### PR TITLE
Fix broken city of Albuquerque addresses source

### DIFF
--- a/sources/us/nm/albuquerque.json
+++ b/sources/us/nm/albuquerque.json
@@ -22,7 +22,7 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://coagisweb.cabq.gov/arcgis/rest/services/public/cadastral/MapServer/6",
+                "data": "https://coageo.cabq.gov/cabqgeo/rest/services/public/Address_Points/MapServer/0",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",


### PR DESCRIPTION
The city of Albuquerque addresses source (`sources/us/nm/albuquerque.json`) has been failing consistently (jobs 908594, 903644, 898752).

Root cause: the old ArcGIS server `coagisweb.cabq.gov` now returns a 302 redirect to `https://www.cabq.gov/gis` (an HTML landing page) instead of serving the ArcGIS REST API, so the old layer at `public/cadastral/MapServer/6` no longer exists.

Fix: found the city's replacement GIS server at `coageo.cabq.gov`, which hosts a dedicated `public/Address_Points/MapServer/0` layer with the same field names as before (STREETNUMBER, STREETNAME, STREETDESIGNATION, STREETQUADRANT, APARTMENT). Verified the layer directly:

- 257,610 features, consistent with a citywide address point layer for Albuquerque
- No auth/token errors
- Same field schema as the previous working source, so the existing conform mapping applies unchanged
- Hosted on the city's own GIS server under the same `public/` folder structure as the old cadastral service, not a shared/regional multi-jurisdiction dataset

Only the `data` URL changed; the conform mapping is unchanged.