### PR TITLE
Fix broken Cape Town addresses source

### DIFF
--- a/sources/za/wc/cape_town.json
+++ b/sources/za/wc/cape_town.json
@@ -16,9 +16,9 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://citymaps.capetown.gov.za/agsext1/rest/services/Theme_Based/Open_Data_Service/FeatureServer/56",
+                "data": "https://esapqa.capetown.gov.za/agsext/rest/services/Theme_Based/ODP_SPLIT_6/FeatureServer/1",
                 "protocol": "ESRI",
-                "website": "https://odp-cctegis.opendata.arcgis.com/datasets/cctegis::land-parcels/about",
+                "website": "https://odp-cctegis.opendata.arcgis.com/datasets/cctegis::street-address-numbers/about",
                 "license": {
                     "url": "https://www.capetown.gov.za/General/Terms-of-use-open-data"
                 },


### PR DESCRIPTION
The City of Cape Town's old GIS server path (`citymaps.capetown.gov.za/agsext1/rest/services/Theme_Based/Open_Data_Service/FeatureServer/56`) now returns a plain IIS 404 for the whole rest/services tree — the service was retired, not just moved.

The city's ArcGIS Hub open data feed (`odp-cctegis.opendata.arcgis.com`) still lists live ArcGIS GeoServices REST endpoints for the split-out replacement services on `esapqa.capetown.gov.za`. The address points are now served from the split-out **Street Address Numbers** layer:

`https://esapqa.capetown.gov.za/agsext/rest/services/Theme_Based/ODP_SPLIT_6/FeatureServer/1`

Verified before writing the conform:
- `?f=json` returns a valid `fields` array, no auth error
- Feature count: 862,337 (sane for the whole city)
- Layer extent (Web Mercator) matches Cape Town's bounding box
- Field names are unchanged from the old service (`ADR_NO`, `ADR_NO_SFX`, `STR_NAME`, `LU_STR_NAME_TYPE`), so the existing `conform` block still applies as-is
- This is the city's own dataset (not a shared regional/provincial layer), so no jurisdiction-filtering concern

Only the `addresses`/`city` layer's `data` and `website` were updated; `parcels` and `buildings` in this same file are also currently failing against the old dead host and will need their own follow-up (their replacement services are also visible in the same ArcGIS Hub feed, just not in scope here).

Schema validated with `test/lib.js`.