### PR TITLE
Fix broken Butte County, SD addresses source

### DIFF
--- a/sources/us/sd/butte.json
+++ b/sources/us/sd/butte.json
@@ -14,18 +14,21 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://gis.districtiii.org/server/rest/services/BUTTE_COUNTY_WEB_LAYERS/MapServer/29",
+                "data": "https://services5.arcgis.com/mdEJo5v0fnzDS3yR/arcgis/rest/services/Structures_and_Access_PUBLIC/FeatureServer/0",
+                "website": "https://gis.districtiii.org/butte",
                 "protocol": "ESRI",
                 "conform": {
-                    "number": "new_add",
+                    "number": "ADRS_NUM",
                     "street": [
-                        "dir",
-                        "rd_nm"
+                        "PRE_DIR",
+                        "STRT_NM",
+                        "STRT_NM_SFX",
+                        "POST_DIR"
                     ],
-                    "unit": "location",
-                    "city": "new_city",
-                    "region": "new_st",
-                    "postcode": "new_zip",
+                    "unit": "LOCATION",
+                    "city": "NEW_CITY",
+                    "region": "NEW_ST",
+                    "postcode": "NEW_ZIP",
                     "format": "geojson"
                 }
             }


### PR DESCRIPTION
The addresses/county layer for Butte County, SD was failing on the last 3 production jobs (908107, 903157, 898265) with:

    esridump.errors.EsriDownloadError: Could not retrieve layer metadata: Service BUTTE_COUNTY_WEB_LAYERS/MapServer not started

Investigation on the host (`gis.districtiii.org`) found that `BUTTE_COUNTY_WEB_LAYERS` (the old service backing layer 29) has been superseded by `BUTTE_COUNTY_WEB_LAYERS2`, but that renamed service no longer includes an address layer. Tracing the county's live WebGIS app (`gis.districtiii.org/butte`) to its underlying ArcGIS Online web map showed the county's 911 address dataset has moved to a separate hosted feature service:

`https://services5.arcgis.com/mdEJo5v0fnzDS3yR/arcgis/rest/services/Structures_and_Access_PUBLIC/FeatureServer/0` ("Structures" layer)

This is the same underlying MaPS Inc. 911-addressing dataset (matching `COUNTY`, `NEW_CITY`, `NEW_ST`, `NEW_ZIP` field values and content) that previously lived at the broken URL, just republished with cleaner, uppercased field names and separate parsed `ADRS_NUM`/`PRE_DIR`/`STRT_NM`/`STRT_NM_SFX`/`POST_DIR` fields instead of the old combined `dir`/`rd_nm` fields. Verified:

- 6,669 features, geometry type Point, `format=geojson` reprojects correctly to WGS84
- No auth errors
- Overwhelmingly Butte County records (`COUNTY = 'BUTTE'` for ~93%); the remainder are Belle Fourche/Aladdin-area addresses tagged `COUNTY = 'CROOK'` (Crook County, WY), consistent with mailing-address overlap near the SD/WY line in this county's own 911 dataset — not a separate/regional dataset (Crook County, WY already has its own independent source at `sources/us/wy/crook.json`)

Updated the `addresses`/`county` conform to point at the new service with the correct field names.

Note: the `parcels` layer in this same source file is also currently failing (`BUTTE_COUNTY_WEB_LAYERS/MapServer/3` hits the same "service not started" error), but a parcels-equivalent layer does exist at `BUTTE_COUNTY_WEB_LAYERS2/MapServer/3`. Left that out of scope for this PR since it wasn't part of the requested fix; happy to follow up separately.