### PR TITLE
Fix broken City of Courtenay, BC addresses source

### DIFF
--- a/sources/ca/bc/city_of_courtenay.json
+++ b/sources/ca/bc/city_of_courtenay.json
@@ -29,7 +29,7 @@
                 "conform": {
                     "format": "geojson",
                     "number": "StreetAddress",
-                    "street": ["StreetName", "StreetType"],
+                    "street": "StreetName",
                     "unit": "Unit",
                     "city": "City"
                 }

--- a/sources/ca/bc/city_of_courtenay.json
+++ b/sources/ca/bc/city_of_courtenay.json
@@ -16,7 +16,7 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://services3.arcgis.com/PwS5hVLYsEN2U36s/arcgis/rest/services/AddressPoints/FeatureServer/0",
+                "data": "https://services3.arcgis.com/PwS5hVLYsEN2U36s/ArcGIS/rest/services/Address_Points_(Open_Data)/FeatureServer/0",
                 "website": "https://data-courtenay.opendata.arcgis.com/datasets/addresspoints",
                 "license": {
                     "url": "https://data-courtenay.opendata.arcgis.com/pages/city-of-courtenay-open-data-licence",
@@ -28,8 +28,10 @@
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
-                    "number": "TEXTSTRING",
-                    "street": "StreetName"
+                    "number": "StreetAddress",
+                    "street": ["StreetName", "StreetType"],
+                    "unit": "Unit",
+                    "city": "City"
                 }
             }
         ]


### PR DESCRIPTION
The AddressPoints FeatureServer at services3.arcgis.com/PwS5hVLYsEN2U36s became token-gated (`Token Required`, HTTP 499), failing the last several weekly jobs.

Found a public replacement layer on the same server: `Address_Points_(Open_Data)` FeatureServer/0. Verified before switching:
- Returns valid metadata with no auth error
- 12,426 features, all populated `StreetAddress`/`StreetName` fields
- Confirmed scoped to Courtenay only: a count query for records where `City` is not like '%ourtenay%' returns 0, and the extent matches Courtenay's location (not a regional/multi-jurisdiction dataset)

Updated `conform` field names against the new service's actual fields (verified via sample query), switching the number field from `TEXTSTRING` (which had stray parentheses in some values) to the cleaner `StreetAddress`, and adding `unit`/`city` mappings that weren't in the previous conform.