### PR TITLE
Fix broken City of Athens, GA addresses source

### DIFF
--- a/sources/us/ga/city_of_athens.json
+++ b/sources/us/ga/city_of_athens.json
@@ -22,7 +22,13 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://services2.arcgis.com/xSEULKvB31odt3XQ/arcgis/rest/services/AddressPoint/FeatureServer/0",
+                "data": "https://enigma.accgov.com/server/rest/services/ACC_Address_Point/FeatureServer/0",
+                "website": "https://www.arcgis.com/home/item.html?id=63ac622f811944588fb87371542e2979",
+                "license": {
+                    "url": "https://creativecommons.org/licenses/by/4.0/",
+                    "attribution": true,
+                    "attribution name": "Athens-Clarke County Unified Government"
+                },
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",


### PR DESCRIPTION
The `city` addresses source for Athens-Clarke County, GA has been failing for roughly 6 years. Job logs (e.g. job 910015) show `EsriDownloadError: Could not retrieve layer metadata: Invalid URL Invalid URL` when fetching `services2.arcgis.com/xSEULKvB31odt3XQ/.../AddressPoint/FeatureServer/0` — that specific hosted service no longer exists on the AGOL org, though the org itself (Athens-Clarke County's ArcGIS Online account) is alive and hosts several other dated snapshot address layers.

Root cause: the old `AddressPoint` service was removed at some point; ACC has since republished several dated snapshot copies (`AddressPt_20240705_WFL1`, etc.) on the same AGOL org, but the actual authoritative, actively-maintained copy lives on the county's own ArcGIS Server at `enigma.accgov.com`, in the `ACC_Address_Point` FeatureServer (last edited Feb 2026, 78,043 features vs. ~70k in the stale AGOL snapshot).

Verified before writing the conform:
- Feature count 78,043, no auth required, fields present via `esri-explore.py`.
- Field names (`HouseNum`, `PreDir`, `StreetName`, `StreetType`, `PostDir`, `UnitType`, `Unit`, `POSTALCITY`, `State`, `Zipcode`, `AddressID`) match the previous conform's field names exactly, so no conform changes were needed beyond the URL.
- Checked jurisdiction scope via a `groupBy` on `City`: 76,858 Athens + 810 Winterville + 254 ACC + 109 Bogart — all within Athens-Clarke County's consolidated addressing authority (Winterville is an incorporated city inside Clarke County), not a wider regional dataset. Spatial extent matches the county's known bounds.
- Confirmed via the ArcGIS Online item record (id `63ac622f811944588fb87371542e2979`, owned by an accgov.com account) that this is the county's official, CC BY 4.0 licensed "Address Point" dataset — added a `license` block accordingly.

Change: updated `data` to `https://enigma.accgov.com/server/rest/services/ACC_Address_Point/FeatureServer/0`, added `website` and `license`. Conform is otherwise unchanged.