### PR TITLE
Fix broken City of Riverside, CA addresses source

### DIFF
--- a/sources/us/ca/city_of_riverside.json
+++ b/sources/us/ca/city_of_riverside.json
@@ -21,7 +21,7 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://services.arcgis.com/Fu2oOWg1Aw7azh41/ArcGIS/rest/services/Riverside_Address_Pt/FeatureServer/5",
+                "data": "https://services.arcgis.com/Fu2oOWg1Aw7azh41/ArcGIS/rest/services/Riverside_Address_Pt/FeatureServer/0",
                 "website": "https://geodata-cityofriverside.opendata.arcgis.com/datasets/CityOfRiverside::riverside-address-pt/about",
                 "protocol": "ESRI",
                 "conform": {


### PR DESCRIPTION
The addresses/city layer was failing with `EsriDownloadError: Could not retrieve layer metadata: The requested layer (layerId: 5) was not found.` — the city's ArcGIS FeatureServer (Riverside_Address_Pt) was restructured and now only exposes the address points at layer index 0 instead of 5.

The parcels and buildings layers on the same server (Fu2oOWg1Aw7azh41) are still succeeding, confirming the server itself is healthy and this is just a layer index shift.

Verified the new layer before writing the fix:
- `FeatureServer/0` ("Riverside Address Points") has the same field schema as before (StreetNumber, PrefixDir, StreetName, StreetType, SuffixDir, UnitType, Unit, CitySitus, State, ZipCode, AddressID), so the existing conform still applies unchanged.
- Feature count: 92,927 — reasonable for a single city.
- Scoping check: `CitySitus <> 'RIVERSIDE'` returns only 1 feature out of 92,927 (negligible border noise), and CitySitus is a coded-value domain field defaulting to "Riverside" alongside neighboring cities (Corona, Eastvale, Norco, etc.) that aren't present in the data — confirms this is scoped to the City of Riverside, not a shared regional layer.

Change: updated `data` URL from `.../Riverside_Address_Pt/FeatureServer/5` to `.../Riverside_Address_Pt/FeatureServer/0` in `sources/us/ca/city_of_riverside.json`. No conform changes needed.