### PR TITLE
Fix broken Blair County, PA addresses and parcels sources

### DIFF
--- a/sources/us/pa/blair.json
+++ b/sources/us/pa/blair.json
@@ -14,49 +14,35 @@
         "addresses": [
             {
                 "name": "county",
-                "website": "https://www.blairco.org/Dept/GIS/Pages/default.aspx",
+                "website": "https://www.pasda.psu.edu/uci/DataSummary.aspx?dataset=2036",
                 "contact": {
                     "phone": "(814) 693-2535",
                     "email": "gis@blairco.org",
                     "address": "Blair County Courthouse, 423 Allegheny St., Suite 011, Hollidaysburg, PA 16648"
                 },
-                "data": "https://gis.blairco.org/arcgis/rest/services/BCWebMap/WebStructures/MapServer/0",
+                "data": "https://mapservices.pasda.psu.edu/server/rest/services/pasda/BlairCounty/MapServer/0",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
                     "number": "Add_Number",
-                    "street": [
-                        "St_PreMod",
-                        "St_PreDir",
-                        "St_PreTyp",
-                        "St_PreSep",
-                        "St_Name",
-                        "St_PosTyp",
-                        "St_PosDir",
-                        "St_PosMod"
-                    ],
+                    "street": "StreetFull",
                     "unit": [
                         "SubAddType",
                         "SUBADR_NUM"
-                    ],
-                    "id": "PIN",
-                    "city": "Post_Comm",
-                    "district": "County",
-                    "region": "State",
-                    "postcode": "Post_Code"
+                    ]
                 }
             }
         ],
         "parcels": [
             {
                 "name": "county",
-                "website": "https://www.blairco.org/Dept/GIS/Pages/default.aspx",
+                "website": "https://www.pasda.psu.edu/uci/DataSummary.aspx?dataset=2037",
                 "contact": {
                     "phone": "(814) 693-2535",
                     "email": "gis@blairco.org",
                     "address": "Blair County Courthouse, 423 Allegheny St., Suite 011, Hollidaysburg, PA 16648"
                 },
-                "data": "https://gis.blairco.org/arcgis/rest/services/BCWebMap/WebParcels/MapServer/0",
+                "data": "https://mapservices.pasda.psu.edu/server/rest/services/pasda/BlairCounty/MapServer/2",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",


### PR DESCRIPTION
The county's own ArcGIS server (gis.blairco.org) has been unreachable (ConnectTimeout) for at least the last 4 weekly production runs, for both the addresses and parcels layers.

Replaced both layers with Blair County's mirrored ArcGIS REST service on Pennsylvania Spatial Data Access (PASDA), which is scoped specifically to Blair County (not a statewide/regional dataset):

- Addresses: https://mapservices.pasda.psu.edu/server/rest/services/pasda/BlairCounty/MapServer/0 (67,960 features, extent matches Blair County bounding box)
- Parcels: https://mapservices.pasda.psu.edu/server/rest/services/pasda/BlairCounty/MapServer/2 (66,128 features, same PAR_NUM field as before)

Field names were re-verified against the new service (StreetFull replaces the old multi-part street component fields; city/postcode/district/region fields are no longer available in this dataset and were dropped rather than guessed). Website links updated to the PASDA dataset summary pages.