### PR TITLE
Fix broken Blue Earth County MN addresses source

### DIFF
--- a/sources/us/mn/blue_earth.json
+++ b/sources/us/mn/blue_earth.json
@@ -15,7 +15,8 @@
             {
                 "name": "county",
                 "protocol": "ESRI",
-                "data": "https://gis.blueearthcountymn.gov/arcgis/rest/services/Basemaps/BECBasemap/MapServer/2",
+                "data": "https://gis.blueearthcountymn.gov/server/rest/services/LandRecords/AddressPoints/MapServer/0",
+                "website": "https://www.blueearthcountymn.gov/329/Mapping-Data",
                 "conform": {
                     "format": "geojson",
                     "number": [
@@ -26,17 +27,15 @@
                         "ST_PRE_MOD",
                         "ST_PRE_DIR",
                         "ST_PRE_TYP",
-                        "ST_PRE_SEP",
                         "ST_NAME",
                         "ST_POS_TYP",
-                        "ST_POS_DIR",
-                        "ST_POS_MOD"
+                        "ST_POS_DIR"
                     ],
                     "unit": [
                         "SUB_TYPE1",
-                        "SUBID1"
+                        "SUB_ID1"
                     ],
-                    "city": "CITY",
+                    "city": "POSTCOMM",
                     "district": "CO_NAME",
                     "region": "STATE_CODE",
                     "postcode": "ZIP"
@@ -47,10 +46,11 @@
             {
                 "name": "county",
                 "protocol": "ESRI",
-                "data": "https://gis.blueearthcountymn.gov/arcgis/rest/services/Basemaps/BECBasemap/MapServer/5",
+                "data": "https://gis.blueearthcountymn.gov/server/rest/services/LandRecords/TaxParcels/MapServer/0",
+                "website": "https://www.blueearthcountymn.gov/329/Mapping-Data",
                 "conform": {
                     "format": "geojson",
-                    "pid": "PIN"
+                    "pid": "ParcelNo"
                 }
             }
         ]


### PR DESCRIPTION
The county's ArcGIS Server moved from `/arcgis/rest/services` to `/server/rest/services` — the old MapServer path now returns a plain 404 (IIS-level, not an ESRI error), which was failing every job for the `addresses` and `parcels` layers.

Found the new service tree at `https://gis.blueearthcountymn.gov/server/rest/services` (folders: Basemap, Boundary, Drainage, Hosted, LandRecords, Planning, Tools, Utilities) and updated both layers to the equivalent services under `LandRecords`:

- `addresses`: now `LandRecords/AddressPoints/MapServer/0` (28,405 features). Verified `CO_NAME <> 'Blue Earth'` returns 0 records, confirming the layer is scoped to this county only. Field names changed slightly from the old service (`SUBID1` -> `SUB_ID1`, `CITY` -> `POSTCOMM`, dropped unused `ST_PRE_SEP`/`ST_POS_MOD` which no longer exist), verified against `?f=json` and sample records.
- `parcels`: now `LandRecords/TaxParcels/MapServer/0` (33,637 features, consistent with third-party parcel counts for the county). `pid` updated from `PIN` to `ParcelNo`, the current parcel identifier field.

Added a `website` link to the county's Mapping & Data page for both layers.