### PR TITLE
Fix broken Orangeburg County, SC addresses, parcels, and buildings sources

### DIFF
--- a/sources/us/sc/orangeburg.json
+++ b/sources/us/sc/orangeburg.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://gis2.orangeburgcounty.org/dataportal/rest/services/SiteAddressesView/MapServer/0",
+                "data": "https://services2.arcgis.com/bUKn95BqgpYYTnx3/arcgis/rest/services/Main_Public_Tax_Parcel_Map_WFL1/FeatureServer/1",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
@@ -32,7 +32,7 @@
         "parcels": [
             {
                 "name": "county",
-                "data": "https://gis2.orangeburgcounty.org/dataportal/rest/services/TaxParcelsAssessor/MapServer/2",
+                "data": "https://services2.arcgis.com/bUKn95BqgpYYTnx3/arcgis/rest/services/Main_Public_Tax_Parcel_Map_WFL1/FeatureServer/0",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
@@ -43,7 +43,7 @@
         "buildings": [
             {
                 "name": "county",
-                "data": "https://gis2.orangeburgcounty.org/dataportal/rest/services/BuildingFootprints/MapServer/0",
+                "data": "https://services2.arcgis.com/bUKn95BqgpYYTnx3/arcgis/rest/services/Main_Public_Tax_Parcel_Map_WFL1/FeatureServer/6",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson"


### PR DESCRIPTION
The old server at gis2.orangeburgcounty.org (used by all three layers) has been unreachable (connection refused) on every weekly job since 2026-06-12, roughly three months of consistent failures across addresses, parcels, and buildings (last success 2026-02-20).

The county has republished the same underlying dataset as a hosted Feature Service on ArcGIS Online: `Main_Public_Tax_Parcel_Map_WFL1`. Verified before switching:

- Addresses (layer 1): 59,304 features, same field names as before (ADD_STNUM, ADD_STREET, ADD_EXT, ADD_TOWN, ADD_STATE, ADD_ZIP), sampled records confirm `COUNTY: ORANGEBURG COUNTY` and extent matches the county.
- Parcels (layer 0): 62,519 features, same `MAPBLOLOT` pid field as before.
- Buildings (layer 6): 90,283 features, polygon geometry.

No auth errors, no coverage widening — this is the same authoritative county dataset, just moved hosts.