### PR TITLE
Fix broken Delta County, CO addresses, buildings, and parcels sources

### DIFF
--- a/sources/us/co/delta.json
+++ b/sources/us/co/delta.json
@@ -20,7 +20,7 @@
                     "street": "FSN",
                     "city": "PCN"
                 },
-                "data": "https://maps.deltacounty.com/arcgis/rest/services/AddressesONLY_service/MapServer/0",
+                "data": "https://maps.deltacountyco.gov/arcgis/rest/services/AddressesONLY_service/FeatureServer/0",
                 "protocol": "ESRI"
             }
         ],
@@ -30,7 +30,7 @@
                 "conform": {
                     "format": "geojson"
                 },
-                "data": "https://maps.deltacounty.com/arcgis/rest/services/Structures/MapServer/0",
+                "data": "https://maps.deltacountyco.gov/arcgis/rest/services/Structures2025/MapServer/139",
                 "protocol": "ESRI"
             }
         ],
@@ -39,9 +39,9 @@
                 "name": "county",
                 "conform": {
                     "format": "geojson",
-                    "pid": "TaxPIN"
+                    "pid": "TaxPIN_GIS"
                 },
-                "data": "https://maps.deltacounty.com/arcgis/rest/services/PARCELSonly/MapServer/0",
+                "data": "https://maps.deltacountyco.gov/arcgis/rest/services/PARCELSonly/FeatureServer/209",
                 "protocol": "ESRI"
             }
         ]


### PR DESCRIPTION
Delta County's GIS server (`maps.deltacounty.com`) has become completely unreachable — TCP connections to port 443 are reset during the TLS handshake and port 80 times out, confirmed both from a local shell and reflected in the last 10+ weeks of production job failures (all three layers: addresses, buildings, parcels).

The county has migrated its ArcGIS server to a new domain, `maps.deltacountyco.gov`, found via an ArcGIS Online search (`PSAP Address Points` result). It hosts the same service names as before, so this is a same-publisher, same-coverage fix, not a widening of scope. All layers scoped to Delta County only (verified via CITY_COUNTY/AREAID fields and record counts consistent with a single county).

- addresses: `AddressesONLY_service/FeatureServer/0` — 19,282 features, fields SAN/FSN/PCN unchanged from before, so the conform is untouched.
- parcels: `PARCELSonly/FeatureServer/209` — 19,238 features. The parcel ID field was renamed from `TaxPIN` to `TaxPIN_GIS`, updated the conform accordingly.
- buildings: `Structures2025/MapServer/139` (no FeatureServer available for this service) — 44,564 features, replacing the old `Structures` service which no longer exists on the new server; format-only conform, no field changes needed.

All three layers verified via `f=json` metadata (no auth errors, fields array present), feature-count queries, and sample records before writing the source file. Schema validated with `test/lib.js`.