### PR TITLE
Fix broken Montgomery County VA addresses source

### DIFF
--- a/sources/us/va/montgomery.json
+++ b/sources/us/va/montgomery.json
@@ -14,31 +14,30 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://services5.arcgis.com/IZ8QFYP84iubFqmi/arcgis/rest/services/NRVPSAP_AP_RCL/FeatureServer/0",
+                "data": "https://services5.arcgis.com/IZ8QFYP84iubFqmi/arcgis/rest/services/Public_View_Address_Points/FeatureServer/0",
                 "protocol": "ESRI",
-                "website": "https://data-montva-gis.opendata.arcgis.com/datasets/MontVA-GIS::site-address-points/about",
+                "website": "https://data-montva-gis.opendata.arcgis.com/datasets/339a840c37b84c8786709e7afde39a4e_0",
                 "conform": {
                     "format": "geojson",
                     "number": [
-                        "AddNum_Pre",
-                        "Add_Number",
-                        "AddNum_Suf"
+                        "address_number_prefix",
+                        "address_number",
+                        "address_number_suffix"
                     ],
                     "street": [
-                        "St_PreMod",
-                        "St_PreDir",
-                        "St_PreTyp",
-                        "St_PreSep",
-                        "St_Name",
-                        "St_PosTyp",
-                        "St_PosDir",
-                        "St_PosMod"
+                        "street_name_pre_modifier",
+                        "street_name_pre_directional",
+                        "street_name_pre_type",
+                        "street_name",
+                        "street_name_post_type",
+                        "street_name_post_directional",
+                        "street_name_post_modifier"
                     ],
-                    "unit": "Unit",
-                    "city": "Post_Comm",
-                    "district": "County",
-                    "region": "State",
-                    "postcode": "Post_Code"
+                    "unit": "unit",
+                    "city": "municipality",
+                    "district": "county",
+                    "region": "state",
+                    "postcode": "postal_code"
                 }
             }
         ],


### PR DESCRIPTION
The `addresses`/`county` layer has been failing every weekly run since at least 2026-08 with `esridump.errors.EsriDownloadError: Could not retrieve layer metadata: Invalid URL Invalid URL`.

Root cause: the ArcGIS service `NRVPSAP_AP_RCL` on `services5.arcgis.com/IZ8QFYP84iubFqmi` no longer exists (it was likely renamed/replaced). The county's `parcels` and `buildings` layers, hosted on the same servers, continue to succeed, so the server itself is healthy.

Fix: found a replacement service on the same ArcGIS Online org, `Public_View_Address_Points` (FeatureServer/0), whose AGOL item is titled "Public View Address Points" and described as "Montgomery County VA Address Points." Verified before using it:

- `?f=json` returns a valid `fields` array, no auth error.
- Feature count is 46,537, a reasonable count for this county.
- The `county` field has a coded-value domain listing several New River Valley counties (Floyd, Roanoke, Craig, Radford City, Pulaski, Montgomery, Giles), so this looks like it could be a shared regional layer. Queried `county<>'Montgomery County'` and got a count of 0, and `county='Montgomery County'` matches the full 46,537 — confirming every feature currently served is scoped to Montgomery County only.
- Updated the `website` field to the new dataset's ArcGIS Hub page.
- Rebuilt the `conform` block against the new field names (`address_number`/`address_number_prefix`/`address_number_suffix`, `street_name` and its pre/post modifier and directional fields, `unit`, `municipality`, `county`, `state`, `postal_code`) — none of the old field names carried over.

Validated against the schema (`test/lib.js`) before committing.