### PR TITLE
Fix broken Buncombe County, NC addresses source

### DIFF
--- a/sources/us/nc/buncombe.json
+++ b/sources/us/nc/buncombe.json
@@ -14,20 +14,19 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://gisdownload.buncombecounty.org/addresses.zip",
-                "protocol": "http",
-                "compression": "zip",
-                "website": "https://www.buncombecounty.org/Governing/Depts/GIS/DataDownload.aspx",
+                "data": "https://gis.buncombecounty.org/arcgis/rest/services/opendata/FeatureServer/2",
+                "protocol": "ESRI",
+                "website": "https://gis.buncombecounty.org/buncomap/",
                 "conform": {
-                    "number": "street_num",
+                    "format": "geojson",
+                    "number": "HouseNumber",
                     "street": [
-                        "street_pre",
-                        "street_nam",
-                        "street_typ",
-                        "street_pos"
+                        "StreetPrefix",
+                        "StreetName",
+                        "StreetType",
+                        "StreetPostDirection"
                     ],
-                    "format": "shapefile",
-                    "postcode": "postal_cod"
+                    "postcode": "ZipCode"
                 }
             }
         ]


### PR DESCRIPTION
The old source downloaded a shapefile ZIP from `gisdownload.buncombecounty.org`, which no longer resolves (DNS dead — confirmed via job log for job 908863: `NameResolutionError`). The last 8+ weekly jobs all failed.

Replaced with the county's own public ArcGIS FeatureServer layer (`gis.buncombecounty.org/arcgis/rest/services/opendata/FeatureServer/2`, layer name "Address"), part of the same "bcmapnew" service that also publishes the county's own County Boundary, Parcel, and Street Centerline layers.

Verification performed:
- Feature count: 187,514, all within Buncombe County's zip codes (e.g. a query for Charlotte's 28202 returns 0 — confirms this is county-scoped data, not a regional/statewide layer)
- Fields verified directly against the service (`HouseNumber`, `StreetPrefix`, `StreetName`, `StreetType`, `StreetPostDirection`, `ZipCode`) with sample queries showing all four street components populated
- No auth errors, geometry type is Point as expected for addresses
- Updated `website` to the county's current GIS portal (`gis.buncombecounty.org/buncomap/`) since the old `buncombecounty.org` DataDownload page 404s under the new `buncombenc.gov` domain
- Validated against the schema (`test/lib.js`) — passes