### PR TITLE
Fix broken Franklin County, WA addresses and parcels sources

### DIFF
--- a/sources/us/wa/franklin.json
+++ b/sources/us/wa/franklin.json
@@ -14,36 +14,39 @@
         "addresses": [
             {
                 "name": "county",
-                "license": "https://gis.co.franklin.wa.us/datadisclaimer.shtml",
-                "protocol": "ESRI",
-                "data": "https://gisportal.franklin.co.franklin.wa.us/arcgis/rest/services/Address_Points/MapServer/0",
-                "website": "https://gisportal.franklin.co.franklin.wa.us/arcgisportal/home/item.html?id=7485b54ee408498b884380908bc59e07",
+                "license": "https://www.franklincountywa.gov/670/Mapping-GIS",
+                "protocol": "http",
+                "compression": "zip",
+                "data": "https://content.franklincountywa.gov/gis/Data/Address_Web.zip",
+                "website": "https://www.franklincountywa.gov/671/Data-Downloads",
                 "conform": {
-                    "format": "geojson",
-                    "number": "HouseNumber",
+                    "format": "shapefile",
+                    "number": "HouseNumbe",
                     "street": [
                         "DirPrefix",
-                        "FeatureName",
-                        "FeatureType",
+                        "FeatureNam",
+                        "FeatureTyp",
                         "DirSuffix"
                     ],
                     "unit": [
                         "UnitType",
                         "UnitNumber"
-                    ]
+                    ],
+                    "city": "ZipArea"
                 }
             }
         ],
         "parcels": [
             {
                 "name": "county",
-                "license": "https://gis.co.franklin.wa.us/datadisclaimer.shtml",
-                "protocol": "ESRI",
-                "data": "https://gisportal.franklin.co.franklin.wa.us/arcgis/rest/services/Parcels/MapServer/15",
-                "website": "https://gisportal.franklin.co.franklin.wa.us/arcgisportal/home/item.html?id=90a875f5725441e48565cf7b13f6290e",
+                "license": "https://www.franklincountywa.gov/670/Mapping-GIS",
+                "protocol": "http",
+                "compression": "zip",
+                "data": "https://content.franklincountywa.gov/gis/Data/Parcels_Web.zip",
+                "website": "https://www.franklincountywa.gov/671/Data-Downloads",
                 "conform": {
-                    "format": "geojson",
-                    "pid": "APN"
+                    "format": "shapefile",
+                    "pid": "PARCELNUMB"
                 }
             }
         ]


### PR DESCRIPTION
The county's old ArcGIS server (gisportal.franklin.co.franklin.wa.us) has been returning HTTP 500 "Could not access any server machines" errors for both the addresses and parcels layers since at least June 2026 (confirmed via job history at batch.openaddresses.io — 13+ consecutive weekly failures, and the ArcGIS REST root itself still 500s today).

The county has since moved to a new site (franklincountywa.gov) with a GIS data downloads page (https://www.franklincountywa.gov/671/Data-Downloads) that serves direct shapefile ZIP downloads, last updated 2026-09-11:

- Addresses: https://content.franklincountywa.gov/gis/Data/Address_Web.zip (33,295 point features)
- Parcels: https://content.franklincountywa.gov/gis/Data/Parcels_Web.zip (34,723 polygon features)

Both were downloaded and inspected with ogrinfo to confirm geometry type, feature counts, and exact field names before updating the conform. The address fields (HouseNumbe/DirPrefix/FeatureNam/FeatureTyp/DirSuffix/UnitType/UnitNumber) carried over from the old service; added `city` mapped to `ZipArea`, which holds the postal city name (Pasco, Connell, Mesa, etc.). Parcels now use `PARCELNUMB` as `pid` (the old `APN` field no longer exists in this export).

Switched both layers from ESRI protocol to `http`/`shapefile`/zip compression to match the new source.