### PR TITLE
Fix broken City of Fayetteville, AR addresses source

### DIFF
--- a/sources/us/ar/city_of_fayetteville.json
+++ b/sources/us/ar/city_of_fayetteville.json
@@ -22,26 +22,20 @@
             {
                 "name": "city",
                 "website": "https://www.fayetteville-ar.gov/384/GIS-Interactive-Maps",
-                "data": "https://maps.fayetteville-ar.gov/server/rest/services/Addresses/MapServer/0",
+                "data": "https://maps.fayetteville-ar.gov/server/rest/services/Addresses_and_Zip_Codes/MapServer/0",
                 "protocol": "ESRI",
                 "attribution": "City of Fayetteville",
                 "conform": {
                     "format": "geojson",
-                    "number": [
-                        "NUMBER",
-                        "SUB_NUM"
-                    ],
-                    "street": [
-                        "PREDIR",
-                        "PRE_TYPE",
-                        "NAME",
-                        "TYPE",
-                        "SUF_DIR"
-                    ],
+                    "number": "NUMBER",
+                    "street": {
+                        "function": "remove_prefix",
+                        "field": "FULLADD",
+                        "field_to_remove": "NUMBER"
+                    },
                     "unit": "UNIT_NUM",
-                    "city": "CITY",
-                    "postcode": "ZIP",
-                    "region": "STATE"
+                    "city": "ADR_CITY",
+                    "postcode": "ZIP"
                 }
             }
         ]


### PR DESCRIPTION
The `Addresses/MapServer` service on `maps.fayetteville-ar.gov` no longer exists — the source has been failing continuously for roughly 6 years (job 910687 and its predecessors all error with `Could not retrieve layer metadata: Service Addresses/MapServer not found`).

Found the city's current address point layer on the same host: `Addresses_and_Zip_Codes/MapServer/0` ("Address", point geometry, 74,085 features, no auth required). This appears to be the city's own address-point dataset (not a regional consortium layer), verified against Arkansas State Plane North (EPSG:3433) coordinates matching Fayetteville, AR / Washington County (not to be confused with Fayetteville, NC).

The new layer's schema differs from the old one — there's no longer a decomposed street-name field, only a combined `FULLADD` (e.g. "84 E DICKSON ST") plus a separate `NUMBER" field, so `street` is derived with `remove_prefix` (same pattern as Salem, OR).

- Layer: addresses
- Source: https://maps.fayetteville-ar.gov/server/rest/services/Addresses_and_Zip_Codes/MapServer/0
- Fields verified with `scripts/esri-explore.py` (suggest/count/sample) and validated against `test/lib.js`