### PR TITLE
Fix broken City of Flagstaff, AZ addresses source

### DIFF
--- a/sources/us/az/city_of_flagstaff.json
+++ b/sources/us/az/city_of_flagstaff.json
@@ -21,8 +21,8 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://gis.flagstaffaz.gov/arcgisserver/rest/services/Addresses/FeatureServer/0",
-                "website": "https://gis.flagstaffaz.gov/portal/apps/sites/#/opendata/datasets/54fa279b97294558b71e23869d60c487/about",
+                "data": "https://gis.flagstaffaz.gov/arcgisserver/rest/services/COF_Authoritative/FeatureServer/1",
+                "website": "https://gis.flagstaffaz.gov/portal/home/item.html?id=85db623f177b40e3af0f23a713a9b779",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",


### PR DESCRIPTION
The addresses/city source pointed at `https://gis.flagstaffaz.gov/arcgisserver/rest/services/Addresses/FeatureServer/0`, which now returns `Service not found` (the last 4 production jobs all failed with this error, confirmed via the batch API job log). The service was removed/renamed on the city's ArcGIS Server.

Found the replacement by browsing the server's root services listing (`/arcgisserver/rest/services?f=json`), which no longer lists an `Addresses` service but does list `COF_Authoritative`, a consolidated feature service containing the city's NENA layers. Layer 1 of that service, "City NENA Address Points", has the identical field schema as the old service (`Add_Number`, `AddNum_Suf`, `St_PreDir`, `St_PreTyp`, `St_Name`, `St_PosTyp`, `St_PosDir`, `Post_Comm`, `Post_Code`, `UnitType`, `Unit`, `AddressID`, `State`), so the existing conform mapping did not need to change.

Verified before writing the fix:
- `?f=json` on the new layer returns a valid `fields` array with no auth errors.
- Feature count is 39,460, all with `Inc_Muni = 'Flagstaff'` and `Post_Comm = 'Flagstaff'` (0 records otherwise), and the layer's spatial extent is ~12 x 8 miles, consistent with the city's actual footprint rather than a countywide dataset — confirming this is scoped to the city, not a regional/multi-jurisdiction layer.
- Sample records show correct field values matching the expected conform.

Updated the `data` URL to the new layer and the `website` URL to the current ArcGIS portal item page (the old opendata dataset page for this layer no longer resolves to anything).

- Layer: addresses
- New source: https://gis.flagstaffaz.gov/arcgisserver/rest/services/COF_Authoritative/FeatureServer/1