### PR TITLE
Fix broken Monmouth County NJ addresses source

### DIFF
--- a/sources/us/nj/monmouth.json
+++ b/sources/us/nj/monmouth.json
@@ -14,23 +14,16 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://services1.arcgis.com/PsDtSYIjNsyfjwcX/ArcGIS/rest/services/Parcels_gdb/FeatureServer/0",
+                "data": "https://services1.arcgis.com/PsDtSYIjNsyfjwcX/ArcGIS/rest/services/NG911_Address_Points/FeatureServer/0",
+                "website": "https://gisdata-monmouthcty.opendata.arcgis.com/",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
-                    "number": {
-                        "function": "prefixed_number",
-                        "field": "PropertyLocation"
-                    },
-                    "street": {
-                        "function": "postfixed_street",
-                        "field": "PropertyLocation",
-                        "may_contain_units": true
-                    },
-                    "unit": {
-                        "function": "postfixed_unit",
-                        "field": "PropertyLocation"
-                    }
+                    "number": "ADD_NUMBER",
+                    "street": ["ST_PREDIR", "ST_NAME", "ST_POSTYP", "ST_POSDIR"],
+                    "unit": "UNIT",
+                    "city": "POST_COMM",
+                    "postcode": "POST_CODE"
                 }
             }
         ]


### PR DESCRIPTION
The addresses/county source for Monmouth County, NJ has been failing every weekly run since 2026-07 with `EsriDownloadError: Could not retrieve layer metadata: Invalid URL`. The old service (`Parcels_gdb/FeatureServer/0`) no longer exists on the county's ArcGIS server.

Listed the county's ArcGIS server (`services1.arcgis.com/PsDtSYIjNsyfjwcX`) and found `NG911_Address_Points/FeatureServer/0`, a proper NENA-schema address point layer (not a parcel layer requiring text parsing like the old source).

Verified before using:
- Layer returns valid fields and 264,791 features with no auth errors.
- Queried `COUNTY<>'882910'` (Monmouth's NG911 county code) and got 0 results, and `COUNTY='882910'` matches all 264,791 records — confirms the layer is scoped entirely to Monmouth County, not a shared regional dataset.
- Sample records show correct municipalities (Colts Neck, Tinton Falls, etc.) all within Monmouth County.

Updated conform to map directly from NG911 fields (`ADD_NUMBER`, `ST_PREDIR`/`ST_NAME`/`ST_POSTYP`/`ST_POSDIR`, `UNIT`, `POST_COMM`, `POST_CODE`) instead of the old regex-based parsing of a combined `PropertyLocation` field.