### PR TITLE
Fix broken Floyd County GA addresses source

### DIFF
--- a/sources/us/ga/floyd.json
+++ b/sources/us/ga/floyd.json
@@ -21,10 +21,6 @@
                     "format": "geojson",
                     "number": "St_Number",
                     "street": ["Road_Name", "Quadrant"],
-                    "unit": {
-                        "function": "first_non_empty",
-                        "fields": ["Suite", "Apt"]
-                    },
                     "city": "City",
                     "postcode": "Zip_Code"
                 }

--- a/sources/us/ga/floyd.json
+++ b/sources/us/ga/floyd.json
@@ -15,13 +15,18 @@
             {
                 "name": "county",
                 "protocol": "ESRI",
-                "data": "https://romefloyd.agdmaps.com/server/rest/services/Hosted/Addresses/FeatureServer/0",
+                "data": "https://services2.arcgis.com/nV67H1IJR8GS6SAA/arcgis/rest/services/CurrentAddresses/FeatureServer/1",
+                "website": "https://www.romefloyd.com/departments/gis",
                 "conform": {
                     "format": "geojson",
-                    "number": "st_number",
-                    "street": "road_name",
-                    "city": "city",
-                    "postcode": "zip_code"
+                    "number": "St_Number",
+                    "street": ["Road_Name", "Quadrant"],
+                    "unit": {
+                        "function": "first_non_empty",
+                        "fields": ["Suite", "Apt"]
+                    },
+                    "city": "City",
+                    "postcode": "Zip_Code"
                 }
             }
         ],


### PR DESCRIPTION
The addresses layer for Floyd County, GA (sources/us/ga/floyd.json) has been failing every weekly job since at least 2026-06-12, with a ConnectTimeout to the old on-prem host romefloyd.agdmaps.com. That host now times out entirely (both /server/rest/services and the site root), and a sibling subdomain (ags2.romefloyd.agdmaps.com) is also unreachable, so the county's old ArcGIS Server appears to be decommissioned.

Rome/Floyd County's GIS department has migrated their address data to a hosted feature layer on their own ArcGIS Online organization: https://services2.arcgis.com/nV67H1IJR8GS6SAA/arcgis/rest/services/CurrentAddresses/FeatureServer/1 (item description: "This layer contains addresses for the City of Rome and Floyd County Georgia"). Verified before using it:

- 49,072 features, all fields present, no auth errors.
- Spatial extent matches Floyd County, GA.
- Grouped by City, essentially all records fall in Rome and the small towns/unincorporated communities within Floyd County (Armuchee, Cave Spring, Silver Creek, Aragon, Lindale, Adairsville, Kingston, Plainville); a couple hundred records carry neighboring-county postal city names (Calhoun, Cedartown), consistent with normal USPS mailing-city border noise (~1% of records), not jurisdiction leakage.
- Re-verified field names from scratch (St_Number, Road_Name, Quadrant, Suite, Apt, City, Zip_Code) — none of the old lowercase field names carried over.

Rome, GA addresses are quadrant-suffixed (e.g. "5 Brookhollow Rd SW"), so street is Road_Name + Quadrant. Unit is combined from Suite/Apt via first_non_empty since both are populated on different records.

The parcels layer in this same file points at the same dead host and is left untouched/still broken — out of scope for this fix, since no equivalent parcel layer was confirmed on the new AGOL org.

Schema validated with test/lib.js.