### PR TITLE
fix broken hutchinson county sd addresses and parcels sources

### DIFF
--- a/sources/us/sd/hutchinson.json
+++ b/sources/us/sd/hutchinson.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://gis.districtiii.org/server/rest/services/HUTCHINSON_COUNTY_WEB_LAYERS/MapServer/16",
+                "data": "https://gis.districtiii.org/server/rest/services/HUTCHINSON_COUNTY_WEB_LAYERS2/MapServer/16",
                 "protocol": "ESRI",
                 "conform": {
                     "id": "UniqueSiteID",
@@ -32,7 +32,7 @@
         "parcels": [
             {
                 "name": "county",
-                "data": "https://gis.districtiii.org/server/rest/services/HUTCHINSON_COUNTY_WEB_LAYERS/MapServer/14",
+                "data": "https://gis.districtiii.org/server/rest/services/HUTCHINSON_COUNTY_WEB_LAYERS2/MapServer/14",
                 "protocol": "ESRI",
                 "conform": {
                     "pid": "PARCEL_ID",


### PR DESCRIPTION
The addresses and parcels sources for Hutchinson County, SD were failing with `Service HUTCHINSON_COUNTY_WEB_LAYERS/MapServer not found`.

The county's GIS host (gis.districtiii.org) renamed the service to `HUTCHINSON_COUNTY_WEB_LAYERS2`. The layer IDs (16 for ADDRESS POINTS, 14 for PARCELS) and all field names are unchanged, so this is a URL-only fix.

Verified before committing:
- `?f=json` on the new service returns a valid `fields` array for both layers, no auth errors.
- Address layer: 4,572 features; parcel layer: 12,438 features — reasonable for a single county.
- Filtering the address layer to `COUNTY<>'Hutchinson_County'` returns 0 features, confirming the dataset is scoped to this county even though it's hosted on a shared multi-county district server.
- Sample records match the existing conform field names (`Z`, `D`, `ST`, `COMMUNITY`, `UniqueSiteID`, `STATE` for addresses; `PARCEL_ID` for parcels).
- Schema validated with `test/lib.js`.