### PR TITLE
Fix broken Tazewell County, IL addresses source

### DIFF
--- a/sources/us/il/tazewell.json
+++ b/sources/us/il/tazewell.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://gis.tazewell.com/arcgis/rest/services/ETSB/ETSBData/MapServer/0",
+                "data": "https://gis.tazewell-il.gov/arcgis/rest/services/ETSB/ETSBData/MapServer/0",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",


### PR DESCRIPTION
The addresses/county source for Tazewell County, IL had failed its last 3+ weekly runs with a DNS resolution failure: `gis.tazewell.com` no longer resolves.

The county's ETSB (E911) address point service is still live under a different hostname, `gis.tazewell-il.gov`, which is the same host already used successfully by this file's `parcels` layer. The service path and layer index are unchanged (`ETSB/ETSBData/MapServer/0`, layer name "Address Points"), and the field schema is identical (House, Dir, Street, Suffix, Post_Dir, AptNum, Community), so only the hostname needed updating — the conform mapping did not change.

Verified before committing:
- `?f=json` on the new URL returns the same fields, no auth error
- Feature count: 56,887 (consistent with a county of this size)
- Distinct `Community` values are all Tazewell County towns (Pekin, Morton, East Peoria, Washington, Tremont, Mackinaw, etc.)
- Schema validation passes (`test/lib.js`)