### PR TITLE
Fix broken St. Mary's County, MD addresses source

### DIFF
--- a/sources/us/md/st_marys.json
+++ b/sources/us/md/st_marys.json
@@ -15,10 +15,11 @@
             {
                 "name": "county",
                 "website": "https://www.stmaryscountymd.gov/it/gis/",
-                "data": "https://stmgis.stmarysmd.com/arcgis/rest/services/Public/PublicLayers2/MapServer/0",
-                "protocol": "ESRI",
+                "data": "https://gis.stmaryscountymd.gov/Downloads/Address_Points.zip",
+                "compression": "zip",
+                "protocol": "http",
                 "conform": {
-                    "format": "geojson",
+                    "format": "shapefile",
                     "street": [
                         "PREDIR",
                         "STREET_NAM",
@@ -26,7 +27,7 @@
                     ],
                     "number": "STREET_NUM",
                     "unit": "STREET_APA",
-                    "city": "POSTAL_NAME",
+                    "city": "POSTAL_NAM",
                     "postcode": "ZIP"
                 }
             }


### PR DESCRIPTION
The old ESRI service (`stmgis.stmarysmd.com/arcgis/rest/services/Public/PublicLayers2/MapServer/0`) has been removed — the `Public` folder on that server now only contains `PublicLayers1`, and none of the remaining folders/services expose an address point feature layer (only geocoders and other unrelated services). Jobs have been failing consistently for several weeks (909239, 904289, 894477, 889604, etc.).

The county's GIS page (https://www.stmaryscountymd.gov/it/gis/) now links directly to a static county-scoped download at `gis.stmaryscountymd.gov`, so this switches the source from the dead ESRI FeatureServer to that HTTP shapefile-in-zip download:

- Verified the ZIP downloads successfully (2.2MB, `application/x-zip-compressed`).
- Inspected the shapefile with `ogrinfo`: Point geometry, 46,597 features, extent matches St. Mary's County.
- Field names are the same as before (`STREET_NUM`, `STREET_NAM`, `STREET_SUF`, `PREDIR`, `STREET_APA`, `ZIP`), except the city field is actually `POSTAL_NAM` — the old conform had a typo (`POSTAL_NAME`) that never matched any field, which is fixed here too.

Note: the `parcels` layer in this same file is also currently broken (same dead ESRI server), and the county publishes a corresponding `Parcels.zip` at the same download host, but that layer is out of scope for this fix.