### PR TITLE
Fix broken Harford County, MD addresses source

### DIFF
--- a/sources/us/md/harford.json
+++ b/sources/us/md/harford.json
@@ -14,18 +14,18 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://geodata.md.gov/appdata/rest/services/Addressing/MD_Addressing/MapServer/13",
+                "data": "https://mdgeodata.md.gov/appdata/rest/services/Addressing/MD_Addressing/MapServer/13",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
-                    "id": "ADDID",
-                    "number": "ADDNUMCPLT",
-                    "street": "NAMECPLT",
-                    "unit": "SUBBADDCPLT",
-                    "city": "CITY",
-                    "district": "COUNTY",
-                    "region": "STATE",
-                    "postcode": "ZIPCODE"
+                    "id": "Add_Id",
+                    "number": "Add_Number",
+                    "street": ["St_PreDir", "St_Name", "St_PosTyp", "St_PosDir"],
+                    "unit": "Unit",
+                    "city": "Post_Comm",
+                    "district": "County",
+                    "region": "State",
+                    "postcode": "Post_Code"
                 }
             }
         ],

--- a/sources/us/md/harford.json
+++ b/sources/us/md/harford.json
@@ -20,11 +20,19 @@
                     "format": "geojson",
                     "id": "Add_Id",
                     "number": "Add_Number",
-                    "street": ["St_PreDir", "St_Name", "St_PosTyp", "St_PosDir"],
+                    "street": [
+                        "St_PreDir",
+                        "St_Name",
+                        "St_PosTyp",
+                        "St_PosDir"
+                    ],
                     "unit": "Unit",
                     "city": "Post_Comm",
                     "district": "County",
-                    "region": "State",
+                    "region": {
+                        "function": "constant",
+                        "value": "MD"
+                    },
                     "postcode": "Post_Code"
                 }
             }


### PR DESCRIPTION
The addresses/county source pointed at https://geodata.md.gov/appdata/rest/services/Addressing/MD_Addressing/MapServer/13, which has been returning HTTP 503 "Site Maintenance" for the whole geodata.md.gov host since at least 2026-09-04 (jobs 904306 and 909256 both failed on this, and the host is still down as of today).

The same layer (MapServer layer 13, named "Harford", same 115,238-record Harford-County-only extent) is live under an alternate hostname for Maryland's statewide addressing service: https://mdgeodata.md.gov/appdata/rest/services/Addressing/MD_Addressing/MapServer/13. Verified:

- `?f=json` returns valid metadata, no auth error
- Feature count: 115,238, all `County` = "Harford County"
- Spatial extent matches Harford County (~-76.57 to -76.08 lon, 39.39 to 39.72 lat)

The field schema on this layer has also changed since the source was last updated (from `ADDID`/`ADDNUMCPLT`/`NAMECPLT`/etc. to NENA-style `Add_Id`/`Add_Number`/`St_Name`/`St_PreDir`/`St_PosTyp`/`St_PosDir`/`Unit`/`Post_Comm`/`County`/`State`/`Post_Code`), so `conform` was rewritten to match the current field names, verified against sample records.