### PR TITLE
Fix broken De Soto Parish LA addresses/parcels source

### DIFF
--- a/sources/us/la/desoto.json
+++ b/sources/us/la/desoto.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://services8.arcgis.com/t9nZiIqtWRhVGuPI/ArcGIS/rest/services/DeSoto_911_Jan2024/FeatureServer/2",
+                "data": "https://services8.arcgis.com/t9nZiIqtWRhVGuPI/ArcGIS/rest/services/DeSoto_911_Jul25/FeatureServer/1",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
@@ -28,7 +28,7 @@
         "parcels": [
             {
                 "name": "county",
-                "data": "https://services8.arcgis.com/t9nZiIqtWRhVGuPI/ArcGIS/rest/services/DeSoto_911_Jan2024/FeatureServer/8",
+                "data": "https://services1.arcgis.com/jh7pbmmfSzUSNziy/arcgis/rest/services/Desoto_Weblayers/FeatureServer/9",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",


### PR DESCRIPTION
The AGOL FeatureServer item `DeSoto_911_Jan2024` was deleted/renamed on the county's ArcGIS Online organization, so both the `addresses` and `parcels` layers were failing with `Invalid URL` errors on every recent job.

Found the replacement services and confirmed both are scoped specifically to De Soto Parish, LA (not a regional/multi-parish dataset):

- Addresses: renamed service `DeSoto_911_Jul25` on the same server (`services8.arcgis.com/t9nZiIqtWRhVGuPI`), layer 1 ("Addresses"). Service title is "Map package for De Soto Parish, LA." and includes a Parish boundary layer. 18,070 features. Same conform fields as before (ADDNUM/FULLSTREET/COMMUNITY/ZIP) still exist and were re-verified via a sample.
- Parcels: no parcels layer exists on the new addresses service, so found a separate county GIS service `Desoto_Weblayers` (`services1.arcgis.com/jh7pbmmfSzUSNziy`), layer 9 ("Parcels_AGOL"). Confirmed via sample records containing "DESOTO PARISH, LA" in the legal description, plus parish-specific layers on the same service (Police Jury District, Parish_Limits). 41,951 features, using PARCEL_ID for pid.

Validated against the schema with the inline lib.js check (passes).

- Addresses: https://services8.arcgis.com/t9nZiIqtWRhVGuPI/ArcGIS/rest/services/DeSoto_911_Jul25/FeatureServer/1
- Parcels: https://services1.arcgis.com/jh7pbmmfSzUSNziy/arcgis/rest/services/Desoto_Weblayers/FeatureServer/9