### PR TITLE
fix broken Malheur County, OR addresses source

### DIFF
--- a/sources/us/or/malheur.json
+++ b/sources/us/or/malheur.json
@@ -14,12 +14,12 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://services.arcgis.com/uUvqNMGPm7axC2dD/ArcGIS/rest/services/AddressPointsData/FeatureServer/0",
+                "data": "https://services5.arcgis.com/ZfBm5CKxbEBYLP3J/arcgis/rest/services/County_GIS_Portal_WFL1/FeatureServer/5",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
-                    "id": "FID",
-                    "number": "HouseNumbe",
+                    "id": "OBJECTID",
+                    "number": "HouseNumber",
                     "street": [
                         "PreDir",
                         "StreetName",


### PR DESCRIPTION
The addresses/county source for Malheur County, OR has been failing every recent weekly job with `EsriDownloadError: Could not retrieve layer metadata: Invalid URL`, meaning the old ArcGIS Online service (`.../uUvqNMGPm7axC2dD/.../AddressPointsData/FeatureServer/0`) no longer exists on that org.

I searched the org's service listing and ArcGIS Online generally and found the county's current GIS portal service, "Malheur County GIS map" (`County_GIS_Portal_WFL1`), which includes an `AddressPoints` layer (id 5) with the same field structure as before (HouseNumber, PreDir, StreetName, StreetType, SufDir, UnitNumber, CITY, ZipCode).

Verified before switching:
- Feature count is 13,029, consistent with a single county (Ontario, Vale, Nyssa, Adrian, Jordan Valley plus unincorporated areas).
- Layer extent falls entirely within southeastern Oregon (roughly -118.16 to -116.83 longitude), not statewide.
- Sample records show Ontario, OR addresses with ZIP 97914, matching Malheur County.
- A CITY=PORTLAND filter query returns 0, confirming this isn't a broader/unfilterable dataset.
- Service returns a normal fields array with no auth errors.

Updated the `addresses`/`county` layer's `data` URL to the new FeatureServer layer and re-verified all conform field names against the new service (they matched the old names except the id field, now `OBJECTID` instead of `FID`). The `parcels` layer, which points to a different, still-working service, is unchanged.