### PR TITLE
fix broken city of cranston ri addresses source

### DIFF
--- a/sources/us/ri/city_of_cranston.json
+++ b/sources/us/ri/city_of_cranston.json
@@ -22,20 +22,16 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://gis.cranstonri.org/arcgis/rest/services/Assessor_Web/MapServer/17",
+                "data": "https://arcgisserver.cranstonri.org/arcgis/rest/services/Labels_E911Addresses/MapServer/17",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
-                    "id": "ESiteID",
-                    "number": "HouseNumbe",
-                    "street": [
-                        "PD",
-                        "SN",
-                        "ST",
-                        "SD"
-                    ],
-                    "city": "ZN",
-                    "postcode": "ZIP"
+                    "id": "siteaddid",
+                    "number": "addrnum",
+                    "street": "fullname",
+                    "unit": "unitid",
+                    "city": "municipality",
+                    "postcode": "zipcode"
                 }
             }
         ]


### PR DESCRIPTION
The addresses/city source for City of Cranston, RI has been failing for at least 3 weeks (jobs 898363, 903255, 908205) with a TCP connection timeout to `gis.cranstonri.org` — the host resolves in DNS but nothing answers on port 443. This is a total host outage, not a service-level issue.

The City of Cranston has moved its ArcGIS Server to a new subdomain: `arcgisserver.cranstonri.org`. The old layer `Assessor_Web/MapServer/17` has a direct replacement at `Labels_E911Addresses/MapServer/17` ("E911 Site Addresses"), which is:

- Live (ArcGIS Server 11.5), returns a valid fields array, no auth errors.
- 32,746 point features.
- Confirmed scoped to Cranston only — a distinct-values query on `municipality` returns exactly one value, `CRANSTON` (not a multi-jurisdiction regional layer).
- Sample records show addresses within Cranston (e.g. `10 ARROW GLEN ST, CRANSTON, RI 02921`).

Updated the conform with verified field names from the new service:
- `number`: `addrnum`
- `street`: `fullname` (already includes street type/suffix)
- `unit`: `unitid`
- `city`: `municipality`
- `postcode`: `zipcode`
- `id`: `siteaddid`

Validated against the schema (`npm test` passes; the 2 pre-existing failures are unrelated schema-validator edge cases).