### PR TITLE
Fix broken Franklin County, AL addresses, parcels, and buildings sources

### DIFF
--- a/sources/us/al/franklin.json
+++ b/sources/us/al/franklin.json
@@ -19,8 +19,7 @@
                 "conform": {
                     "format": "geojson",
                     "number": "SitusAddNumber",
-                    "street": "SitusAddName",
-                    "city": "SitusAddCity"
+                    "street": "SitusAddName"
                 }
             }
         ],

--- a/sources/us/al/franklin.json
+++ b/sources/us/al/franklin.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://web5.kcsgis.com/kcsgis/rest/services/Franklin/Public/MapServer/105",
+                "data": "https://web6.kcsgis.com/kcsgis/rest/services/Franklin/Franklin_Public_ISV/MapServer/105",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
@@ -27,7 +27,7 @@
         "parcels": [
             {
                 "name": "county",
-                "data": "https://web5.kcsgis.com/kcsgis/rest/services/Franklin/Public/MapServer/105",
+                "data": "https://web6.kcsgis.com/kcsgis/rest/services/Franklin/Franklin_Public_ISV/MapServer/105",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
@@ -38,7 +38,7 @@
         "buildings": [
             {
                 "name": "county",
-                "data": "https://web5.kcsgis.com/kcsgis/rest/services/Franklin/Public/MapServer/102",
+                "data": "https://web6.kcsgis.com/kcsgis/rest/services/Franklin/Franklin_Public_ISV/MapServer/102",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson"


### PR DESCRIPTION
The KCS GIS server hosting Franklin County's public map service was reorganized: `web5.kcsgis.com/.../Franklin/Public/MapServer` was replaced with a `Public_monthly` service that no longer publishes the parcel/address layer (105), causing `Service Franklin/Public/MapServer not started` failures for all three layers (addresses, parcels, buildings).

Found the county's current parcel viewer (isv.kcsgis.com/al.franklin_revenue) still references a live backend at `web6.kcsgis.com/kcsgis/rest/services/Franklin/Franklin_Public_ISV/MapServer`, which republishes the same layer structure under the same layer IDs (105 = Parcels, 102 = Buildings) with the same field names (SitusAddNumber, SitusAddName, SitusAddCity, PARCELID).

Verified before committing:
- Layer 105 (Parcels): 23,519 features, fields match the existing conform exactly, sample records show real Franklin County parcels (Russellville, Spruce Pine, etc.)
- Layer 102 (Buildings): 33,315 features
- Service full extent (~-88.20 to -87.48 lon, ~34.22 to 34.49 lat) matches Franklin County, AL
- No auth/token errors, no special User-Agent required
- Schema validated with `test/lib.js`

Only the `data` URLs changed; conform blocks are unchanged since field names carried over identically.