### PR TITLE
Fix broken Butler County, KS addresses source

### DIFF
--- a/sources/us/ks/butler.json
+++ b/sources/us/ks/butler.json
@@ -15,7 +15,7 @@
             {
                 "name": "county",
                 "protocol": "ESRI",
-                "data": "https://ww1.bucoks.com/arcgis/rest/services/BuCoKs_NGAddressPoints/MapServer/0",
+                "data": "https://ww1.bucoks.com/bucogis1/rest/services/PublicOutreach/Address_Points/MapServer/44",
                 "conform": {
                     "format": "geojson",
                     "number": [


### PR DESCRIPTION
The old data URL (`https://ww1.bucoks.com/arcgis/rest/services/BuCoKs_NGAddressPoints/MapServer/0`) returns HTTP 404 - the service was removed from that path (last 3 batch jobs all Fail with 'Could not retrieve layer metadata HTTP 404').

Found the same NG911 address point dataset still published on the same host under a new path: `https://ww1.bucoks.com/bucogis1/rest/services/PublicOutreach/Address_Points/MapServer/44` (layer name `AddressPoints`, 36154 features). Verified via ArcGIS Online search of the county's org.

- Confirmed 100% of features have `COUNTY = 'BUTLER COUNTY'` (0 records otherwise) - correctly scoped, not a regional/statewide layer.
- All existing conform field names (HNO, HNS, PRD, STP, RD, STS, UNIT, MUNI, COUNTY, ZIP) still exist on the new layer with identical semantics/sample values, so no conform changes were needed - just the data URL.
- Validated against the JSON schema (`test/lib.js`).