### PR TITLE
Fix broken Weld County, CO addresses source

### DIFF
--- a/sources/us/co/weld.json
+++ b/sources/us/co/weld.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://services.arcgis.com/ewjSqmSyHJnkfBLL/arcgis/rest/services/Address_Points_open_data/FeatureServer/0",
+                "data": "https://services.arcgis.com/ewjSqmSyHJnkfBLL/arcgis/rest/services/Address_Points_open_data/FeatureServer/1",
                 "protocol": "ESRI",
                 "conform": {
                     "number": "HOUSENUM",


### PR DESCRIPTION
The addresses/county layer on Weld County's Address_Points_open_data FeatureServer has been failing every weekly run with `Could not retrieve layer metadata: The requested layer (layerId: 0) was not found.`

The parcels/county layer on the same server (Parcels_open_data) has continued to succeed, confirming the host itself is fine and this is specific to the addresses service.

Root cause: the feature layer inside Address_Points_open_data FeatureServer moved from layer id 0 to layer id 1 (the service root now only exposes layer id 1, named Address_Points_open_data, Feature Layer). The layer id shifted; the service name and location did not change.

Verified the replacement layer before committing:
- `FeatureServer/1?f=json` returns the same field set as before (HOUSENUM, PRE_DIR, PRETYPE, STR_NAME, STR_TYPE, SUF_DIR, UNIT, COMMUNITY, COUNTY, STATE, ZIPCODE), so the existing conform is still valid.
- Feature count is 161,733, a reasonable total for a populous county the size of Weld.
- Sample records show COUNTY=WELD, STATE=CO, and the spatial extent falls within northern Colorado.
- No auth errors.

Fix: updated `data` from `.../Address_Points_open_data/FeatureServer/0` to `.../Address_Points_open_data/FeatureServer/1`. No conform changes were needed since field names are unchanged.