### PR TITLE
Fix broken Lancaster County, PA addresses source

### DIFF
--- a/sources/us/pa/lancaster.json
+++ b/sources/us/pa/lancaster.json
@@ -22,25 +22,22 @@
                     "address": "Lancaster County Government Center, 150 N Queen St., Lancaster, Pennsylvania 17603"
                 },
                 "website": "https://www.co.lancaster.pa.us/143/GIS-Division",
-                "data": "https://arcgis.lancastercountypa.gov/arcgis/rest/services/Hosted/AddressWithPostal/FeatureServer/0",
+                "data": "https://services1.arcgis.com/I6XnrlnguPDoEObn/arcgis/rest/services/Address_Points/FeatureServer/0",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
                     "number": [
-                        "adrnum",
-                        "numsfx"
+                        "ADRNUM",
+                        "NUMSFX"
                     ],
                     "street": [
-                        "fdpre",
-                        "fname",
-                        "ftype",
-                        "fdsuf"
+                        "FDPRE",
+                        "FNAME",
+                        "FTYPE",
+                        "FDSUF"
                     ],
-                    "unit": [
-                        "unittype",
-                        "unitnum"
-                    ],
-                    "city": "muni"
+                    "unit": "UNIT",
+                    "city": "MUNI"
                 }
             }
         ]


### PR DESCRIPTION
The addresses/county source pointed at `arcgis.lancastercountypa.gov/.../Hosted/AddressWithPostal/FeatureServer/0`, which now returns `Service not found` (service removed/renamed). Every job for the past several months has failed with this error.

Searched the county's ArcGIS servers and organization for a replacement:
- The old server's `Hosted` folder no longer has an address points service (only a small 19-record personal test layer, `MJDAddressPoints`, which is not usable).
- Found `Address Points` (description: "A point representation of 911 address points in Lancaster County...") published under the county's own ArcGIS Online org (`I6XnrlnguPDoEObn`, the same org hosting the county's other authoritative open data layers): `https://services1.arcgis.com/I6XnrlnguPDoEObn/arcgis/rest/services/Address_Points/FeatureServer/0`.
- Verified this is scoped to Lancaster County: 228,885 features, and a group-by count on the `MUNI` field shows all of Lancaster County's ~60 townships/boroughs, with only a handful of stray records from bordering counties (Berks, Chester, Dauphin, Lebanon) — normal border noise, not a multi-county regional dataset.
- Field names carried over conceptually from the old source (`ADRNUM`/`NUMSFX`, `FDPRE`/`FNAME`/`FTYPE`/`FDSUF`) but are now uppercase; re-verified every field against a live sample rather than assuming the old lowercase names still applied. Also switched `unit` to the single pre-combined `UNIT` field.
- Confirmed no auth/token requirements and no bot-blocking (works with and without a `User-Agent` header).
- Confirmed large AGOL-hosted county feature services process fine in production at this scale by checking Montgomery County, PA's currently-succeeding addresses job (360,774 features on a similar `services1.arcgis.com` hosted FeatureServer).

Updated `sources/us/pa/lancaster.json` with the new `data` URL and conform field names; kept the existing `website`/`contact` info. Validated against `test/lib.js` (VALID).