### PR TITLE
Fix broken Kern County CA parcels source

### DIFF
--- a/sources/us/ca/kern.json
+++ b/sources/us/ca/kern.json
@@ -46,7 +46,7 @@
             {
                 "name": "county",
                 "attribution": "Kern County",
-                "data": "https://maps.co.kern.ca.us/arcgis/rest/services/Accela_Base/MapServer/5",
+                "data": "https://services5.arcgis.com/Y8jwjGUWbRjuqpG5/arcgis/rest/services/Assessor_Parcels_Land_2026_gdb/FeatureServer/0",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",


### PR DESCRIPTION
## Root cause

Both the `addresses` and `parcels` layers for `us/ca/kern` pointed at `https://maps.co.kern.ca.us/arcgis/rest/services/Accela_Base/MapServer/5`. Job log for the most recent failure (job 910491):

    esridump.errors.EsriDownloadError: Could not retrieve layer metadata: Service Accela_Base/MapServer not found

The `Accela_Base` service has been removed entirely from Kern County's ArcGIS Server (confirmed via a full services listing on both `maps.co.kern.ca.us` and `maps.kerncounty.com` — no `Accela_Base` service, and no `Assessor` folder either).

## addresses layer — left broken

The old conform derived number/street/unit/city from a `Situs_Address` field on that now-deleted service. I searched for a replacement:

- Kern County's own ArcGIS Server (`maps.co.kern.ca.us`, `maps.kerncounty.com`): no address-point service published. The one Assessor address service that does exist, `Assessor/Assessor_Public/MapServer`, returns `{"error":{"code":499,"message":"Token Required"}}` even with a browser User-Agent — this is a genuine ArcGIS token/auth requirement, not a spoofable bot-block, so the champaign/utah `User-Agent` workaround doesn't apply.
- Kern's ArcGIS Online org (`KernGIS`) and its GEODAT open data hub (`geodat-kernco.opendata.arcgis.com`): full catalog listing (62 items) and a full-text search for "address" turned up no address-point dataset — only `Centerline Roads` (has address ranges, not points) and general parcel/boundary layers with no situs address attribute.
- The county's Assessor GIS-data web page returns 403 to automated requests, so no downloadable file could be checked there either.

No usable, county-scoped, non-authenticated address-point source was found, so the `addresses` layer is left as-is and will continue to fail until a replacement surfaces.

## parcels layer — fixed

Kern's `KernGIS` ArcGIS Online org publishes current assessor parcel geometry directly:

- `https://services5.arcgis.com/Y8jwjGUWbRjuqpG5/arcgis/rest/services/Assessor_Parcels_Land_2026_gdb/FeatureServer/0` — 424,125 features, `APN` field (matches existing `pid` conform), no auth required, single-county scoped (KernGIS org's own "Assessor Parcels Land 2026" layer).

Updated the `parcels.county` entry's `data` URL to this service; the conform (`pid: APN`) needed no changes. Feature count is consistent with Kern County's size, and the layer/org is unambiguously scoped to Kern County (no other jurisdiction mixed in).

Validated against `test/lib.js` (VALID).