### PR TITLE
Fix broken Lincoln County, NC addresses source

### DIFF
--- a/sources/us/nc/lincoln.json
+++ b/sources/us/nc/lincoln.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://arcgisserver.lincolncounty.org/arcgis/rest/services/Events/MapServer/0",
+                "data": "https://arcgisserver.lincolncounty.org/arcgis/rest/services/ComDevData/MapServer/2",
                 "protocol": "ESRI",
                 "website": "https://www.co.lincoln.nc.us/index.aspx?NID=470",
                 "conform": {


### PR DESCRIPTION
The addresses/county layer was pointing at `Events/MapServer/0`, which the server now reports as "Service Events/MapServer not started" (jobs 908804, 903854, 898962 all failed with this error). The `Events` service no longer appears at all in the server's root services listing.

Found the county's live master address point layer at `ComDevData/MapServer/2` ("SiteAddressPoint") on the same server. It has the identical field schema as the old service (PREADDRNUM, ADDRNUM, ADDRNUMSUF, FULLNAME, RDTYPE, POST_DIR, UNITTYPE, UNITID, ZIP), returns 46,678 features with no auth errors, and sample records show Lincoln County zip codes (28080, 28092) and municipalities (LINCOLNTON, UNINCORPORATED), confirming it's scoped to the county rather than a regional dataset.

Updated `data` to the new layer URL; the conform is unchanged since the field names carried over exactly.

- Layer: addresses / county
- New source: https://arcgisserver.lincolncounty.org/arcgis/rest/services/ComDevData/MapServer/2