### PR TITLE
Fix broken Hawaii County, HI addresses source

### DIFF
--- a/sources/us/hi/hawaii.json
+++ b/sources/us/hi/hawaii.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://gis.hawaiicounty.gov/arcgis/rest/services/COHGIS_Public/COHGIS_Public/MapServer/22",
+                "data": "https://gis.hawaiicounty.gov/arcgis/rest/services/DIT/County_of_Hawaii/FeatureServer/1",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",


### PR DESCRIPTION
The addresses/county service (`COHGIS_Public/COHGIS_Public/MapServer/22`) returns "Service not found" — the folder was removed from the county's ArcGIS server's public listing entirely (only a handful of unrelated services remain there, and the folder now 499s).

Found the same address point data republished under a new service on the same server: `DIT/County_of_Hawaii/FeatureServer/1` ("Address Points", 95,284 features). The field schema is identical to the old service (ADDRESSNUM, ADDRESSSUF, SDIRPRE, SFEANME, SFEATYP, SDIRSUF, ZIPCODE), so no conform changes were needed — just the data URL.

Verified before committing:
- `?f=json` returns a valid fields array, no auth error
- Feature count query returns 95,284 (consistent with a single-county address dataset)
- Sample records confirm exact field names match the existing conform
- Service supports pagination/extract (maxRecordCount 2000, capabilities Query,Extract)
- No User-Agent blocking

Note: the parcels/county layer in this same file uses the same defunct `COHGIS_Public` service and is also failing; I found a likely replacement (`Hosted/cohParcels_prod_pa11_VIEW:FeatureServer` or `DIT/County_of_Hawaii/FeatureServer/5`) but left it out of this PR since the task scope was addresses only.