### PR TITLE
Fix broken Simcoe County ON addresses source

### DIFF
--- a/sources/ca/on/simcoe.json
+++ b/sources/ca/on/simcoe.json
@@ -17,12 +17,13 @@
             {
                 "name": "county",
                 "protocol": "ESRI",
-                "data": "https://maps.simcoe.ca/arcgis/rest/services/Public/Search_Layers_Dynamic/MapServer/0",
+                "data": "https://maps.simcoe.ca/arcgis/rest/services/Public/Operational_Layers_Dynamic/MapServer/1",
                 "website": "https://maps.simcoe.ca/beta/",
                 "conform": {
                     "format": "geojson",
                     "number": "STNUM",
                     "street": "FULLNAME",
+                    "unit": "Unit",
                     "city": "MUNI"
                 }
             }


### PR DESCRIPTION
The addresses/county layer for Simcoe County, ON was failing with `esridump.errors.EsriDownloadError: Could not retrieve layer metadata: Layer not found`. The old layer URL (`Public/Search_Layers_Dynamic/MapServer/0`) no longer exists on the county's ArcGIS server — the server was reorganized and address points now live in a different service/layer.

Found the replacement by listing all services on `maps.simcoe.ca` and searching layers for an address-point layer:

- New layer: `https://maps.simcoe.ca/arcgis/rest/services/Public/Operational_Layers_Dynamic/MapServer/1` ("Address Numbers", Point geometry)
- Feature count: 190,366 (comparable in magnitude to the last successful run's 228,918, and covers the same set of lower-tier Simcoe County municipalities plus small enclaves already present in the old dataset, e.g. CFB Borden)
- No auth required, standard pagination supported (maxRecordCount 2000, supportsPagination true)
- Verified field names directly from the service metadata (`STNUM`, `FULLNAME`, `Unit`, `MUNI`) rather than assuming they carried over from the old layer

Conform changes:
- `data` URL updated to the new layer
- Added `unit": "Unit"` since the new layer exposes a unit field the old one didn't