### PR TITLE
Fix broken Cass County, IA addresses source

### DIFF
--- a/sources/us/ia/cass.json
+++ b/sources/us/ia/cass.json
@@ -14,38 +14,19 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "ftp://ftp.igsb.uiowa.edu/gis_library/counties/Cass/Address_15.zip",
+                "data": "https://wfs.schneidercorp.com/arcgis/rest/services/CassCountyIA_WFS/MapServer/0",
+                "website": "https://www.casscountyia.gov/county-departments/gis-coordinator/",
                 "license": {
                     "text": "Public Domain",
                     "attribution": false,
                     "share-alike": false
                 },
-                "year": "2012?",
-                "protocol": "ftp",
-                "compression": "zip",
+                "protocol": "ESRI",
                 "conform": {
-                    "number": {
-                        "function": "regexp",
-                        "field": "address",
-                        "pattern": "^([0-9]+)"
-                    },
-                    "street": {
-                        "function": "regexp",
-                        "field": "address",
-                        "pattern": "^(?:[0-9]+ )(.*)",
-                        "replace": "$1"
-                    },
-                    "unit": {
-                        "function": "regexp",
-                        "field": "address",
-                        "pattern": "^.* ((Unit|Apt) [0-9A-Za-z])$",
-                        "replace": "$1"
-                    },
-                    "city": "POSTAL_COM",
-                    "district": "COUNTY",
-                    "region": "STATE",
-                    "postcode": "ZIP_CODE",
-                    "format": "shapefile"
+                    "format": "geojson",
+                    "number": "streetnum",
+                    "street": "streetname",
+                    "city": "city"
                 }
             }
         ]


### PR DESCRIPTION
The Cass County, IA addresses source pulled from `ftp://ftp.igsb.uiowa.edu/gis_library/counties/Cass/Address_15.zip`, the Iowa Geological Survey Bureau's FTP server. That host has been completely unreachable (connection timeout on port 21) across the last 18 batch runs, and this is a systemic failure affecting dozens of other Iowa county sources that share the same `ftp.igsb.uiowa.edu` host.

Replacement found: Cass County's site-address data is available from its GIS vendor, Schneider Corp (the same vendor behind the county's Beacon property search), via a public ArcGIS REST MapServer:

`https://wfs.schneidercorp.com/arcgis/rest/services/CassCountyIA_WFS/MapServer/0`

This is the county's Parcels layer, which carries `streetnum`/`streetname`/`city` site-address fields per parcel (polygon geometry, so the address point is derived from the parcel). This is the same pattern already in production for Lyon County, IA (`sources/us/ia/lyon.json`), which uses the identical field names on the identical vendor platform. Verified before writing the conform:
- Feature count: 17,145 (sane for a county this size)
- No auth required, public FeatureServer response
- `city` field distinct-value breakdown matches only Cass County towns and unincorporated townships (Atlantic, Anita, Griswold, Lewis, Cumberland, Massena, Wiota, Marne, etc.), confirming correct scope

Cass County's own GIS download page only offers Parcels/Subdivisions/boundary shapefiles (no dedicated address layer), and no ArcGIS Online item or other public source with a proper point-address layer was found, so the Parcels-derived address fields are the best available public source.

General pattern for other broken IGSB-sourced Iowa counties: check `https://wfs.schneidercorp.com/arcgis/rest/services/<CountyName>CountyIA_WFS/MapServer` (or `_AGS`) for a services list — Schneider Corp hosts many Iowa counties' assessor/GIS data (the same vendor behind each county's Beacon parcel search), sometimes with a dedicated address layer, sometimes only a Parcels layer with `streetnum`/`streetname`/`city` fields usable as a site-address surrogate.