### PR TITLE
Fix broken City of Banff, AB addresses source

### DIFF
--- a/sources/ca/ab/city_of_banff.json
+++ b/sources/ca/ab/city_of_banff.json
@@ -16,16 +16,19 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://banffdata.blob.core.windows.net/converted/shp.AddressPoints.zip",
-                "website": "https://www.banffopendata.ca/DataBrowser/BanffData/AddressPoints",
-                "license": "https://www.banffopendata.ca/Home/About",
+                "data": "https://maps.banff.ca/opendata/shp/AddressPoints.zip",
+                "website": "https://maps.banff.ca/opendata/",
+                "license": "https://maps.banff.ca/opendata/",
                 "protocol": "http",
                 "compression": "zip",
-                "attribution": "City of Banff",
+                "attribution": "Town of Banff",
                 "conform": {
                     "format": "shapefile",
                     "number": "STREET_NUM",
-                    "street": "STREET_NAM",
+                    "street": [
+                        "STREET_NAM",
+                        "ST_TYPE"
+                    ],
                     "unit": "SUITE"
                 }
             }


### PR DESCRIPTION
The old source downloaded from `banffdata.blob.core.windows.net`, a host that no longer resolves (DNS dead) — every job for the past several months failed with a NameResolutionError.

The Town of Banff's open data site (`banffopendata.ca`) now redirects to a new portal at https://maps.banff.ca/opendata/. That portal bundles per-layer shapefiles as individual zips, and `AddressPoints.zip` is directly downloadable at https://maps.banff.ca/opendata/shp/AddressPoints.zip (no auth, no special User-Agent needed).

Verified before using it:
- 1,645 point features, a sane count for a small town.
- Spatial extent (598923, 5668757)-(601598, 5672202) in UTM 11N lines up with Banff's location.
- Sample records are addresses on Banff Ave etc. with fields `STREET_NUM`, `STREET_NAM`, `ST_TYPE`, `SUITE` — field names changed from the old service, so the conform is rebuilt against the current schema (previous conform was also missing the street type, e.g. "Banff" instead of "Banff Avenue").
- License terms at the same portal are an open, attribution-required license (based on the UK/BC/Toronto Open Government Licence model), permitting redistribution and commercial use.

Updated `data`, `website`, `license`, `attribution`, and `conform.street` in `sources/ca/ab/city_of_banff.json` accordingly.