### PR TITLE
Fix broken Crawford County, PA addresses source

### DIFF
--- a/sources/us/pa/crawford.json
+++ b/sources/us/pa/crawford.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "website": "https://www.crawfordcountypa.net/GIS/Pages/home.aspx",
+                "website": "https://share-open-data-crawfordcountypa.opendata.arcgis.com/",
                 "contact": {
                     "name": "Andrew Parkin",
                     "title": "GIS Manager",
@@ -22,11 +22,11 @@
                     "email": "gisaddressing@co.crawford.pa.us",
                     "address": "903 Diamond Park Sq, Meadville, PA 16335"
                 },
-                "data": "https://ccgis.crawfordcountypa.net/arcgis/rest/services/Crawford_Web/AddressPoints_WebUse/FeatureServer/0",
+                "data": "https://services1.arcgis.com/CcJI8wbz22fo71LO/ArcGIS/rest/services/CivQuest_Core/FeatureServer/0",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
-                    "id": "AD_STRU_NUM",
+                    "id": "UniqueStructureNumber",
                     "number": [
                         "Add_Number",
                         "AddNum_Suf"


### PR DESCRIPTION
The old ESRI FeatureServer (`ccgis.crawfordcountypa.net/.../Crawford_Web/AddressPoints_WebUse/FeatureServer/0`) now returns HTTP 404 for both the layer and the entire services root — the county's old ArcGIS Server appears to have been decommissioned, and the old GIS website page (`www.crawfordcountypa.net/GIS/Pages/home.aspx`) now returns HTTP 410 Gone.

Found a current, county-specific replacement via ArcGIS Online search: Crawford County's new CivQuest-hosted address points layer at `https://services1.arcgis.com/CcJI8wbz22fo71LO/ArcGIS/rest/services/CivQuest_Core/FeatureServer/0` (owner `gisadmin_crawford`, last modified December 2025). Verified:
- Public, no auth required
- 45,424 features, all with `CountyFIPS`/`CountyName` = Crawford County, PA (not a regional/multi-county dataset)
- Spatial extent matches Crawford County
- Field names re-verified from a live sample (`Add_Number`, `AddNum_Suf`, `St_FullName`, `Unit`, `Post_Comm`, `Post_Code`, `CountyName`, `UniqueStructureNumber`)

Updated `data`, `website` (now the county's ArcGIS Open Data hub), and the `id` conform key to match the new field name.