### PR TITLE
Fix broken Darlington County, SC addresses and parcels sources

### DIFF
--- a/sources/us/sc/darlington.json
+++ b/sources/us/sc/darlington.json
@@ -14,25 +14,25 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://services5.arcgis.com/8FJikaProY6O3ncx/ArcGIS/rest/services/Darco_AddressPnts/FeatureServer/0",
+                "data": "https://services5.arcgis.com/8FJikaProY6O3ncx/ArcGIS/rest/services/Darco_AddressPnts/FeatureServer/1",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
-                    "number": "STNUM",
+                    "number": "stnum",
                     "street": [
-                        "DIRECTION",
-                        "STREET"
+                        "dir",
+                        "street"
                     ],
-                    "unit": "UNIT",
-                    "city": "COMMUNITY",
-                    "postcode": "ZIPCODE"
+                    "unit": "unit",
+                    "city": "community",
+                    "postcode": "zip"
                 }
             }
         ],
         "parcels": [
             {
                 "name": "county",
-                "data": "https://services5.arcgis.com/8FJikaProY6O3ncx/ArcGIS/rest/services/PARCELS/FeatureServer/0",
+                "data": "https://services5.arcgis.com/8FJikaProY6O3ncx/ArcGIS/rest/services/PARCELS/FeatureServer/1",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",


### PR DESCRIPTION
The county's ArcGIS server (services5.arcgis.com/8FJikaProY6O3ncx) republished both the `Darco_AddressPnts` and `PARCELS` services with their layer IDs shifted from 0 to 1, causing every recent job to fail with `The requested layer (layerId: 0) was not found.` Field names on the address layer were also relowercased (e.g. `STNUM` -> `stnum`, `DIRECTION` -> `dir`, `STREET` -> `street`, `UNIT` -> `unit`, `COMMUNITY` -> `community`, `ZIPCODE` -> `zip`).

Verified against the same host, same service, layer 1:
- Addresses: 35,105 features, all within Darlington County (community/county fields confirm this, not a regional dataset)
- Parcels: 41,765 features, `MBP` pid field still present

Updated both layers' `data` URLs to `FeatureServer/1` and refreshed the addresses conform field names to match current casing.