### PR TITLE
Fix broken City of Bismarck, ND addresses source

### DIFF
--- a/sources/us/nd/city_of_bismarck.json
+++ b/sources/us/nd/city_of_bismarck.json
@@ -22,7 +22,7 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://services1.arcgis.com/XxHmL09eFqJWI0gE/ArcGIS/rest/services/Address_Points_View/FeatureServer/1",
+                "data": "https://services1.arcgis.com/XxHmL09eFqJWI0gE/ArcGIS/rest/services/Address_Points_View/FeatureServer/4",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",


### PR DESCRIPTION
The addresses/city source for Bismarck, ND was failing with `EsriDownloadError: Could not retrieve layer metadata: The requested layer (layerId: 1) was not found.` The underlying ArcGIS service (`Address_Points_View` on `services1.arcgis.com/XxHmL09eFqJWI0gE`) is still live, but was republished and the address points layer is now id 4 (named "Address Points") instead of id 1.

Verified the new layer before updating:
- `FeatureServer/4?f=json` returns valid metadata with no error.
- Feature count is 46,948 (non-zero).
- All conform fields (`Add_Number`, `STR_NAME`, `Unit`, `Post_Comm`, `County`, `State`, `Post_Code`) are present with unchanged names/casing, so no conform changes were needed.
- Sample records confirm Bismarck-area addresses (e.g. `DiscrpAgID: bismarcknd.gov`, `Inc_Muni: BISMARCK`).

Only the layer index in the `data` URL changed, from `/FeatureServer/1` to `/FeatureServer/4`.