### PR TITLE
Fix broken City of Allentown PA addresses source

### DIFF
--- a/sources/us/pa/city_of_allentown.json
+++ b/sources/us/pa/city_of_allentown.json
@@ -22,7 +22,7 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://geoservices1.allentownpa.gov/server/rest/services/CityAddresses/MapServer/0",
+                "data": "https://geoservices1.allentownpa.gov/server/rest/services/CityAddresses/FeatureServer/3",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",


### PR DESCRIPTION
The addresses/city layer was failing with `esridump.errors.EsriDownloadError: Could not retrieve layer metadata: Layer not found` against `CityAddresses/MapServer/0`.

The city's own GIS server (geoservices1.allentownpa.gov) still hosts the `CityAddresses` service, but the address layer was republished at layer ID 3 instead of 0 — same fields, same data (57,894 records, all CITY = ALLENTOWN, confirmed with a count query). Updated the `data` URL to `CityAddresses/FeatureServer/3` (also switched MapServer to FeatureServer). No conform changes were needed since all fields (HOUSE_NUM, PRE_DIR, ST_NAME, ST_TYPE, SUF_DIR, UNIT, CITY, STATE, ZIP, SITEADDRESSID) are unchanged on the new layer.