### PR TITLE
Fix broken City of Chattanooga, TN addresses source

### DIFF
--- a/sources/us/tn/city_of_chattanooga.json
+++ b/sources/us/tn/city_of_chattanooga.json
@@ -22,14 +22,12 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://data.chattlibrary.org/api/views/rz29-uyu4/rows.csv?accessType=DOWNLOAD",
-                "website": "https://data.chattlibrary.org/Government/Address-Data/rz29-uyu4",
-                "license": "https://data.chattlibrary.org/terms",
-                "protocol": "http",
+                "data": "https://pwgis.chattanooga.gov/arcgis/rest/services/Misc/Addressing_FeatService/FeatureServer/0",
+                "website": "https://www.arcgis.com/home/item.html?id=2249aaee6a6c450eab5dae52a9cdec33",
+                "license": "https://data.chattanooga.gov/pages/terms",
+                "protocol": "ESRI",
                 "conform": {
-                    "srs": "EPSG:4326",
-                    "lon": "LONGITUDE",
-                    "lat": "LATITUDE",
+                    "format": "geojson",
                     "number": "STNUM",
                     "street": [
                         "DIRPFX",
@@ -44,7 +42,6 @@
                         "BUILDING"
                     ],
                     "city": "CITY",
-                    "format": "csv",
                     "postcode": "ZIPCODE"
                 }
             }


### PR DESCRIPTION
The `addresses`/`city` layer for Chattanooga, TN has failed its last 3 weekly jobs (Aug 28, Sep 4, Sep 11 2026) with a `ConnectTimeout` connecting to `data.chattlibrary.org`. That host (and its `chattadata.org` alias) is unreachable from this environment as well, confirming it's dead rather than transient.

The underlying dataset is still maintained by the city and is now exposed through an ArcGIS Hub feature service instead of the old Socrata CSV export:

- New source: `https://pwgis.chattanooga.gov/arcgis/rest/services/Misc/Addressing_FeatService/FeatureServer/0` ("Addressing" — GISAdmin_CHATTGIS, public, described as "Authoritative feature service for Addressing Points within Chattanooga city limits")
- Verified: fields present, 126,979 features, no auth errors, extent matches Chattanooga
- Field names (`STNUM`, `DIRPFX`, `PRETYPE`, `STNAME`, `TYPESFX`, `DIRSFX`, `CATEGORY`, `UNIT`, `BUILDING`, `CITY`, `ZIPCODE`) match the original conform exactly — this is the same underlying municipal addressing dataset, just republished as ESRI FeatureServer rather than the retired Socrata portal
- Switched `protocol` from `http`/`csv` to `ESRI`/`geojson` accordingly, and updated `website`/`license` to the current ArcGIS Hub item and terms page