### PR TITLE
Fix broken Vermilion County, IL addresses source

### DIFF
--- a/sources/us/il/vermilion.json
+++ b/sources/us/il/vermilion.json
@@ -14,24 +14,16 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://ags.bhamaps.com/arcgisserver/rest/services/VermilionIL/VermilionIL_PAT_Parcel_Taxmap/MapServer/0",
+                "data": "https://services6.arcgis.com/am689ZyfXfdo9vCK/arcgis/rest/services/Addressing/FeatureServer/3",
+                "website": "https://vermilion-county-illinois-gis-hub-vermilioncoil.hub.arcgis.com/",
                 "protocol": "ESRI",
                 "conform": {
-                    "number": {
-                        "function": "regexp",
-                        "field": "FullSiteAddress1",
-                        "pattern": "^([0-9]+)"
-                    },
-                    "street": {
-                        "function": "regexp",
-                        "field": "FullSiteAddress1",
-                        "pattern": "^(?:[0-9]+ )(.*)",
-                        "replace": "$1"
-                    },
-                    "format": "geojson"
-                },
-                "skip": true,
-                "note": "bhamaps.com servers are dead as of 2026-04"
+                    "format": "geojson",
+                    "number": ["Add_Number", "AddNum_Suf"],
+                    "street": ["St_PreDir", "St_PreTyp", "St_Name", "St_PosTyp", "St_PosDir", "St_PosMod"],
+                    "city": "Post_Comm",
+                    "postcode": "Post_Code"
+                }
             }
         ],
         "parcels": [


### PR DESCRIPTION
The addresses/county layer for Vermilion County, IL was marked `skip: true` after its old provider (ags.bhamaps.com) went fully offline as of 2026-04 (the ArcGIS Server there now returns 404/expired-cert on every path). Job history confirms it has been failing on every run since (jobs 894741, 899664, 904556, 909506).

Found the county's real ArcGIS Online organization (`am689ZyfXfdo9vCK`, "Vermilion County Illinois", home of the county's GIS Hub) and its `Addressing/FeatureServer/3` "AddressPoints" layer:

- Point geometry, NENA-style schema (Add_Number/AddNum_Suf/St_PreDir/St_Name/etc.)
- 35,958 features
- Sampled records cover Danville, Georgetown, Hoopeston, Westville, Rossville, Alvin, Armstrong, Bismarck, Collison, Fithian, Ogden, Penfield, Potomac, Rankin — all Vermilion County communities
- Confirmed scoped to the county: a filter for a neighboring county's city (`Post_Comm='CHAMPAIGN'`) returns 0 features, while an in-county town (`Post_Comm='GEORGETOWN'`) returns 2,161
- No auth requirements, no User-Agent blocking

Updated the `addresses`/`county` layer to point at this service with a verified conform (fields confirmed via a live sample query, not assumed).

Note for a maintainer: while investigating I found the existing `parcels`/`county` layer (`services6.arcgis.com/Z2F3lckKXNBvWQZU/.../Parcel/FeatureServer/1`) actually returns Putnam County, IL parcels (e.g. Magnolia, IL 61336; extent centers near 41.3N -89.3W), not Vermilion County data, even though that layer currently reports "Success" in job history. That looks like a separate pre-existing data-scoping bug worth its own fix, so I left it untouched here.