### PR TITLE
Fix broken Kent County, MD addresses source

### DIFF
--- a/sources/us/md/kent.json
+++ b/sources/us/md/kent.json
@@ -14,18 +14,22 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://geodata.md.gov/appdata/rest/services/Addressing/MD_Addressing/MapServer/15",
+                "data": "https://mdgeodata.md.gov/appdata/rest/services/Addressing/MD_Addressing/MapServer/15",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
-                    "id": "ADDID",
-                    "number": "ADDNUMCPLT",
-                    "street": "NAMECPLT",
-                    "unit": "SUBBADDCPLT",
-                    "city": "CITY",
-                    "district": "COUNTY",
-                    "region": "STATE",
-                    "postcode": "ZIPCODE"
+                    "id": "Add_Id",
+                    "number": "Add_Number",
+                    "street": [
+                        "St_PreDir",
+                        "St_Name",
+                        "St_PosTyp"
+                    ],
+                    "unit": "Unit",
+                    "city": "Post_Comm",
+                    "district": "County",
+                    "region": "State",
+                    "postcode": "Post_Code"
                 }
             }
         ]


### PR DESCRIPTION
The Kent County addresses source (sources/us/md/kent.json) has been failing every weekly job since at least 2026-07-03 because the entire geodata.md.gov host is returning a "Site Maintenance" page (HTTP 503) for all requests, not just this layer.

Maryland's statewide addressing ArcGIS server has moved to a new host, mdgeodata.md.gov, which serves the identical service/folder structure (Addressing/MD_Addressing/MapServer). Layer 15 there is still "Kent" with 11,617 point features covering the county (Chestertown, Rock Hall, Betterton, etc. all present).

The field schema on the new host differs from the old one, so the conform was rewritten against the new field names (verified via esri-explore.py suggest/sample):
- number: Add_Number
- street: St_PreDir + St_Name + St_PosTyp
- unit: Unit
- city: Post_Comm
- district: County
- region: State
- postcode: Post_Code
- id: Add_Id

This mirrors the same MD statewide addressing schema/convention already used in sources/us/md/dorchester.json.

Validated against the schema with the inline test/lib.js compile+validate check (VALID).