### PR TITLE
Fix broken City of Hartford CT addresses source

### DIFF
--- a/sources/us/ct/city_of_hartford.json
+++ b/sources/us/ct/city_of_hartford.json
@@ -21,8 +21,9 @@
         "addresses": [
             {
                 "name": "city",
-                "attribution": "Ciy of Hartford",
-                "data": "https://gis1.hartford.gov/arcgis/rest/services/GPSBasemapForFlex/MapServer/0",
+                "attribution": "City of Hartford",
+                "data": "https://gis.hartford.gov/arcgis/rest/services/AssessorAddressPTS/MapServer/0",
+                "website": "https://data.hartford.gov",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
@@ -33,7 +34,8 @@
                         "CV_STTYPE",
                         "CV_STSUFFIX"
                     ],
-                    "unit": "UNITNUM"
+                    "unit": "UNITNUM",
+                    "postcode": "ZipCode"
                 }
             }
         ]


### PR DESCRIPTION
The addresses source for City of Hartford, CT has been failing for roughly 6 years (jobs going back to at least 2020, most recent job 910259). Root cause: the old host `gis1.hartford.gov` is dead — its DNS still resolves but the TCP connection times out entirely (verified with a direct connect test, not just the batch job log), so esridump can never even fetch layer metadata.

The city's GIS has since moved to a new, live ArcGIS server at `gis.hartford.gov`. That server hosts an `AssessorAddressPTS` MapServer whose layer 0 ("Address Points") has the exact same field schema as the old `GPSBasemapForFlex` layer this source used to point at (`STREETNUM`, `CV_STPREFIX`, `CV_STNAME`, `CV_STTYPE`, `CV_STSUFFIX`, `UNITNUM`) — this is clearly the same underlying assessor address-point dataset, just republished on the new server.

Verified before writing the conform:
- Feature count: 42,698 — sane for a single city of Hartford's size.
- Jurisdiction scoping: distinct values of `LeftCityName`, `CountyCode1`, and `LocationName` are all `HARTFORD` (plus some nulls) — not a shared/regional dataset.
- No auth required, fields/sample fetched successfully via `esri-explore.py`.

Changes:
- `data` updated to `https://gis.hartford.gov/arcgis/rest/services/AssessorAddressPTS/MapServer/0`
- Added `website` pointing to the city's open data portal
- Added `postcode` conform mapping from the new `ZipCode` field (available in this dataset but not the old one)
- Fixed a typo in `attribution` ("Ciy" -> "City")
- `street`/`number`/`unit` conform fields kept as-is since the field names carried over unchanged