### PR TITLE
Fix broken Otter Tail County, MN addresses source

### DIFF
--- a/sources/us/mn/otter_tail.json
+++ b/sources/us/mn/otter_tail.json
@@ -14,20 +14,19 @@
         "addresses": [
             {
                 "name": "county",
-                "website": "https://ottertailcountymn.us/content-page/gis-shapefile-downloads/",
-                "data": "https://www.ottertailcounty.us/gisfiles/Addresses.zip",
-                "protocol": "http",
-                "compression": "zip",
+                "website": "https://ottertailcounty.gov/property-home/maps-data/",
+                "data": "https://services3.arcgis.com/Pg1yLLk3jMuhxBKI/arcgis/rest/services/AddressesView/FeatureServer/0",
+                "protocol": "ESRI",
                 "conform": {
-                    "format": "shapefile",
+                    "format": "geojson",
                     "number": "ADDRNUM",
                     "street": "FULLNAME",
                     "unit": [
                         "UNITTYPE",
                         "UNITID"
                     ],
-                    "city": "OTC_POSTCO",
-                    "postcode": "OTC_ZIP"
+                    "city": "POSTCOMM",
+                    "postcode": "ZIPCODE"
                 }
             }
         ]


### PR DESCRIPTION
The county's old shapefile download at https://www.ottertailcounty.us/gisfiles/Addresses.zip now returns a 404 (the county's website moved to ottertailcounty.gov and the /gisfiles/ path is gone). The last 8 weekly jobs for this source have all failed with a 404 DownloadError.

The county has since moved its GIS data distribution to an ArcGIS Hub / Feature Service published by its own GIS org (owner `Ottertail_GIS`):

https://services3.arcgis.com/Pg1yLLk3jMuhxBKI/arcgis/rest/services/AddressesView/FeatureServer/0

Verified before writing the conform:
- Service returns a valid fields array, no auth errors.
- Feature count is 41,740, and the layer's extent matches Otter Tail County's geography (roughly 95.1-96.3W, 46.0-46.6N).
- This is the county's own single-layer address service (not a statewide/regional aggregate), so coverage still matches a county-level source.
- Field names re-verified from a live sample query rather than carried over from the old shapefile conform (ADDRNUM, FULLNAME, UNITTYPE/UNITID, POSTCOMM, ZIPCODE).

Changed the source to ESRI protocol / geojson format pointed at the new FeatureServer layer, updated the `website` link to the county's current maps/data page, and validated the JSON against the schema.