### PR TITLE
Fix broken Somerset County, MD addresses source

### DIFF
--- a/sources/us/md/somerset.json
+++ b/sources/us/md/somerset.json
@@ -30,7 +30,10 @@
                     "unit": "Unit",
                     "city": "Post_Comm",
                     "district": "County",
-                    "region": "State",
+                    "region": {
+                        "function": "constant",
+                        "value": "MD"
+                    },
                     "postcode": "Post_Code"
                 }
             }

--- a/sources/us/md/somerset.json
+++ b/sources/us/md/somerset.json
@@ -14,18 +14,24 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://geodata.md.gov/appdata/rest/services/Addressing/MD_Addressing/MapServer/22",
+                "data": "https://mdgeodata.md.gov/appdata/rest/services/Addressing/MD_Addressing/MapServer/22",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
-                    "id": "ADDID",
-                    "number": "ADDNUMCPLT",
-                    "street": "NAMECPLT",
-                    "unit": "SUBBADDCPLT",
-                    "city": "CITY",
-                    "district": "COUNTY",
-                    "region": "STATE",
-                    "postcode": "ZIPCODE"
+                    "id": "Add_Id",
+                    "number": "Add_Number",
+                    "street": [
+                        "St_PreDir",
+                        "St_PreTyp",
+                        "St_Name",
+                        "St_PosTyp",
+                        "St_PosDir"
+                    ],
+                    "unit": "Unit",
+                    "city": "Post_Comm",
+                    "district": "County",
+                    "region": "State",
+                    "postcode": "Post_Code"
                 }
             }
         ]


### PR DESCRIPTION
The Somerset County addresses source used the old `geodata.md.gov` host, which has been returning a persistent \"Site Maintenance\" 503 page for at least 7+ weeks (confirmed via jobs 909241 and 904291, and job history going back to at least June).

The state's ArcGIS services have moved to a new host, `mdgeodata.md.gov`. The equivalent `Addressing/MD_Addressing/MapServer` service exists there with the same layer 22 for Somerset County (12,231 features, verified via `esri-explore.py`). Field names changed in the new service, so the conform was rewritten:

- `number`: `ADDNUMCPLT` -> `Add_Number`
- `street`: `NAMECPLT` -> `["St_PreDir", "St_PreTyp", "St_Name", "St_PosTyp", "St_PosDir"]`
- `unit`: `SUBBADDCPLT` -> `Unit`
- `city`: `CITY` -> `Post_Comm`
- `district`: `COUNTY` -> `County`
- `region`: `STATE` -> `State`
- `postcode`: `ZIPCODE` -> `Post_Code`
- `id`: `ADDID` -> `Add_Id`

Verified feature count, fields, and a data sample against the new service before writing the conform. Schema validated with `test/lib.js`.