### PR TITLE
Fix broken Clayton County GA addresses source

### DIFF
--- a/sources/us/ga/clayton.json
+++ b/sources/us/ga/clayton.json
@@ -16,7 +16,7 @@
                 "name": "county",
                 "website": "https://www.claytoncountyga.gov/departments/community-development/geographic-information-system.aspx",
                 "attribution": "Clayton County",
-                "data": "https://weba.claytoncountyga.gov:5443/server/rest/services/Reference/AddressPoints/MapServer/0",
+                "data": "https://gis.claytoncountyga.gov/server/rest/services/Reference/AddressPoints/MapServer/0",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",


### PR DESCRIPTION
The addresses layer's ArcGIS server (weba.claytoncountyga.gov:5443) has been returning "Could not access any server machines" for every weekly job since job 851850 (2026-06-12) through the latest run 910004 (2026-09-11) — a whole-server outage confirmed across the last several weeks, affecting both the addresses and parcels layers on that host.

Found that Clayton County's GIS moved to a new ArcGIS Server host at gis.claytoncountyga.gov, hosting the same Reference/AddressPoints MapServer layer with identical field names (ADDRNUM, PREDIR, ROADNAME, ROADTYPE, POSTDIR, UNITTYPE, UNITID, MUNICIPALITY, ZIP). Verified:

- Service returns valid JSON with a full fields array, no auth errors
- Feature count is 134,238 (matches returnCountOnly query)
- Sample records confirm COUNTY: CLAYTON scoping (not a merged regional dataset)
- Field names are unchanged from the old service, so the conform mapping did not need to change

Only the `data` URL was updated to point at the new host.