### PR TITLE
Fix broken Watertown CT addresses source

### DIFF
--- a/sources/us/ct/city_of_watertown.json
+++ b/sources/us/ct/city_of_watertown.json
@@ -21,15 +21,14 @@
         "addresses": [
             {
                 "name": "city",
-                "attribution": "City of Watertown",
-                "data": "https://107.20.209.214/ArcGIS/rest/services/WatertownCT/WatertownDynamic/MapServer/0",
+                "attribution": "Town of Watertown, CT",
+                "data": "https://services9.arcgis.com/beCWDxttpj2jLg72/arcgis/rest/services/Assessor_Map_WFL1/FeatureServer/1",
                 "website": "https://www.watertownct.org/",
                 "protocol": "ESRI",
                 "conform": {
-                    "street": "ParcelPolygon.StreetName",
-                    "number": "ParcelPolygon.StreetNumber",
                     "format": "geojson",
-                    "postcode": "cama.zip"
+                    "number": "StreetNumber",
+                    "street": "StreetName"
                 }
             }
         ]


### PR DESCRIPTION
The addresses/city layer for Watertown, CT has been failing for roughly 6 years (job history back to at least 2020, most recent failing job 910246). Root cause: the source pointed at a bare IP address (https://107.20.209.214/ArcGIS/rest/services/WatertownCT/WatertownDynamic/MapServer/0) which now returns a plain IIS 404 "File or directory not found" page instead of any ArcGIS response — the old vendor-hosted ArcGIS Server instance behind that IP is gone entirely (not a timeout, auth issue, or layer-ID shift). A sibling source (sources/us/ct/city_of_lyme.json) points at the same dead IP, confirming this was a shared vendor host that's been decommissioned.

Replacement: the Town of Watertown now publishes its own GIS data via its ArcGIS Online organization (twnwtneng.maps.arcgis.com). The Assessor_Map_WFL1 FeatureServer's ParcelPolygon layer (layer 1) carries StreetNumber and StreetName directly as native fields (no join required, unlike the old joined MapServer view) and is scoped specifically to Watertown parcels:

- https://services9.arcgis.com/beCWDxttpj2jLg72/arcgis/rest/services/Assessor_Map_WFL1/FeatureServer/1
- 9,742 parcel features, 8,392 with non-blank/non-zero street numbers, verified with esri-explore.py (count/sample/suggest)
- Street names sampled (Georgetown Dr, Barnes Rd, Concord Dr, Aunt Olive Rd, etc.) are consistent with Watertown, CT
- This parcel/CAMA-derived approach for the addresses layer matches existing precedent in this repo, e.g. sources/us/ct/city_of_waterbury.json and sources/us/ct/town_of_new_milford.json (both neighboring CT towns using parcel polygon data for the addresses layer)

Updated protocol/conform: ESRI + format geojson, number=StreetNumber, street=StreetName. Validated against test/lib.js and npm test (only 2 unrelated pre-existing schema edge-case test failures remain, both about `accuracy` validation, untouched by this change).