### PR TITLE
Fix region showing truncated 'Ma' instead of 'MD' for Caroline, Talbot, and Kent counties

### DIFF
--- a/sources/us/md/caroline.json
+++ b/sources/us/md/caroline.json
@@ -30,7 +30,10 @@
                     "unit": "Unit",
                     "city": "Post_Comm",
                     "district": "County",
-                    "region": "State",
+                    "region": {
+                        "function": "constant",
+                        "value": "MD"
+                    },
                     "postcode": "Post_Code"
                 }
             }

--- a/sources/us/md/kent.json
+++ b/sources/us/md/kent.json
@@ -28,7 +28,10 @@
                     "unit": "Unit",
                     "city": "Post_Comm",
                     "district": "County",
-                    "region": "State",
+                    "region": {
+                        "function": "constant",
+                        "value": "MD"
+                    },
                     "postcode": "Post_Code"
                 }
             }

--- a/sources/us/md/talbot.json
+++ b/sources/us/md/talbot.json
@@ -29,7 +29,10 @@
                     "unit": "Unit",
                     "city": "Post_Comm",
                     "district": "County",
-                    "region": "State",
+                    "region": {
+                        "function": "constant",
+                        "value": "MD"
+                    },
                     "postcode": "Post_Code"
                 }
             }


### PR DESCRIPTION
Follow-up to #8418, #8424, and #8426. All three sources pull `region` directly from the upstream Maryland ArcGIS service's `State`/`STATE` field, which is truncated to "Ma" in production. Replaced with a `constant` conform function to hardcode the correct value.

Same defect affects the still-open #8420 (Harford) and #8422 (Somerset), which are being fixed the same way.