### PR TITLE
Fix broken Crook County, WY addresses and parcels source

### DIFF
--- a/sources/us/wy/crook.json
+++ b/sources/us/wy/crook.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://crookela.centralus.cloudapp.azure.com/server/rest/services/Crook/GrowthAndDevelopmentData/MapServer/0",
+                "data": "https://cwn.geographicinnovations.com/arcgis/rest/services/CrookCounty/GrowthDevelopmentMaintainedData/MapServer/0",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
@@ -26,14 +26,14 @@
                         "function": "postfixed_street",
                         "field": "ADDRESS"
                     },
-                    "city": "Community"
+                    "city": "COMMUNITY"
                 }
             }
         ],
         "parcels": [
             {
                 "name": "county",
-                "data": "https://crookela.centralus.cloudapp.azure.com/server/rest/services/Crook/AssessorData/MapServer/5",
+                "data": "https://cwn.geographicinnovations.com/arcgis/rest/services/CrookCounty/AssessorMaintainedData/MapServer/5",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",


### PR DESCRIPTION
The old server \`crookela.centralus.cloudapp.azure.com\` has gone away entirely (DNS NXDOMAIN). The last 3 addresses/county jobs (897420, 902312, 907262) all failed with the same \`NameResolutionError\` going back to at least 2026-08-28. The parcels layer pointed at the same dead host and would fail identically.

Crook County has since moved their GIS hosting to \`cwn.geographicinnovations.com\` (found via their public "Crook County Cloud Viewer" ArcGIS web map, item \`bd8a9c739e1046fcaf27ca2fb5106ac2\`). Updated both layers to the new host:

- \`addresses\`: \`CrookCounty/GrowthDevelopmentMaintainedData/MapServer/0\` — same \`ADDRESS\`/city field schema as before (city field is now \`COMMUNITY\`, all caps), 5600 features, extent consistent with Crook County (WY State Plane East, NAD83).
- \`parcels\`: \`CrookCounty/AssessorMaintainedData/MapServer/5\` — same \`PIDN\` field as before, 6840 features.

Both layers verified directly against the ArcGIS REST endpoints (fields, feature counts, sample records, extent) before writing the conform — no auth errors, no empty fields array, county-scoped (not a multi-county regional dataset).

Schema validated via \`test/lib.js\` and \`npm test\` (2 pre-existing unrelated test failures confirmed present on master as well, not caused by this change).