### PR TITLE
Fix broken Municipality of Nacka, Sweden addresses source

### DIFF
--- a/sources/se/municipality_of_nacka.json
+++ b/sources/se/municipality_of_nacka.json
@@ -8,7 +8,7 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://webbkarta.nacka.se/geoserver/wfs?SERVICE=WFS&version=1.1.0&request=GetFeature&typeName=nacka:adresspunkter&outputFormat=application%2Fjson&srsName=EPSG:4326",
+                "data": "https://karta.nacka.se/geoserver/wfs?SERVICE=WFS&version=1.1.0&request=GetFeature&typeName=nacka:adresspunkter&outputFormat=application%2Fjson&srsName=EPSG:4326",
                 "protocol": "http",
                 "conform": {
                     "format": "geojson",


### PR DESCRIPTION
The addresses/city source for Nacka kommun was failing every weekly job with a ConnectTimeout to `webbkarta.nacka.se` — the host is completely unreachable (DNS resolves but no TCP/ICMP response), not just the WFS endpoint.

The municipality's GeoServer has moved to `karta.nacka.se`. Verified the replacement:
- Same GeoServer layer name (`nacka:adresspunkter`) is present in the new host's WFS GetCapabilities listing.
- Sample and full WFS GetFeature queries return valid GeoJSON with the same field names (`adrplats`, `adromrade`) used in the existing conform.
- Feature count is 25,461, and the spatial extent (lon 18.107–18.380, lat 59.247–59.366) matches Nacka kommun exactly — confirming the layer is scoped to this municipality, not a regional/national dataset.

Fix is a one-line hostname change in the `data` URL; conform is unchanged since field names carried over.