### PR TITLE
Fix broken Newton County GA addresses source

### DIFF
--- a/sources/us/ga/newton.json
+++ b/sources/us/ga/newton.json
@@ -14,23 +14,22 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://gis.ncboc.com/arcgis/rest/services/Public/Newton_Address_Points/MapServer/0",
+                "data": "https://services.arcgis.com/mq0BGE5kHpm8mHFz/arcgis/rest/services/Site_Structure_Address_Point/FeatureServer/0",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
-                    "number": "AddNum",
+                    "number": [
+                        "AddNum_Pre",
+                        "AddNumber",
+                        "AddNum_Suf"
+                    ],
                     "street": [
-                        "StPreDir",
-                        "StPreType",
-                        "StName",
-                        "StType",
-                        "StDir"
+                        "LSt_PreDir",
+                        "LSt_Name",
+                        "LSt_Typ",
+                        "LSt_PosDir"
                     ],
-                    "unit": [
-                        "UnitType",
-                        "Unit"
-                    ],
-                    "postcode": "ZipCode"
+                    "city": "MSAGComm"
                 }
             }
         ]


### PR DESCRIPTION
The Newton County, GA addresses source has been failing for years (job history back to at least job 885368, most recently job 909883 on 2026-09-11).

Root cause: the county's ArcGIS Server (`gis.ncboc.com`) moved the `Public/Newton_Address_Points` service (and every other folder on that server except a handful of unrelated layers) behind ArcGIS token authentication — the service now returns `{"error":{"code":499,"message":"Token Required"}}` for both metadata and data requests, with no anonymous access at all. This is a genuine access restriction, not a bot-blocking/User-Agent issue (confirmed by testing with a browser User-Agent, which made no difference), and not a pagination/timeout problem (there's no other still-working layer on that host to compare against — the whole service catalog is locked down).

Replacement found: Newton County's NG911 site address point data is publicly republished on ArcGIS Online by GeoComm (the county's addressing vendor) as "Site Structure Address Point" (tagged "Newton County", "GA" by the owner). Verified before use:
- Extent (-84.05 to -83.68 lon, 33.37 to 33.74 lat) matches Newton County's bounding box.
- Each record's `NGUID` is stamped `...:ncboc.org`, i.e. Newton County Board of Commissioners — confirming this is the county's own authoritative dataset, not a different jurisdiction.
- Feature count is 51,175, a sane figure for a full county the size of Newton.
- `MSAGComm` community values are Covington, Oxford, Mansfield, Newborn, Porterdale, plus minor edge overlap into neighboring USPS communities (Conyers, Social Circle) — expected for a county-boundary address dataset, not a sign of misscoped data.
- Fully public, no token required.

Updated `sources/us/ga/newton.json`:
- `data` now points to `https://services.arcgis.com/mq0BGE5kHpm8mHFz/arcgis/rest/services/Site_Structure_Address_Point/FeatureServer/0`
- `conform.number` uses `AddNum_Pre`/`AddNumber`/`AddNum_Suf`
- `conform.street` uses `LSt_PreDir`/`LSt_Name`/`LSt_Typ`/`LSt_PosDir`
- `conform.city` uses `MSAGComm` (same pattern as `sources/us/al/cherokee.json` and `sources/us/fl/baker.json`)
- No `unit` or `postcode` fields exist in this service, so those keys are omitted rather than guessed

Validated with the schema compiler in `test/lib.js` (VALID) and `npm test` (no new failures; the 2 pre-existing failures are unrelated to this file).