### PR TITLE
Fix broken City of Commerce City, CO address source

### DIFF
--- a/sources/us/co/city_of_commerce_city.json
+++ b/sources/us/co/city_of_commerce_city.json
@@ -21,7 +21,7 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://arcgis.c3gov.com/arcgis/rest/services/Open_Data/CommerceCity_OpenData/MapServer/0",
+                "data": "https://gisserver.c3gov.com/gisserver/rest/services/Open_Data/Commerce_City_Open_Data/MapServer/2",
                 "website": "https://data-c3.opendata.arcgis.com/datasets/83e8b92b2d294cf6be802dd1e53561da_0/explore",
                 "license": {
                     "attribution name": "City of Commerce City",
@@ -30,13 +30,11 @@
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
-                    "number": "ADDR_HN",
-                    "street": "COMPLETE_ST_NAME",
-                    "unit": "COMPLETE_SUBADDR",
-                    "city": "ADDR_CITY",
-                    "district": "COUNTY",
-                    "region": "STATE",
-                    "postcode": "ZIP_CODE"
+                    "number": "SITE_NUM_COMPLETE",
+                    "street": "ST_NAME_COMPLETE",
+                    "unit": "SUBADDR_COMPLETE",
+                    "city": "CITY",
+                    "postcode": "ZIP"
                 }
             }
         ]


### PR DESCRIPTION
The addresses/city source for Commerce City, CO was failing (jobs 900516, 905412, 910362, spanning Aug 28 - Sep 11) with a 504 Gateway Timeout while fetching ESRI layer metadata from `arcgis.c3gov.com`.

The old host `arcgis.c3gov.com` still resolves and completes a TLS handshake but hangs indefinitely on any `rest/services` request (confirmed directly, not just via the batch job). Looking up the dataset's ArcGIS Online item (id `83e8b92b2d294cf6be802dd1e53561da`) showed the city migrated this service to a new host: `gisserver.c3gov.com`, under a renamed service (`Commerce_City_Open_Data` instead of `CommerceCity_OpenData`) with the Addresses layer now at index 2 instead of 0.

Verified the new layer before writing the conform:
- `https://gisserver.c3gov.com/gisserver/rest/services/Open_Data/Commerce_City_Open_Data/MapServer/2` returns valid metadata, geometry type Point, no auth errors.
- 35,289 features, all sampled records show `CITY: COMMERCE CITY` — this is the city's own GIS server (not a shared regional/county dataset), so coverage still matches the city-only source.
- `maxRecordCount` is 2000 with pagination support, so no walltime/pagination risk.
- Field names changed since the old service: `SITE_NUM_COMPLETE`, `ST_NAME_COMPLETE`, `SUBADDR_COMPLETE`, `CITY`, `ZIP` (verified via `?f=json` and a sample query). The old `COUNTY`/`STATE` fields no longer exist on this layer, so `district`/`region` were dropped from the conform rather than guessed.

Updated `data` URL and `conform` field names accordingly; `website` and `license` left unchanged since the ArcGIS Hub dataset page is still live.