### PR TITLE
Fix broken Weber County UT source

### DIFF
--- a/sources/us/ut/weber.json
+++ b/sources/us/ut/weber.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://maps.co.weber.ut.us/arcgis/rest/services/gis/parcel_labels/MapServer/5",
+                "data": "https://maps.webercountyutah.gov/arcgis/rest/services/gis/parcel_labels/MapServer/5",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
@@ -31,15 +31,15 @@
                         "UNIT",
                         "UNIT_NUM"
                     ],
-                    "city": "City_name",
-                    "postcode": "ZipCode"
+                    "city": "CITY_NAME",
+                    "postcode": "ZIP"
                 }
             }
         ],
         "parcels": [
             {
                 "name": "county",
-                "data": "https://maps.co.weber.ut.us/arcgis/rest/services/gis/parcels_geogizmo2/MapServer/0",
+                "data": "https://maps.webercountyutah.gov/arcgis/rest/services/gis/parcels_geogizmo2/MapServer/0",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
@@ -50,7 +50,7 @@
         "buildings": [
             {
                 "name": "county",
-                "data": "https://maps.co.weber.ut.us/arcgis/rest/services/gis/basemap_cache/MapServer/5",
+                "data": "https://maps.webercountyutah.gov/arcgis/rest/services/gis/basemap_cache/MapServer/5",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson"


### PR DESCRIPTION
Weber County's old GIS host (maps.co.weber.ut.us) has gone completely offline (DNS NXDOMAIN, confirmed failing for 3+ consecutive weekly runs across all three layers: addresses, parcels, buildings).

The county's website moved to webercountyutah.gov, and their ArcGIS server moved to maps.webercountyutah.gov with the same folder/service/layer structure intact (gis/parcel_labels, gis/parcels_geogizmo2, gis/basemap_cache — same layer indices).

Verified on the new host before updating:
- addresses (gis/parcel_labels/MapServer/5, "Address Points"): 117,160 features, same ADDR_HN/ADDR_PD/ADDR_PT/ADDR_SN/ADDR_ST/ADDR_SD/UNIT/UNIT_NUM/ADD_ID fields as before; city/postcode fields renamed City_name -> CITY_NAME and ZipCode -> ZIP, updated in conform accordingly
- parcels (gis/parcels_geogizmo2/MapServer/0, "Parcel Master"): 115,325 features, PARCEL_ID field unchanged
- buildings (gis/basemap_cache/MapServer/5, "Building Footprints"): 92,595 features

All three feature counts are consistent with Weber County's size. Only the hostname and two field names changed; conform structure otherwise unchanged.