### PR TITLE
Fix broken City of Hurst, TX addresses source

### DIFF
--- a/sources/us/tx/city_of_hurst.json
+++ b/sources/us/tx/city_of_hurst.json
@@ -22,18 +22,18 @@
             {
                 "name": "city",
                 "protocol": "ESRI",
-                "data": "https://mms.hursttx.gov/arcgis/rest/services/AddressPoints/MapServer/0",
+                "data": "https://mms.hursttx.gov/arcgis/rest/services/CAD/FeatureServer/0",
                 "conform": {
                     "format": "geojson",
-                    "number": "STREET_NUM",
+                    "number": "house_num",
                     "street": [
-                        "PREFIX",
-                        "STREET_NAM",
-                        "STREET_TYP",
-                        "SUFFIX"
+                        "pre_dir",
+                        "st_name",
+                        "st_type",
+                        "post_dir"
                     ],
-                    "unit": "SUITE_NO",
-                    "postcode": "ZIP"
+                    "unit": "unit_numb",
+                    "postcode": "zipcode"
                 }
             }
         ],


### PR DESCRIPTION
The addresses/city ESRI source (`AddressPoints/MapServer/0`) has been failing every weekly job with `Service AddressPoints/MapServer not found` — the service was removed from the server entirely.

Checked the root services listing at `https://mms.hursttx.gov/arcgis/rest/services?f=json` and found no address-specific service by any name, but the `CAD` FeatureServer (layer 0, `CAD_Addresses`) contains city address point data with 18,313 features, all scoped to `comm_name = HURST` (verified: 0 features with any other comm_name value), with reasonable extent/coordinates within Hurst city limits. The buildings/city layer on the same server has continued succeeding on every run, confirming the host itself is healthy.

- Layer: addresses
- Replacement source: https://mms.hursttx.gov/arcgis/rest/services/CAD/FeatureServer/0
- Updated conform field names to match the new service's schema (`house_num`, `pre_dir`/`st_name`/`st_type`/`post_dir`, `unit_numb`, `zipcode`) — all verified via sample queries against the live service.