### PR TITLE
Fix broken Franklin County, NC addresses source

### DIFF
--- a/sources/us/nc/franklin.json
+++ b/sources/us/nc/franklin.json
@@ -14,18 +14,16 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://arcgis4.roktech.net/arcgis/rest/services/Franklin/baseGoMaps4/MapServer/9",
+                "data": "https://www.franklincountymaps.net/arcgis/rest/services/OperationalLayers/MapServer/1",
+                "website": "https://www.franklincountymaps.net/maps/",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
-                    "number": "B_ADDRESS",
-                    "street": [
-                        "ROAD_PRE",
-                        "ROAD_NAME",
-                        "ROAD_TYPE",
-                        "ROAD_SUF"
-                    ],
-                    "unit": "ADDSUF"
+                    "number": "Add_Number",
+                    "street": "L_FullName",
+                    "unit": "AddNum_Suf",
+                    "city": "Post_Comm",
+                    "postcode": "Post_Code"
                 }
             }
         ]


### PR DESCRIPTION
The county's previous ArcGIS host (arcgis4.roktech.net) no longer serves the Franklin service — the server's root services listing (checked on arcgis4 and its sibling arcgis5) shows the Franklin folder is gone entirely, and the last 3 batch jobs (908825, 903875, 898983) all failed with `Service Franklin/baseGoMaps4/MapServer not found`.

Found the county's current GIS platform at https://www.franklincountymaps.net/maps/ (linked from the county's GIS/Mapping Department page). Its app config (`assets/config/gis.json`) points to an ArcGIS Server at `https://www.franklincountymaps.net/arcgis/rest/services/OperationalLayers/MapServer`, layer 1 'Address Points'.

Verified before writing the conform:
- `?f=json` returns a valid fields array, no auth errors
- Feature count: 43,984 (reasonable for this county, and the service/extent is scoped to Franklin County NC specifically — not a regional/multi-county dataset)
- `maxRecordCount` is 2000 with pagination supported, so the ~22-page pull is not a walltime risk
- Sampled records confirm field values (Add_Number, L_FullName, AddNum_Suf, Post_Comm, Post_Code) and geographic extent match Franklin County, NC towns (Louisburg, Henderson, etc.)
- No FeatureServer sibling is available on this server (returns a 500 'featureserver not found' error), so MapServer is used as before

Updated the conform to use the new field names and added a `website` pointing to the map portal.