### PR TITLE
Fix broken Teton County WY addresses and parcels source

### DIFF
--- a/sources/us/wy/teton.json
+++ b/sources/us/wy/teton.json
@@ -14,17 +14,19 @@
         "addresses": [
             {
                 "name": "county",
-                "website": "https://gis.tetoncountywy.gov/portal/apps/sites/#/teton-county-gis-hub/datasets/687993dd9d494ed9b89203255b948117/about?layer=0",
+                "website": "https://maps.terragis.net/tetonwy/mapserver/download/download.php",
                 "license": {
                     "url": "https://www.tetoncountywy.gov/958/Geographic-Information-System",
                     "text": "Indemnification",
                     "attribution": false,
                     "share-alike": false
                 },
-                "data": "https://gis.tetoncountywy.gov/server/rest/services/Public_Services/Addressing/FeatureServer/0",
-                "protocol": "ESRI",
+                "data": "https://maps.terragis.net/tetonwy/mapserver/download/data/ownership_shp.zip",
+                "protocol": "http",
+                "compression": "zip",
                 "conform": {
-                    "format": "geojson",
+                    "format": "shapefile",
+                    "file": "ownership/address.shp",
                     "number": "street_num",
                     "street": [
                         "st_dir",
@@ -43,17 +45,19 @@
         "parcels": [
             {
                 "name": "county",
-                "website": "https://gis.tetoncountywy.gov/portal/apps/sites/#/teton-county-gis-hub/datasets/687993dd9d494ed9b89203255b948117/about?layer=1",
+                "website": "https://maps.terragis.net/tetonwy/mapserver/download/download.php",
                 "license": {
                     "url": "https://www.tetoncountywy.gov/958/Geographic-Information-System",
                     "text": "Indemnification",
                     "attribution": false,
                     "share-alike": false
                 },
-                "data": "https://gis.tetoncountywy.gov/server/rest/services/Public_Services/Parcels/FeatureServer/0",
-                "protocol": "ESRI",
+                "data": "https://maps.terragis.net/tetonwy/mapserver/download/data/ownership_shp.zip",
+                "protocol": "http",
+                "compression": "zip",
                 "conform": {
-                    "format": "geojson",
+                    "format": "shapefile",
+                    "file": "ownership/ownership.shp",
                     "pid": "pidn"
                 }
             }


### PR DESCRIPTION
Teton County's ArcGIS Server (`gis.tetoncountywy.gov`) has been retired and now 301-redirects entirely to a new GIS portal at `maps.terragis.net`, which serves an HTML disclaimer page instead of the ArcGIS REST API — so both the `addresses` and `parcels` jobs have been failing with a JSON-decode error (esridump could not parse the metadata response as JSON) for the last several runs (jobs 907238/907239, 902288/902289, 897396/897397).

The new portal at `maps.terragis.net/tetonwy/mapserver/download/` no longer exposes an ArcGIS REST endpoint, but does offer a direct GIS data download page with a shapefile bundle (`ownership_shp.zip`) containing both the address points (`ownership/address.shp`, 14,142 features — same `street_num`/`st_dir`/`st_name`/`st_type`/`st_unit`/`msag_city`/`msag_zip`/`pidn` fields as the old ESRI service) and the parcel polygons (`ownership/ownership.shp`, 12,574 features, same `pidn` field). This is Teton County's own official GIS data export, so it's correctly scoped to the county — a city/community breakdown of the address points shows only Jackson, Wilson, Teton Village, Hoback, Alta, Moran, Kelly, Moose, and Grand Teton National Park, all of which are within Teton County, WY.

Updated both layers to `protocol: http` / `format: shapefile` / `compression: zip`, pointing at the new zip and the appropriate `file` inside it. Field names are unchanged from the previous ESRI conform. License notes are unchanged (same indemnification/no-warranty terms, same county GIS info page).

- Layers: addresses, parcels
- New source: https://maps.terragis.net/tetonwy/mapserver/download/data/ownership_shp.zip