### PR TITLE
Fix broken Crook County, OR addresses source

### DIFF
--- a/sources/us/or/crook.json
+++ b/sources/us/or/crook.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://geo.co.crook.or.us/server/rest/services/openData/places/MapServer/1",
+                "data": "https://gis.crookcountyor.gov/server/rest/services/OpenData/Places/MapServer/0",
                 "website": "https://data-crookcounty.opendata.arcgis.com/datasets/crookcounty::address-points/about",
                 "protocol": "ESRI",
                 "conform": {


### PR DESCRIPTION
The addresses/county source for Crook County, OR was failing because the ESRI service host `geo.co.crook.or.us` now redirects to `gis.crookcountyor.gov/portal/home/...`, which 404s (the ArcGIS portal item URL, not a REST services endpoint).

Found the renamed service directly on the county's own ArcGIS Server (`gis.crookcountyor.gov/server/rest/services`): `OpenData/Places/MapServer/0` ("Address Points", 14,111 features), the successor to the old `openData/places/MapServer/1` layer. Same field names as the existing conform (number, direction, street_name, street_type, city, zip), same host, and geographic extent/sample records confirmed within Crook County (Prineville, Powell Butte).

Only the addresses layer's `data` URL was updated; the parcels layer is untouched.