### PR TITLE
Fix broken City of Bothell WA addresses/parcels/buildings source

### DIFF
--- a/sources/us/wa/city_of_bothell.json
+++ b/sources/us/wa/city_of_bothell.json
@@ -16,7 +16,7 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://gisweb.bothellwa.gov/server/rest/services/public/COBMap_Public_Property_Land/MapServer/0",
+                "data": "https://gisweb.bothellwa.gov/server/rest/services/public/dsi_Basemap_CSS/MapServer/1",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
@@ -38,7 +38,7 @@
         "parcels": [
             {
                 "name": "city",
-                "data": "https://gisweb.bothellwa.gov/server/rest/services/public/COBMap_Public_Property_Land/MapServer/2",
+                "data": "https://gisweb.bothellwa.gov/server/rest/services/public/dsi_Basemap_CSS/MapServer/7",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
@@ -49,7 +49,7 @@
         "buildings": [
             {
                 "name": "city",
-                "data": "https://gisweb.bothellwa.gov/server/rest/services/public/COBMap_Public_Property_Land/MapServer/3",
+                "data": "https://gisweb.bothellwa.gov/server/rest/services/public/dsi_Basemap_CSS/MapServer/2",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson"


### PR DESCRIPTION
The addresses, parcels, and buildings layers were all failing with \`EsriDownloadError: Could not retrieve layer metadata: Service public/COBMap_Public_Property_Land/MapServer not found\` — the city's ArcGIS server retired that service.

I checked the server's root services listing (\`https://gisweb.bothellwa.gov/server/rest/services?f=json\`) and found the same data now published under \`public/dsi_Basemap_CSS/MapServer\`, with the layers renumbered:

- addresses: layer 0 -> layer 1 ("Addresses", 26,094 features, field names unchanged: \`Addr_Num\`, \`PreDir\`, \`Street\`, \`Street_Type\`, \`PostDir\`, \`Unit\`, \`PostalCity\`, \`County\`, \`State\`, \`Zip\`)
- parcels: layer 2 -> layer 7 ("Bothell Parcels", 17,035 features, \`PIN\` field unchanged)
- buildings: layer 3 -> layer 2 ("Buildings", 35,283 features)

Verified each layer is scoped to the city itself, not a regional dataset: querying \`Jurisdiction\`/\`JURISDICTION\` on the addresses and parcels layers returns only \`BOTHELL\` (0 features for any other value), and the service extent matches Bothell, WA. No auth is required and the conform field names carry over unchanged from the previous service, since only the service path and layer indexes moved.

Validated against the schema with \`test/lib.js\`.