### PR TITLE
Fix broken Talbot County, MD addresses source

### DIFF
--- a/sources/us/md/talbot.json
+++ b/sources/us/md/talbot.json
@@ -14,18 +14,23 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://geodata.md.gov/appdata/rest/services/Addressing/MD_Addressing/MapServer/23",
+                "data": "https://mdgeodata.md.gov/appdata/rest/services/Addressing/MD_Addressing/MapServer/23",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
-                    "id": "ADDID",
-                    "number": "ADDNUMCPLT",
-                    "street": "NAMECPLT",
-                    "unit": "SUBBADDCPLT",
-                    "city": "CITY",
-                    "district": "COUNTY",
-                    "region": "STATE",
-                    "postcode": "ZIPCODE"
+                    "id": "Add_Id",
+                    "number": "Add_Number",
+                    "street": [
+                        "St_PreDir",
+                        "St_Name",
+                        "St_PosTyp",
+                        "St_PosDir"
+                    ],
+                    "unit": "Unit",
+                    "city": "Post_Comm",
+                    "district": "County",
+                    "region": "State",
+                    "postcode": "Post_Code"
                 }
             }
         ],


### PR DESCRIPTION
The `addresses`/`county` layer has been failing for 2+ weeks with a persistent HTTP 503 ("Site Maintenance") from `geodata.md.gov`. The entire `geodata.md.gov` host is currently returning 503 for every path, confirming a sustained outage rather than a transient blip.

Maryland's statewide address point service (`Addressing/MD_Addressing/MapServer`, with a dedicated per-county sub-layer, layer 23 = Talbot) is also reachable at an alternate, currently-working hostname: `mdgeodata.md.gov`. This is the same per-county-scoped layer as before (not a widened/regional dataset) — verified:

- Layer name is "Talbot", `County` attribute is "Talbot County" on all sampled records, `AddSource` is "TALBOT COUNTY"
- Feature count: 23,918 (reasonable for a single county, not statewide)
- Fields present, no auth errors

The schema on this host has changed since the old `geodata.md.gov` endpoint (old fields like `ADDNUMCPLT`/`NAMECPLT` no longer exist), so the conform was rebuilt against the current field names (`Add_Number`, `St_PreDir`/`St_Name`/`St_PosTyp`/`St_PosDir`, `Unit`, `Post_Comm`, `County`, `State`, `Post_Code`) — consistent with the same schema already used by `sources/us/md/washington.json` and `sources/us/md/dorchester.json`.

- Layer: addresses
- Source: https://mdgeodata.md.gov/appdata/rest/services/Addressing/MD_Addressing/MapServer/23
- Validated with `npm test` / schema compiler