### PR TITLE
Fix broken Douglas County, KS addresses source

### DIFF
--- a/sources/us/ks/douglas.json
+++ b/sources/us/ks/douglas.json
@@ -34,7 +34,8 @@
                     "region": "STATE",
                     "postcode": "ZIP"
                 },
-                "data": "https://gis.lawrenceks.org/arcgis/rest/services/AddressPoints/MapServer/0",
+                "data": "https://services.arcgis.com/8O9UlSTnqjKptoda/arcgis/rest/services/Address_Point/FeatureServer/0",
+                "website": "https://gis.lawrenceks.org/portal/home/",
                 "protocol": "ESRI"
             }
         ]


### PR DESCRIPTION
The county ArcGIS Server host (gis.lawrenceks.org/arcgis/rest/services/AddressPoints/MapServer/0) now 404s across the last 6 weekly jobs — the whole /arcgis/rest/services path on that IIS host is gone (the host itself is up and now redirects to a new ArcGIS Enterprise portal at gis.lawrenceks.org/portal/home/).

The same authoritative dataset (Douglas County GIS Division / City of Lawrence IT) is still published, now as a hosted ArcGIS Online Feature Service: https://services.arcgis.com/8O9UlSTnqjKptoda/arcgis/rest/services/Address_Point/FeatureServer/0

Verified before writing the conform:
- Layer returns 63,183 features, no auth required.
- Field names are unchanged from the old service (HNO, HNS, PRD, RD, STS, UNIT_TYPE, UNIT, MUNI, COUNTY, STATE, ZIP), confirmed via a live sample query, so the existing conform mapping is still correct.
- Coverage check: querying COUNTY<>'DOUGLAS COUNTY' returns only 1 of 63,183 records (border noise), confirming this layer is scoped to Douglas County and not a wider regional dataset.

Updated the `data` URL to the new FeatureServer layer and added a `website` pointing at the county's new GIS portal home.