### PR TITLE
Fix broken Sublette County WY addresses and parcels source

### DIFF
--- a/sources/us/wy/sublette.json
+++ b/sources/us/wy/sublette.json
@@ -15,7 +15,7 @@
             {
                 "name": "county",
                 "compression": "zip",
-                "data": "https://greenwoodmap.com/sublette/mapserver/download/ownership_shp.zip",
+                "data": "https://maps.terragis.net/sublette/mapserver/download/ownership_shp.zip",
                 "protocol": "http",
                 "conform": {
                     "format": "shapefile",
@@ -34,7 +34,7 @@
             {
                 "name": "county",
                 "compression": "zip",
-                "data": "https://greenwoodmap.com/sublette/mapserver/download/ownership_shp.zip",
+                "data": "https://maps.terragis.net/sublette/mapserver/download/ownership_shp.zip",
                 "protocol": "http",
                 "conform": {
                     "format": "shapefile",


### PR DESCRIPTION
Both the addresses and parcels layers were failing with a 404 Download Error from https://greenwoodmap.com/sublette/mapserver/download/ownership_shp.zip.

Root cause: Greenwood Mapping migrated all of its Wyoming/Idaho county MapServer hosting to Terra GIS. The greenwoodmap.com root page now confirms this and links to https://www.terragis.net/county-gis/, which lists the new Sublette County GIS site at https://maps.terragis.net/sublette/.

The same download path exists at the new host (https://maps.terragis.net/sublette/mapserver/download/ownership_shp.zip) and returns a valid zip containing address.shp and ownership.shp with identical field names to the previous conform (streetnum, streetdir, streetname, streetsuf, pidn for addresses; pidn for parcels). Verified with ogrinfo: address.shp has 12,335 point features with Sublette County content (Big Piney, US Hwy 189/191, etc.), and ownership.shp retains the pidn field used for parcels.

- Layer: addresses, parcels (both reference the same zip)
- New source: https://maps.terragis.net/sublette/mapserver/download/ownership_shp.zip
- No conform or field-name changes needed — only the host changed