### PR TITLE
Fix broken Clallam County, WA addresses source

### DIFF
--- a/sources/us/wa/clallam.json
+++ b/sources/us/wa/clallam.json
@@ -18,17 +18,20 @@
                     "format": "geojson",
                     "number": "SITUS_ADDR",
                     "street": [
-                        "SITUS_DIR",
-                        "SITUS_RD"
+                        "SITUS_ST",
+                        "SITUS_ST1",
+                        "SITUS_TYPE"
                     ],
-                    "city": "SITUS_CITY"
+                    "unit": "SITUS_ST2",
+                    "city": "SITUS_CITY",
+                    "postcode": "SITUS_ZIP"
                 },
                 "license": {
                     "url": "https://clallam-county-portal-clallam.hub.arcgis.com/pages/county-disclaimer"
                 },
                 "protocol": "ESRI",
-                "data": "https://services8.arcgis.com/noCZ2SM2C0rVag8y/arcgis/rest/services/prc_land_p1/FeatureServer/0",
-                "website": "https://clallam-county-portal-clallam.hub.arcgis.com/datasets/clallam::parcels-public/about"
+                "data": "https://services8.arcgis.com/noCZ2SM2C0rVag8y/arcgis/rest/services/Site_Addresses/FeatureServer/0",
+                "website": "https://clallam-county-portal-clallam.hub.arcgis.com/datasets/clallam::site-addresses/about"
             }
         ],
         "parcels": [


### PR DESCRIPTION
The addresses/county source was failing every job with `esridump.errors.EsriDownloadError: Could not retrieve layer metadata: Invalid URL Invalid URL`. The `data` URL (`.../prc_land_p1/FeatureServer/0`) is actually the county's **parcels** service (it was mistakenly duplicated into the addresses layer), and that specific ArcGIS item now returns a 400 'Invalid URL' error on its own metadata endpoint, likely renamed/removed server-side.

Searched the same ArcGIS Online org (`services8.arcgis.com/noCZ2SM2C0rVag8y`) and found `Site_Addresses/FeatureServer/0`, a dedicated county-scoped address point layer (43,192 features, spatial extent matching Clallam County, WA). Verified fields against a live sample:

- `SITUS_ADDR` — house number
- `SITUS_ST` / `SITUS_ST1` / `SITUS_TYPE` — prefix direction / street name / street type
- `SITUS_ST2` — unit
- `SITUS_CITY` — city
- `SITUS_ZIP` — postcode

Updated `data` and `website` to point at this service and rewrote `conform` to match its actual field names.

Note: the `parcels` layer in this same file is also currently failing (same `prc_land_p1` URL, same 'Invalid URL' error), but that is a separate layer/issue and is left untouched here — out of scope for this addresses fix.