### PR TITLE
Fix broken Doddridge County, WV addresses and parcels sources

### DIFF
--- a/sources/us/wv/doddridge.json
+++ b/sources/us/wv/doddridge.json
@@ -14,7 +14,8 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://www.landmarkgeospatial.com:8443/arcgis/rest/services/Doddridge/DoddridgeParcels/MapServer/0",
+                "data": "https://services7.arcgis.com/IRwObajcV9nxQIrC/arcgis/rest/services/DoddridgeParcels/FeatureServer/0",
+                "website": "https://apps.landmarkgeospatial.com/doddridgegis/",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
@@ -33,7 +34,8 @@
         "parcels": [
             {
                 "name": "county",
-                "data": "https://www.landmarkgeospatial.com:8443/arcgis/rest/services/Doddridge/DoddridgeParcels/MapServer/0",
+                "data": "https://services7.arcgis.com/IRwObajcV9nxQIrC/arcgis/rest/services/DoddridgeParcels/FeatureServer/0",
+                "website": "https://apps.landmarkgeospatial.com/doddridgegis/",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",


### PR DESCRIPTION
The Doddridge County parcel/address service migrated to a new ArcGIS Online host. The old endpoint (`www.landmarkgeospatial.com:8443/arcgis/rest/services/Doddridge/DoddridgeParcels/MapServer/0`) has been failing for 3+ consecutive weekly runs with `Service Doddridge/DoddridgeParcels/MapServer not found`.

Landmark Geospatial's old parcel viewer (`landmarkgeospatial.com:8443/doddridgegis/`) now serves an HTML redirect to `apps.landmarkgeospatial.com/doddridgegis/`, whose app JS references a new hosted feature service:

`https://services7.arcgis.com/IRwObajcV9nxQIrC/arcgis/rest/services/DoddridgeParcels/FeatureServer/0`

Verified before writing the conform:
- Same fields as before (`PARID`, `PARCELADDRESS`), same layer structure (parcels layer doubling as the address source via `prefixed_number`/`postfixed_street` on `PARCELADDRESS`, same as the old source).
- 7,943 features, extent centered on West Union, WV (the Doddridge County seat) — county-scoped, not a multi-county dataset (a separate `defaultParcel_WV" statewide layer exists on the same org and was not used).
- No auth errors, public FeatureServer.

Updated both the `addresses` and `parcels` layers to the new URL and added a `website` pointing at the new viewer app.