### PR TITLE
Fix broken Park County, CO addresses and parcels source

### DIFF
--- a/sources/us/co/park.json
+++ b/sources/us/co/park.json
@@ -16,13 +16,13 @@
                 "name": "county",
                 "conform": {
                     "format": "geojson",
-                    "number": "SAN",
-                    "street": "GeocodeStName",
-                    "unit": "UNIT",
-                    "postcode": "ZIPCODE",
-                    "city": "MCN"
+                    "number": "STREETNO",
+                    "street": ["PREDIRECTION", "STREETNAME"],
+                    "city": "P_CITY",
+                    "postcode": "P_ZIPCODE"
                 },
-                "data": "https://maps.parkco.us/arcgis/rest/services/Parcels/ParkParcelPublic/MapServer/1",
+                "data": "https://services3.arcgis.com/atP7uTVHA2caR3p6/arcgis/rest/services/c250430ParcelCopyXY/FeatureServer/52",
+                "website": "https://www.parkcountyco.gov/80/GISMapping",
                 "protocol": "ESRI"
             }
         ],
@@ -33,7 +33,8 @@
                     "format": "geojson",
                     "pid": "ScheduleNu"
                 },
-                "data": "https://maps.parkco.us/arcgis/rest/services/Parcels/ParkParcelPublic/MapServer/0",
+                "data": "https://services3.arcgis.com/atP7uTVHA2caR3p6/arcgis/rest/services/c250430ParcelCopyXY/FeatureServer/52",
+                "website": "https://www.parkcountyco.gov/80/GISMapping",
                 "protocol": "ESRI"
             }
         ]


### PR DESCRIPTION
The addresses and parcels sources for Park County, CO (`sources/us/co/park.json`) have been failing for at least the last several weekly runs (jobs 910288/910289, 905338/905339, 900442/900443).

Root cause: the county's old ArcGIS Server at `maps.parkco.us` is entirely broken — every REST endpoint (root services listing, folder listing, service and layer metadata) now returns the ArcGIS Web Adaptor's own HTML config/error page instead of JSON, regardless of path or User-Agent. This affected both the `addresses` and `parcels` layers, which shared that server.

Replacement found: Park County GIS now publishes a hosted ArcGIS Online parcel layer (with situs address attributes) under their own organization:

`https://services3.arcgis.com/atP7uTVHA2caR3p6/arcgis/rest/services/c250430ParcelCopyXY/FeatureServer/52`

Verified before use:
- Public FeatureServer, no auth required, `fields` array present.
- 42,017 features, spatial extent matches Park County, CO (Colorado Central State Plane feet), sample records show towns within Park County (Alma, Hartsel, Bailey, Grant, Shawnee).
- Owned by the Park County GIS account (`shasselbusch_parkgis`) that also publishes the county's other official layers (fire/ambulance/sanitation districts, roads, PLSS, etc.) and the "Park County Online Map" / "Assessor's Map" apps linked from the county's GIS page.
- This single layer contains both parcel geometry and situs address fields, so it replaces both the old `addresses` and `parcels` layers (an established pattern elsewhere in this repo, e.g. `sources/us/vt/city_of_burlington.json`, several `sources/us/sd/*.json`).

Changes:
- `addresses`: `number` -> `STREETNO`, `street` -> `["PREDIRECTION", "STREETNAME"]`, `city` -> `P_CITY`, `postcode` -> `P_ZIPCODE`. Field names re-verified from the new service's metadata; old field names (`SAN`, `GeocodeStName`, `MCN`, `ZIPCODE`) do not exist on the new layer. Dropped `unit` — the closest candidate field (`UNITNAME`) is a numeric field with values inconsistent with real unit numbers, so it was omitted rather than mapping bad data.
- `parcels`: `pid` stays `ScheduleNu`, which exists unchanged on the new layer.
- Added a `website` pointing to the county's GIS page.

Validated with the schema compiler in `test/lib.js` (passes) and `npm test` (only 2 unrelated pre-existing failures in `accuracy` conform edge-case tests, not touching this file).