### PR TITLE
fix broken City of Palmerston North, NZ addresses source

### DIFF
--- a/sources/nz/city_of_palmerston_north.json
+++ b/sources/nz/city_of_palmerston_north.json
@@ -15,9 +15,9 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://opendata.arcgis.com/datasets/af0f40a1e7da43b4bd550f66a3ba887e_0.geojson",
-                "protocol": "http",
-                "website": "https://data-pncc.opendata.arcgis.com/datasets/af0f40a1e7da43b4bd550f66a3ba887e_0",
+                "data": "https://services.arcgis.com/Fv0Tvc98QEDvQyjL/arcgis/rest/services/House_Number_General/FeatureServer/0",
+                "protocol": "ESRI",
+                "website": "https://pncc.maps.arcgis.com/home/item.html?id=7f482f77608e4f48897ad301c9872085",
                 "license": {
                     "url": "https://creativecommons.org/licenses/by/4.0/",
                     "text": "CC BY 4.0",
@@ -28,7 +28,7 @@
                     "number": "HOUSENUM",
                     "street": [
                         "ST_NAME",
-                        "ST_DESC"
+                        "ST_TYPE"
                     ],
                     "postcode": "POSTCODE",
                     "city": "TOWN"


### PR DESCRIPTION
The legacy `opendata.arcgis.com/datasets/<id>_0.geojson` download URL now returns a 403 (the underlying ArcGIS Online item's Hub download endpoint has been locked down). Recent jobs all failed with:

```
openaddr.cache.DownloadError: 403 response from https://opendata.arcgis.com/datasets/af0f40a1e7da43b4bd550f66a3ba887e_0.geojson
```

Found the same dataset republished as a public ArcGIS FeatureServer owned by Palmerston North City Council's own GeoHub org (`PNCC_GeoHUB`, item "PNCC Addresses"):

- https://services.arcgis.com/Fv0Tvc98QEDvQyjL/arcgis/rest/services/House_Number_General/FeatureServer/0

Verified before switching:
- 39,376 features, no auth errors
- Only two `TOWN` values present (Palmerston North and Ashhurst, both within Palmerston North City's boundaries) — confirms this is a city-scoped dataset, not a regional/multi-jurisdiction one
- A filter for an out-of-area town (`Wellington`) returns 0 features
- Service extent (175.50,-40.50 to 175.79,-40.27) matches Palmerston North City's area
- Field names re-verified from `?f=json`/sample query rather than assumed from the old conform (`ST_TYPE` replaces the old `ST_DESC`, other fields unchanged)

Switched protocol from `http`/geojson-download to `ESRI`/FeatureServer, which is more resilient than the deprecated Hub download link.