### PR TITLE
Fix broken Berkeley County, WV addresses and parcels sources

### DIFF
--- a/sources/us/wv/berkeley.json
+++ b/sources/us/wv/berkeley.json
@@ -14,24 +14,27 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://maps.berkeleywv.org/bclive/rest/services/BC_GENERAL/DYN_ADDRESSES/MapServer/0",
+                "data": "https://services3.arcgis.com/XEKxIX32keB27PXV/arcgis/rest/services/Address_911/FeatureServer/0",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
-                    "number": "ADDRNUMBER",
-                    "street": "STREETNAME",
-                    "unit": "UNITID",
-                    "city": "CITY",
-                    "district": "COUNTY",
-                    "region": "STATE",
-                    "postcode": "ZIP"
+                    "number": "housenum",
+                    "street": {
+                        "function": "regexp",
+                        "field": "fulladdr",
+                        "pattern": "^[0-9]+\\s+(.*?)(?:\\s+(?:APT|STE|UNT)\\s+\\S+)?$",
+                        "replace": "$1"
+                    },
+                    "unit": "unitnumber",
+                    "city": "bc_city",
+                    "postcode": "zipcode"
                 }
             }
         ],
         "parcels": [
             {
                 "name": "county",
-                "data": "https://maps.berkeleywv.org/bclive/rest/services/BC_GENERAL/DYN_ASSESSOR/MapServer/1",
+                "data": "https://services3.arcgis.com/XEKxIX32keB27PXV/arcgis/rest/services/Public_Taxparcels/FeatureServer/0",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",


### PR DESCRIPTION
The county's own ArcGIS server (maps.berkeleywv.org/bclive) has been returning a server-side error ("Could not access any server machines") on every layer for the last several weeks, causing the addresses, parcels, and buildings jobs to all fail identically with `KeyError: 'fields'`.

Found a public replacement hosted by the Berkeley County Assessor's Office (bcao.maps.arcgis.com), used by their own live Tax Maps web app:

- addresses: `https://services3.arcgis.com/XEKxIX32keB27PXV/arcgis/rest/services/Address_911/FeatureServer/0` — 63,112 features, all `county = BERKELEY` (matches total count exactly, confirming it's county-scoped, not regional). Verified fields and rewrote the conform: street name/type fields on this service are unpopulated, so `street` is extracted from the combined `fulladdr` field via regexp (stripping the leading house number and any trailing unit suffix); `number` comes from `housenum`, `unit` from `unitnumber`, `city` from `bc_city`, `postcode` from `zipcode`.
- parcels: `https://services3.arcgis.com/XEKxIX32keB27PXV/arcgis/rest/services/Public_Taxparcels/FeatureServer/0` — 63,379 features, same `PARID` field/format as the old source, confirmed working.

No replacement was found for the buildings layer (no footprints/buildings service exists on the same org), so it is left as-is/broken. I searched the assessor's org service listing, ArcGIS Online, and the county's GIS pages and found nothing else suitable — a maintainer may want to leave this layer broken or drop it in a follow-up.

Verified both replacement services return valid `fields` metadata, feature counts > 0, no auth errors, and reasonable `maxRecordCount` relative to feature count (no pagination/timeout risk). Schema validated with the repo's `test/lib.js` compile+validate check.