### PR TITLE
Fix broken Chelan County, WA addresses source

### DIFF
--- a/sources/us/wa/chelan.json
+++ b/sources/us/wa/chelan.json
@@ -20,7 +20,7 @@
                     "share-alike": false
                 },
                 "protocol": "ESRI",
-                "data": "https://atlas.co.chelan.wa.us/arcgis/rest/services/PW/Address_Data_Layers/MapServer/10",
+                "data": "https://services6.arcgis.com/kL9uP9rflLEjUDsy/arcgis/rest/services/Site_Address_Points/FeatureServer/0",
                 "conform": {
                     "format": "geojson",
                     "id": "siteaddid",


### PR DESCRIPTION
The addresses layer of us/wa/chelan.json has failed every weekly job for the past 13+ runs (going back to April 2026, most recently job 907742). The job log shows an EsriDownloadError read timeout against atlas.co.chelan.wa.us on the very first paginated feature request.

Diagnosis: the addresses layer (PW/Address_Data_Layers/MapServer/10, "Site Address Points") lives on the county's own on-prem ArcGIS Server. Manual testing confirmed the count query works fine, but a 1000-record feature query against that specific layer is wildly inconsistent - sometimes ~50-60s, sometimes it never returns within the 300s read timeout esridump enforces per request. The sibling buildings layer (MapServer/14) on the exact same server paginates normally and completes every week, and parcels (a different service on the same host) also succeeds, so the host itself is healthy - this is isolated to that one layer/table being slow or overloaded server-side.

Fix: the same authoritative dataset (RiverCom911's Chelan/Douglas county E911 address point layer - the current source already mixes in a small number of Douglas/Grant/King/Kittitas/Okanogan county rows via the `county`/`district` field, matching the existing conform's `"district": "county"` tag) is also published as an ArcGIS Online hosted feature layer at:

https://services6.arcgis.com/kL9uP9rflLEjUDsy/arcgis/rest/services/Site_Address_Points/FeatureServer/0

Verified before switching:
- Identical field names/values to the existing conform (siteaddid, addrnum, fullname, unittype, unitid, post_comm, county, address_subtype, post_code) - a sample record matches the county's own data exactly (same siteaddid, same RiverCom911.org datasource).
- Feature count (83,240) matches the county's own dedicated PW/Site_Address_Points/MapServer/0 service exactly, and the county-only slice (58,664 rows) is proportionally consistent with what the existing broken source was already serving - no coverage widening, just a faster host of the same data.
- Paginated queries at offsets 0, 2000, 4000, and 78000 all returned in well under a second, vs. 50-300+s and outright timeouts on the old on-prem host.
- No auth required, no truncation (`exceededTransferLimit`) issues at the resultRecordCount esridump uses.

Only the `data` URL for the addresses/county layer changed; the conform, license, and coverage are untouched. Parcels and buildings layers are unaffected and already succeed on the original host.