### PR TITLE
Fix broken City of Elk Grove CA addresses source

### DIFF
--- a/sources/us/ca/city_of_elk_grove.json
+++ b/sources/us/ca/city_of_elk_grove.json
@@ -22,7 +22,11 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://services1.arcgis.com/r6QlyAADl0kfhp1m/ArcGIS/rest/services/Address_Maint_Hosted/FeatureServer/0",
+                "data": "https://webmaps.elkgrove.gov/arcgis/rest/services/AGOL/Land_Data/FeatureServer/0",
+                "website": "https://www.arcgis.com/home/item.html?id=18a97ccfef6347b982cd13dd010882c2",
+                "license": {
+                    "url": "https://www.elkgrovecity.org/departments-and-divisions/geographic-information-systems"
+                },
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
@@ -36,11 +40,11 @@
                         "SUFFIXDIR"
                     ],
                     "unit": [
-                        "UNIT",
-                        "UNITDESIGN"
+                        "UNITDESIGN",
+                        "UNIT"
                     ],
                     "city": "CITY",
-                    "postcode": "ZIPCODE"
+                    "postcode": "ZIP"
                 }
             }
         ],


### PR DESCRIPTION
The addresses layer has been failing every run for years (job history back to at least 2020, most recently failing job 910603). Root cause: the ESRI hosted feature service `Address_Maint_Hosted` on `services1.arcgis.com/r6QlyAADl0kfhp1m` no longer exists (`Invalid URL` from esridump; it is absent from that org's current service listing).

Investigation found the city has since migrated its GIS hosting from `webmaps.elkgrovecity.org` (now decommissioned, empty service folders) to `webmaps.elkgrove.gov`. That new server hosts a `AGOL/Land_Data` FeatureServer whose layer 0 ("Address") is the same authoritative address dataset (matching field names: ADDRESSID, STREETNUMB, PREFIXDIR, PREFIXTYPE, STREETNAME, STREETTYPE, SUFFIXDIR, UNIT, UNITDESIGN, CITY, ZIP). The associated ArcGIS Online item description confirms "Addresses are managed by the City of Elk Grove."

Verified before writing the conform:
- 69,219 features, no auth errors, fields present.
- Scope check: only 18 of 69,219 records (0.03%) have `JURISDICTION <> 'ELK GROVE'` and only 15 have `CITY <> 'ELK GROVE'` — negligible border noise, confirming this is a city-scoped dataset, not a countywide one.
- Field values sampled directly to confirm exact names/case (`ZIP` replaces the old `ZIPCODE`), and corrected the `unit` field order to `UNITDESIGN` then `UNIT` (e.g. "# 100" instead of "100 #") based on sample data.

Parcels and buildings layers in this same file are also currently broken (the old `webmaps.elkgrovecity.org` host is empty), but replacements for those exist too (`OPEN_DATA_PORTAL/Parcels` and `OPEN_DATA_PORTAL/Building_Footprints` on the new `webmaps.elkgrove.gov` host) — left untouched here since this PR is scoped to the addresses layer.