### PR TITLE
Fix broken Hamilton County IA addresses source

### DIFF
--- a/sources/us/ia/hamilton.json
+++ b/sources/us/ia/hamilton.json
@@ -14,38 +14,19 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Hamilton/Address_40.zip",
+                "data": "https://wfs.schneidercorp.com/arcgis/rest/services/HamiltonCountyIA_WFS/MapServer/1",
                 "license": {
                     "text": "Public Domain",
                     "attribution": false,
                     "share-alike": false
                 },
-                "year": "2012?",
-                "protocol": "ftp",
-                "compression": "zip",
+                "protocol": "ESRI",
                 "conform": {
-                    "number": {
-                        "function": "regexp",
-                        "field": "address",
-                        "pattern": "^([0-9]+)"
-                    },
-                    "street": {
-                        "function": "regexp",
-                        "field": "address",
-                        "pattern": "^(?:[0-9]+ )(.*)",
-                        "replace": "$1"
-                    },
-                    "unit": {
-                        "function": "regexp",
-                        "field": "address",
-                        "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
-                        "replace": "$1"
-                    },
-                    "city": "POSTAL_COM",
-                    "district": "COUNTY",
-                    "region": "STATE",
-                    "postcode": "ZIP_CODE",
-                    "format": "shapefile"
+                    "format": "geojson",
+                    "number": "Add_Number",
+                    "street": ["StN_PreDir", "StN_PreTyp", "StreetName", "StN_PosType"],
+                    "unit": "Unit",
+                    "city": "MSAG_Comm"
                 }
             }
         ]


### PR DESCRIPTION
The addresses source for Hamilton County, IA (`sources/us/ia/hamilton.json`) was failing every weekly run with a timeout downloading from `ftp://ftp.igsb.uiowa.edu/gis_library/counties/Hamilton/Address_40.zip` (Iowa Geological Survey Bureau FTP server, which appears to be down/unreachable entirely — this is a systemic failure affecting many other Iowa county sources that use the same FTP host).

Confirmed via job log (job 909764): `Got an error from ftp.igsb.uiowa.edu: [Errno 110] Operation timed out`.

Replaced with Hamilton County's current authoritative address point layer, hosted on Schneider Corp's ArcGIS server:

- Layer: addresses
- Source: https://wfs.schneidercorp.com/arcgis/rest/services/HamiltonCountyIA_WFS/MapServer/1 (Address Points, NENA/NG911-style schema)
- Verified: 8181 features, 8159/8181 with County = 'HAMILTON COUNTY' (remainder null, no cross-jurisdiction contamination), non-empty StN_PreDir/StN_PreTyp/StN_PosType/Unit fields incorporated into conform; Post_Comm/Post_Code fields are entirely empty in this dataset so city is sourced from MSAG_Comm instead and postcode is omitted.
- License: Public Domain (carried over from prior source entry)

Note for maintainers: several other Iowa counties on the same dead IGSB FTP host have working replacements at the same `wfs.schneidercorp.com/arcgis/rest/services/<County>CountyIA_WFS` (or `_AGS`) pattern, though the exact layer IDs and field schemas vary per county and must be verified individually.