### PR TITLE
Fix broken McKenzie County, ND addresses source

### DIFF
--- a/sources/us/nd/mckenzie_county.json
+++ b/sources/us/nd/mckenzie_county.json
@@ -14,7 +14,7 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://mckenziegis.co.mckenzie.nd.us/server/rest/services/AddressPoints/MapServer/0",
+                "data": "https://mckenziegis.co.mckenzie.nd.us/server/rest/services/DEV/Addresses/FeatureServer/11",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",


### PR DESCRIPTION
The addresses/county source for McKenzie County, ND was failing with `EsriDownloadError: Could not retrieve layer metadata: Service not found` — the old `AddressPoints/MapServer/0` service no longer exists on the county's ArcGIS server.

The server itself (mckenziegis.co.mckenzie.nd.us) is alive and healthy; browsing its service catalog turned up the address data relocated to a `DEV/Addresses` FeatureServer, layer 11 ("Address Sites"), alongside a Building Footprints layer (12) and a Parcels Ownership FeatureServer (parcels/buildings source updates left out of this PR per scope, but noted here since they hit the same dead-service issue and this same server has working replacements for them too).

Verified before writing the conform:
- `DEV/Addresses/FeatureServer/11` returns valid metadata with a `fields` array, no auth errors.
- Feature count: 13,302 (reasonable for this county).
- Field names are identical to the old service (`HOUSENUM`, `STRNAME`, `UNIT`, `POSTALCOMM`, `ZIPCODE`), so the existing conform is unchanged — only the `data` URL was updated.
- Distinct `CITY` values are all within McKenzie County (Watford City, Alexander, Arnegard, Unincorporated) — confirms this is scoped to the county, not a shared/regional layer.

- Layer: addresses
- Source: https://mckenziegis.co.mckenzie.nd.us/server/rest/services/DEV/Addresses/FeatureServer/11