### PR TITLE
Fix broken Bonneville County, ID addresses source

### DIFF
--- a/sources/us/id/bonneville.json
+++ b/sources/us/id/bonneville.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://bonneville.esriemcs.com/arcgis/rest/services/BC_Address/FeatureServer/0",
+                "data": "https://gis.bonnevillecountyidaho.gov/hosted/rest/services/BC_Address/FeatureServer/0",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",


### PR DESCRIPTION
The addresses/county source for Bonneville County, ID has been failing for months (last success in January 2026; 13+ consecutive weekly job failures since then, jobs 909703, 904753, 899857, etc.) with:

```
Could not retrieve layer metadata HTTP 503 Service Temporarily Unavailable
```

The entire old host (`bonneville.esriemcs.com`) is confirmed down server-wide — even the root `/arcgis/rest/services` listing and the base domain return 503, with and without a browser User-Agent. The county's `parcels` layer on the same host is also failing for the same reason (out of scope for this PR).

Searched the county's ArcGIS Online organization (`bonneville.maps.arcgis.com`, org id `Xd5SMhLZ1h9t0F3b`) and found the county has migrated its hosted services to a new server, `gis.bonnevillecountyidaho.gov`, which serves an equivalent `BC_Address` FeatureServer with identical field names (`addressnum`, `streetpref`, `streetname`, `streetsuff`, `city`, `state`, `zip`) and address data scoped to Bonneville County (69,624 features, sample records confirm Bonneville County cities like Ammon, ID).

Updated the `data` URL to:
`https://gis.bonnevillecountyidaho.gov/hosted/rest/services/BC_Address/FeatureServer/0`

No conform changes were needed since field names are unchanged. Verified feature count > 0, no auth errors, and validated against the schema.