### PR TITLE
Fix broken Gwinnett County, GA addresses source

### DIFF
--- a/sources/us/ga/gwinnett.json
+++ b/sources/us/ga/gwinnett.json
@@ -16,22 +16,22 @@
                 "name": "county",
                 "website": "https://gcgis-gwinnettcountyga.hub.arcgis.com/",
                 "protocol": "ESRI",
-                "data": "https://gis3.gwinnettcounty.com/dataserver/rest/services/Hosted/GwinnettTransportation/FeatureServer/0",
+                "data": "https://services3.arcgis.com/RfpmnkSAQleRbndX/arcgis/rest/services/GwinnettTransportation/FeatureServer/0",
                 "conform": {
                     "format": "geojson",
                     "number": [
-                        "preeaddrnum",
-                        "addrnum",
-                        "addrnumsuf"
+                        "PREADDRNUM",
+                        "ADDRNUM",
+                        "ADDRNUMSUF"
                     ],
-                    "street": "fullname",
+                    "street": "FULLNAME",
                     "unit": [
-                        "unittype",
-                        "unitid"
+                        "UNITTYPE",
+                        "UNITID"
                     ],
-                    "city": "municipality",
-                    "region": "state",
-                    "postcode": "zip5"
+                    "city": "MUNICIPALITY",
+                    "region": "STATE",
+                    "postcode": "ZIP5"
                 }
             }
         ],


### PR DESCRIPTION
The county's own ArcGIS dataserver (gis3.gwinnettcounty.com) removed the `Hosted/GwinnettTransportation` service (now returns `Service not found`), which broke the addresses layer's last 3+ weekly jobs.

Found the same dataset (owner: GwinnettCountyGIS, same service name `GwinnettTransportation`, same layer title "Site Address Point") now hosted on ArcGIS Online instead: https://services3.arcgis.com/RfpmnkSAQleRbndX/arcgis/rest/services/GwinnettTransportation/FeatureServer/0

Verified before writing the conform:
- Public, no auth required, 414,619 features (reasonable for a single county)
- Sample records show cities within Gwinnett County (Suwanee, Duluth) with STATE=GA
- Field names changed case (e.g. `addrnum` -> `ADDRNUM`, `fullname` -> `FULLNAME`) but map 1:1 to the old conform's fields

Only the `addresses`/`county` layer is fixed here. The `parcels` and `buildings` layers in the same file are also currently broken (their source services were likewise removed from the county dataserver) but are out of scope for this PR.