### PR TITLE
fix broken Ware County, GA addresses, parcels, and buildings sources

### DIFF
--- a/sources/us/ga/ware.json
+++ b/sources/us/ga/ware.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://services9.arcgis.com/XAyIBOsw3fLfDjTY/ArcGIS/rest/services/WareCountyBase_gdb/FeatureServer/0",
+                "data": "https://services9.arcgis.com/XAyIBOsw3fLfDjTY/ArcGIS/rest/services/WareCounty_Base_gdb/FeatureServer/0",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
@@ -28,7 +28,7 @@
         "parcels": [
             {
                 "name": "county",
-                "data": "https://services9.arcgis.com/XAyIBOsw3fLfDjTY/ArcGIS/rest/services/WareCountyBase_gdb/FeatureServer/1",
+                "data": "https://services9.arcgis.com/XAyIBOsw3fLfDjTY/ArcGIS/rest/services/WareCounty_Base_gdb/FeatureServer/38",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
@@ -39,7 +39,7 @@
         "buildings": [
             {
                 "name": "county",
-                "data": "https://services9.arcgis.com/XAyIBOsw3fLfDjTY/ArcGIS/rest/services/WareCountyBase_gdb/FeatureServer/12",
+                "data": "https://services9.arcgis.com/XAyIBOsw3fLfDjTY/ArcGIS/rest/services/WareCounty_Base_gdb/FeatureServer/27",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson"


### PR DESCRIPTION
The ArcGIS server's `WareCountyBase_gdb` FeatureServer was renamed to `WareCounty_Base_gdb` (underscore added), causing all three layers (addresses, parcels, buildings) to fail with `EsriDownloadError: Could not retrieve layer metadata: Invalid URL`.

Confirmed via the root services listing on the same server (`services9.arcgis.com/XAyIBOsw3fLfDjTY`) that the renamed service exists with the same layer structure. Verified each layer:

- addresses (layer 0, `Address_point`): 18,504 features, same field names as before (HOUSE_NUMB, STREET, UNIT, COMMUNITY)
- parcels (layer 38, `Parcels`): 23,114 features, same field name (PARCEL_NO)
- buildings (layer 27, `Ware_Building_Footprints`): 46,777 features

Only the service name and layer indices changed; conform field mappings are unchanged and still valid against the current schema.