### PR TITLE
Fix broken Edgar County IL addresses source

### DIFF
--- a/sources/us/il/edgar.json
+++ b/sources/us/il/edgar.json
@@ -13,35 +13,25 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://ags.bhamaps.com/arcgisserver/rest/services/EdgarIL/EdgarIL_PAT_Taxmap/MapServer/0",
+                "data": "https://services5.arcgis.com/6VdFeKk2GI4rFk2D/arcgis/rest/services/Reach_Parcels/FeatureServer/0",
+                "website": "https://edgar-il.bhamaps.com/",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
                     "number": {
                         "function": "prefixed_number",
-                        "field": "PropertyAddress1"
+                        "field": "SitusAddress1"
                     },
                     "street": {
                         "function": "postfixed_street",
-                        "field": "PropertyAddress1"
+                        "field": "SitusAddress1",
+                        "may_contain_units": true
                     },
-                    "city": {
-                        "function": "regexp",
-                        "field": "PropertyAddress2",
-                        "pattern": "^(.+)(?:, IL)"
-                    },
-                    "region": {
-                        "function": "constant",
-                        "value": "IL"
-                    },
-                    "postcode": {
-                        "function": "regexp",
-                        "field": "PropertyAddress2",
-                        "pattern": "(\\d{5}(?:-\\d{4})?)$"
-                    }
-                },
-                "skip": true,
-                "note": "bhamaps.com servers are dead as of 2026-04"
+                    "unit": "SitusUnitNumber",
+                    "city": "SitusCity",
+                    "region": "SitusState",
+                    "postcode": "SitusPostalCode"
+                }
             }
         ],
         "parcels": [


### PR DESCRIPTION
The addresses/county layer for Edgar County, IL had been marked skip: true since the ags.bhamaps.com server went dead (confirmed still unreachable - connection fails entirely). The last several production jobs (e.g. job 909615) fail with "Error: out.geojson not found" because a skipped source produces no output.

BHA Maps has since migrated Edgar County's public GIS site to https://edgar-il.bhamaps.com/, an ArcGIS Experience Builder app. Inspecting its data sources, the parcel/address data now lives on `services5.arcgis.com/6VdFeKk2GI4rFk2D/.../Reach_Parcels/FeatureServer/0` - the same ArcGIS Online service already used (and successfully running weekly) by this source's existing `parcels` layer, so it is already confirmed to be scoped to Edgar County alone (18,089 features, consistent with the ~18k parcels the county manages; distinct SitusCity values are all Edgar County towns: Paris, Chrisman, Kansas, etc.).

That service doesn't have separate house-number/street fields (SitusStreetNumber is always blank), but it does have a combined `SitusAddress1` field ("123 N MAIN ST # 4") plus clean, already-split `SitusCity`, `SitusState`, and `SitusPostalCode` fields and a `SitusUnitNumber` field. Rewrote the addresses conform to use `prefixed_number`/`postfixed_street` (with `may_contain_units: true`) on `SitusAddress1`, and direct field references for unit/city/region/postcode - removing the old skip flag and regexp-based city/postcode extraction that operated on the old service's PropertyAddress1/PropertyAddress2 fields.

Verified via `scripts/esri-explore.py` and direct ArcGIS REST queries: fields present, feature count 18,089, no auth errors, geographic extent limited to Edgar County. Validated against the schema (`test/lib.js` compile+validate, and `npm test`).