### PR TITLE
Fix broken Kenai Peninsula Borough AK addresses source

### DIFF
--- a/sources/us/ak/kenai_peninsula_borough.json
+++ b/sources/us/ak/kenai_peninsula_borough.json
@@ -31,6 +31,7 @@
                     ],
                     "number": "HouseNumbe",
                     "format": "shapefile",
+                    "file": "PhysicalAddresses.shp",
                     "postcode": "ZIP_CODE",
                     "city": "COMM_NAME"
                 }


### PR DESCRIPTION
The addresses/county job for this source has been failing (job IDs 910822, 905872, 900974). The job log shows the root cause:

```
WARNING: Multiple shapefiles found, but source has no file attribute.
WARNING: Found no features in source data
WARNING: Nothing processed
Error: out.geojson not found
```

The zip at `ftp://ftp.borough.kenai.ak.us/GIS/Downloads/Shapefiles/PhysicalAddress.zip` contains two shapefiles (`PhysicalAddresses.shp` and `Streets.shp`), and the conform had no `file` attribute to disambiguate which one to use, so the pipeline picked neither and processed zero features.

Fix: add `"file": "PhysicalAddresses.shp"` to the addresses conform so the correct shapefile is selected from the zip.