### PR TITLE
Fix broken Paulding County, GA addresses and parcels sources

### DIFF
--- a/sources/us/ga/paulding.json
+++ b/sources/us/ga/paulding.json
@@ -14,27 +14,24 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://arcgis5.roktech.net/arcgis/rest/services/Paulding/TaxMap4/MapServer/1",
+                "data": "https://services8.arcgis.com/7YXQzPPGs9Uc4qKl/arcgis/rest/services/Paulding_Map_Auto_Updated_WFL1/FeatureServer/2",
+                "website": "https://www.paulding.gov/156/Geographic-Information-Systems-GIS-Divis",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
-                    "number": {
-                        "function": "prefixed_number",
-                        "field": "Address"
-                    },
-                    "street": {
-                        "function": "postfixed_street",
-                        "field": "Address"
-                    },
-                    "postcode": "ZipCode",
-                    "city": "City"
+                    "number": "StructureNumber",
+                    "street": ["DirectionalPrefix", "StreetName", "StreetType", "DirectionalSuffix"],
+                    "unit": "Subaddress",
+                    "city": "City",
+                    "postcode": "ZipCode"
                 }
             }
         ],
         "parcels": [
             {
                 "name": "county",
-                "data": "https://arcgis5.roktech.net/arcgis/rest/services/Paulding/TaxMap4/MapServer/6",
+                "data": "https://services8.arcgis.com/7YXQzPPGs9Uc4qKl/arcgis/rest/services/Paulding_Map_Auto_Updated_WFL1/FeatureServer/25",
+                "website": "https://www.paulding.gov/156/Geographic-Information-Systems-GIS-Divis",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",


### PR DESCRIPTION
The addresses and parcels sources for Paulding County, GA (\`sources/us/ga/paulding.json\`) have been failing for 4+ consecutive weekly runs with:

\`\`\`
esridump.errors.EsriDownloadError: Could not retrieve layer metadata: Service Paulding/TaxMap4/MapServer not started
\`\`\`

Investigation showed the entire \`Paulding\` folder on \`arcgis5.roktech.net\` (the county's former ROK Technologies-hosted ArcGIS Server) is now empty/decommissioned — every service under it (\`TaxMap4\`, \`GoMaps4\`, \`orthos_2021\`, etc.) returns "not started" or "not found", while other counties' folders on the same server (e.g. \`gulf\`, \`robeson\`, \`Warren\`) still work fine, confirming this is specific to Paulding rather than a server-wide or transient issue. Even the county's own legacy tax map viewer at \`maps.roktech.net/PauldingTM4\` still points at the same dead service, confirming it was never updated after the migration.

The county has since moved its authoritative GIS data to its own ArcGIS Online organization (\`paulding.maps.arcgis.com\`), linked from its official GIS page. That org hosts a maintained "Paulding Map Auto Updated" feature service with dedicated Address Points and Parcels layers:

- Address Points: \`https://services8.arcgis.com/7YXQzPPGs9Uc4qKl/arcgis/rest/services/Paulding_Map_Auto_Updated_WFL1/FeatureServer/2\` (85,545 features)
- Parcels: \`https://services8.arcgis.com/7YXQzPPGs9Uc4qKl/arcgis/rest/services/Paulding_Map_Auto_Updated_WFL1/FeatureServer/25\` (75,538 features)

Both layers are scoped to Paulding County (~92% of address records have \`AddressJurisdiction = Paulding County\`, with only minor legitimate border bleed into neighboring counties' E911-shared addresses) and their spatial extent matches the county. Field names were re-verified from the live service rather than carried over from the old source (e.g. house number is now \`StructureNumber\`, not extracted from a combined \`Address\` string).

Updated \`sources/us/ga/paulding.json\`:
- \`addresses\`: new ESRI FeatureServer URL, conform rebuilt against actual field names (\`StructureNumber\`, \`DirectionalPrefix\`/\`StreetName\`/\`StreetType\`/\`DirectionalSuffix\`, \`Subaddress\`, \`City\`, \`ZipCode\`)
- \`parcels\`: new ESRI FeatureServer URL, \`pid\` remains \`GPIN\` (field still present under the new service)
- both layers now include a \`website\` pointing to the county's GIS division page

Schema validated with the project's \`test/lib.js\` compile+validate check (VALID).