### PR TITLE
Fix broken Bahamas New Providence addresses source

### DIFF
--- a/sources/bs/new_providence.json
+++ b/sources/bs/new_providence.json
@@ -13,7 +13,8 @@
         "addresses": [
             {
                 "name": "region",
-                "data": "https://bngiscportal.gov.bs/server/rest/services/Hosted/NP_Addresses/FeatureServer/2",
+                "data": "https://services1.arcgis.com/4oMMDQGZOv7y40Xb/arcgis/rest/services/New_Providence___Basemap_WFL1/FeatureServer/3",
+                "website": "https://www.arcgis.com/home/item.html?id=5d143764e55e4dc3a0e583b190e39351",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",


### PR DESCRIPTION
The addresses/region source for New Providence, Bahamas has failed the last 8+ production runs (spanning 9+ weeks, since at least run 14751 in July) with ConnectTimeout errors against `bngiscportal.gov.bs`.

Confirmed the host itself is unreachable: DNS resolves but TCP connections to both port 443 and 80 hang/timeout from an independent client, matching the production log pattern exactly. This is a dead host, not a transient blip.

Found a same-coverage replacement: the New Providence address points dataset has been republished as a public ArcGIS Online Feature Service (`New Providence - Basemap`, owned by a GIS contractor who did address/building surveying work for New Providence). Verified before writing the conform:

- Layer 3 (`New Providence - Address Points`) is public, no auth required, 67,513 features.
- Field names are identical to the old source (`house_numb`, `street_nam`, `island_cod`), confirmed via a live sample query rather than assumed.
- `island_cod` is uniformly `NP` in sampled/distinct-value queries, and the layer's spatial extent is tightly bounded around New Providence island (~-77.56 to -77.26 lon, ~25.05 to 25.13 lat) — this is an island-scoped dataset, not an unfilterable national layer.

Updated `data` to the new FeatureServer layer URL and added a `website` link to the ArcGIS Online item page. Conform is unchanged since field names carried over exactly.