### PR TITLE
Fix broken Benton County WA addresses source

### DIFF
--- a/sources/us/wa/benton.json
+++ b/sources/us/wa/benton.json
@@ -15,8 +15,8 @@
             {
                 "name": "county",
                 "protocol": "ESRI",
-                "data": "https://services7.arcgis.com/NURlY7V8UHl6XumF/ArcGIS/rest/services/Addresses/FeatureServer/0",
-                "website": "https://bentonco.maps.arcgis.com/home/item.html?id=c90c040c2f5b4ed4b2b5e8d0997cdc6d",
+                "data": "https://maps.co.benton.wa.us/server/rest/services/Address_Master/FeatureServer/0",
+                "website": "https://bentonco.maps.arcgis.com/home/item.html?id=86b4885701d04c59b94cf0310b8360bc",
                 "conform": {
                     "format": "geojson",
                     "number": "STRT_NUM",
@@ -25,6 +25,7 @@
                         "STRT_NAM",
                         "RdType"
                     ],
+                    "unit": "Unit_Space",
                     "city": "PostalArea",
                     "postcode": "ZIP"
                 }


### PR DESCRIPTION
The county addresses layer has been failing every run since at least mid-August with `esridump.errors.EsriDownloadError: Could not retrieve layer metadata: Token Required Token Required`.

Root cause: the old ArcGIS Online hosted service (`services7.arcgis.com/NURlY7V8UHl6XumF/.../Addresses/FeatureServer/0`) has become private/token-gated. The sibling `parcels` and `buildings` layers on the same ArcGIS Online org are still public and succeeding, confirming the org itself is healthy — only the `Addresses` service was locked down.

Found the replacement: Benton County now publishes the same dataset directly from their own ArcGIS Server at `https://maps.co.benton.wa.us/server/rest/services/Address_Master/FeatureServer/0` (public, no token required). It exposes the identical field names as the old conform (`STRT_NUM`, `STRT_NAM`, `RdType`, `RWDIR`, `PostalArea`, `ZIP`), confirming it's the same underlying data, just migrated to a new host. Verified:

- 15,468 features, no auth error.
- The ArcGIS Online item description for this layer states it is scoped to "Benton County jurisdiction only and does not include city limits addresses" — i.e. unincorporated county addresses, matching the existing separate `city_of_kennewick.json` source for the incorporated city.
- Grouped by `PostalArea`, all values are towns within Benton County (Kennewick, Richland, West Richland, Prosser, Benton City, Plymouth, Paterson, Grandview, Sunnyside, Hanford) — no out-of-county contamination.

Changes:
- Updated `data` URL to the new host.
- Updated `website` to the current ArcGIS Online item page for `Address_Master`.
- Added `unit: Unit_Space` to the conform since the new service exposes a populated unit field that wasn't previously mapped.

`parcels` and `buildings` layers are untouched since they are still succeeding against the old host.