### PR TITLE
Fix broken City of Carson, CA addresses source

### DIFF
--- a/sources/us/ca/city_of_carson.json
+++ b/sources/us/ca/city_of_carson.json
@@ -21,8 +21,8 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://aethergis.carson.ca.us/server/rest/services/Address_Points/MapServer/0",
-                "website": "https://gis.carson.ca.us/",
+                "data": "https://services1.arcgis.com/D9ezssdp37tr9wbT/arcgis/rest/services/PIS_2025/FeatureServer/78",
+                "website": "https://www.carsonca.gov/",
                 "attribution": "City of Carson",
                 "protocol": "ESRI",
                 "conform": {


### PR DESCRIPTION
The City of Carson addresses source pointed at https://aethergis.carson.ca.us, which has been completely unreachable (TCP connection timeout, not even a bot-block response) since at least late June 2026 — the last 13 consecutive jobs (addresses, parcels, and buildings layers alike) have failed with the identical connection timeout. Direct testing confirms the host does not respond on port 443 (or 80) at all, and DNS still resolves, so the server itself appears to be down/decommissioned. The city's other self-hosted GIS domain (gis.carson.ca.us) is likewise unreachable.

I found a replacement: the City of Carson's "Property Information System" ArcGIS Experience Builder app (carsonproperty.info) uses a web map hosted on ArcGIS Online (org D9ezssdp37tr9wbT) with an "Addresses" layer at:

https://services1.arcgis.com/D9ezssdp37tr9wbT/arcgis/rest/services/PIS_2025/FeatureServer/78

This layer has the exact same field schema as the old source (SITENUMBER, SITEFRAC, SITEPREF, STREETNAME, STREETTYPE, SITEUNIT, City, County, State, SITEZIP) — it's the same underlying dataset, just now served from ArcGIS Online instead of the dead on-prem server. It returns 32,636 features scoped to the city of Carson, with no auth errors, so the existing conform mapping (number, street, unit, city, district, region, postcode) carries over unchanged.

Also updated the `website` field to the city's live domain (carsonca.gov) since gis.carson.ca.us no longer resolves/responds.

Note: the `parcels` and `buildings` layers in this same file still point at the dead aethergis.carson.ca.us server and are out of scope for this fix (only the `addresses`/`city` layer was investigated here).