### PR TITLE
Fix broken Bon Homme County, SD addresses and parcels sources

### DIFF
--- a/sources/us/sd/bon_homme.json
+++ b/sources/us/sd/bon_homme.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://gis.districtiii.org/server/rest/services/BON_HOMME_COUNTY_WEB_LAYERS/MapServer/10",
+                "data": "https://gis.districtiii.org/server/rest/services/BON_HOMME_COUNTY_LAYERS3/MapServer/10",
                 "protocol": "ESRI",
                 "conform": {
                     "number": "HOUSE_NUMBER",
@@ -32,7 +32,7 @@
         "parcels": [
             {
                 "name": "county",
-                "data": "https://gis.districtiii.org/server/rest/services/BON_HOMME_COUNTY_WEB_LAYERS/MapServer/1",
+                "data": "https://gis.districtiii.org/server/rest/services/BON_HOMME_COUNTY_LAYERS3/MapServer/1",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",


### PR DESCRIPTION
The ArcGIS service `BON_HOMME_COUNTY_WEB_LAYERS` backing this source stopped running (jobs failing with `Service BON_HOMME_COUNTY_WEB_LAYERS/MapServer not started`) for the last several weekly runs on both the `addresses` and `parcels` layers.

District III GIS (the host, gis.districtiii.org) has since republished the county's data under `BON_HOMME_COUNTY_LAYERS3` (superseding an intermediate `BON_HOMME_COUNTY_WEB_LAYERS2`, confirmed via the portal's created/modified timestamps as the newest and currently active service). The layer IDs, field names, and schema (ADDRESS_POINTS layer 10, PARCEL layer 1) are unchanged from the old service.

Verified before committing:
- Service returns valid metadata with a populated `fields` array, no auth errors.
- Addresses layer: 3,739 features, extent matches Bon Homme County, SD.
- Parcels layer: 8,878 features, same extent.
- Field names (HOUSE_NUMBER, DLVRY_ADD, LOCATION, COMMUNITY, COUNTY, PARCEL_ID) confirmed identical to the previous conform, so no conform changes were needed — only the `data` URLs.
- Confirmed other counties on the same server (Charles Mix, Brule, Buffalo) are currently succeeding in production, ruling out a host-wide or timeout issue.
- Schema validated with the repo's `test/lib.js` validator.