### PR TITLE
Fix broken Dallas County IA addresses source

### DIFF
--- a/sources/us/ia/dallas.json
+++ b/sources/us/ia/dallas.json
@@ -14,38 +14,14 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Dallas/Address_25.zip",
-                "license": {
-                    "text": "Public Domain",
-                    "attribution": false,
-                    "share-alike": false
-                },
-                "year": "2012?",
-                "protocol": "ftp",
-                "compression": "zip",
+                "data": "https://gis.dallascountyiowa.gov/arcgis/rest/services/Public/Public_AddressPoints/FeatureServer/0",
+                "website": "https://www.dallascountyiowa.gov/206/GIS",
+                "protocol": "ESRI",
                 "conform": {
-                    "number": {
-                        "function": "regexp",
-                        "field": "address",
-                        "pattern": "^([0-9]+)"
-                    },
-                    "street": {
-                        "function": "regexp",
-                        "field": "address",
-                        "pattern": "^(?:[0-9]+ )(.*)",
-                        "replace": "$1"
-                    },
-                    "unit": {
-                        "function": "regexp",
-                        "field": "address",
-                        "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
-                        "replace": "$1"
-                    },
-                    "city": "POSTAL_COM",
-                    "district": "COUNTY",
-                    "region": "STATE",
-                    "postcode": "ZIP_CODE",
-                    "format": "shapefile"
+                    "format": "geojson",
+                    "number": "Add_Number",
+                    "street": ["StN_PreDir", "StN_PreTyp", "StreetName", "StN_PosType", "StN_PosDir"],
+                    "city": "Post_Comm"
                 }
             }
         ]


### PR DESCRIPTION
The addresses source for Dallas County, IA was downloading from `ftp://ftp.igsb.uiowa.edu/gis_library/counties/Dallas/Address_25.zip`. Recent job logs (e.g. job 909780) show `DownloadError: 400 response from ftp://ftp.igsb.uiowa.edu/...` — the Iowa Geological Survey Bureau's FTP host is currently unreachable. This is a shared-host failure affecting many other Iowa county sources that use the same `ftp.igsb.uiowa.edu/gis_library/counties/...` pattern.

Replaced with Dallas County's own ArcGIS address points layer:

- Layer: addresses
- Source: https://gis.dallascountyiowa.gov/arcgis/rest/services/Public/Public_AddressPoints/FeatureServer/0
- Website: https://www.dallascountyiowa.gov/206/GIS
- 13,720 features, public, no auth required
- Verified jurisdiction scope by grouping on the `Post_Comm` field — all values are Dallas County, IA communities (Adel, Perry, Waukee, Grimes, Dallas Center, Van Meter, Woodward, Redfield, De Soto, Minburn, Earlham, Granger, Dexter, Linden, Cumming, Bouton, Dawson, Booneville, Jamaica, Yale) with only negligible border-town counts (Panora, Rippey, Madrid, West Des Moines) consistent with towns that straddle the county line.

Search notes: I first found an ArcGIS Hub called "Dallas County Open Data Hub" (owner `dallascountygis`) that looked promising but turned out to be Dallas County, **Texas**, not Iowa — discarded. The county's real GIS org (`geodallas.maps.arcgis.com`) lists an internal-only `AddressPoints`/`AddressPointCollection` service on `arcgis.dallasco.local`, which is not publicly reachable; the public mirror on `gis.dallascountyiowa.gov` under `Public/Public_AddressPoints` is the one used here.

Note for maintainers: I did not find a single replacement mirror for the whole `ftp.igsb.uiowa.edu/gis_library/counties/` tree — each affected Iowa county appears to need an individual replacement search (some already have their own modern ArcGIS servers, e.g. `sources/us/ia/adair.json`), rather than one shared fix.