### PR TITLE
Fix broken City of Amarillo, TX addresses source

### DIFF
--- a/sources/us/tx/city_of_amarillo.json
+++ b/sources/us/tx/city_of_amarillo.json
@@ -27,7 +27,12 @@
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
-                    "number": "ADDRESS",
+                    "number": {
+                        "function": "regexp",
+                        "field": "ADDRESS",
+                        "pattern": "^([0-9]+)(?:\\.0)?$",
+                        "replace": "$1"
+                    },
                     "street": [
                         "ST_DIR",
                         "ST_NAME",
@@ -36,7 +41,12 @@
                     ],
                     "unit": "APP_UNIT_ID",
                     "city": "POST_CITY",
-                    "postcode": "ZIPCODE"
+                    "postcode": {
+                        "function": "regexp",
+                        "field": "ZIPCODE",
+                        "pattern": "^([0-9]+)(?:\\.0)?$",
+                        "replace": "$1"
+                    }
                 }
             }
         ]

--- a/sources/us/tx/city_of_amarillo.json
+++ b/sources/us/tx/city_of_amarillo.json
@@ -22,7 +22,8 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://services6.arcgis.com/Vdk8uHgdgYx8ZqS6/ArcGIS/rest/services/AddressPointsArcGISOnline/FeatureServer/1",
+                "data": "https://gismaps.amarillo.gov/services/rest/services/AddressPoints/FeatureServer/1",
+                "website": "https://www.amarillo.gov/gis/",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",


### PR DESCRIPTION
The addresses/city source for Amarillo, TX has been failing all recent weekly jobs with:

esridump.errors.EsriDownloadError: Could not retrieve layer metadata: Invalid URL Invalid URL

The old ArcGIS Online-hosted service (services6.arcgis.com/.../AddressPointsArcGISOnline/FeatureServer/1) no longer exists.

Investigation:
- The City of Amarillo's ArcGIS Online org (same org id, Vdk8uHgdgYx8ZqS6) has a similarly-named public service (AddressPointsDroneSense/FeatureServer/0), but it is a regional joint-jurisdiction dataset (Potter/Randall 911 addressing, covering Amarillo plus Canyon, Bushland, Lake Tanglewood, Timbercreek Canyon, and unincorporated county) with no way for this repo's ESRI source schema to filter it down to just Amarillo, so it was not used.
- Found the City's own on-premise ArcGIS Server at gismaps.amarillo.gov, which hosts an "AddressPoints" FeatureServer with the address points layer at index 1 — the same layer index, and identical field names/schema (ADDRESS, APP_UNIT_ID, ST_DIR, ST_NAME, ST_TYPE, ST_POSTDIR, POST_CITY, ZIPCODE) as the previously-working source. This is the authoritative, currently-maintained replacement for the dead AGOL copy.
- Verified the new endpoint returns valid metadata, no auth is required, and it returns 125,608 features with the expected fields.

Updated the `data` URL to the new FeatureServer endpoint and added a `website` link to the City's GIS portal. The `conform` block is unchanged since all field names carried over exactly.