### PR TITLE
Fix broken City of Boise ID addresses source

### DIFF
--- a/sources/us/id/city_of_boise.json
+++ b/sources/us/id/city_of_boise.json
@@ -21,7 +21,7 @@
         "addresses": [
             {
                 "name": "city",
-                "data": "https://gismaps.cityofboise.org/arcgis/rest/services/Korterra/MapServer/31",
+                "data": "https://gismaps.cityofboise.org/arcgis/rest/services/Integration/Korterra/MapServer/31",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",


### PR DESCRIPTION
The addresses layer failed its last 3 batch runs with `esridump.errors.EsriDownloadError: Could not retrieve layer metadata: Service not found` against `https://gismaps.cityofboise.org/arcgis/rest/services/Korterra/MapServer/31`.

The City of Boise ArcGIS server reorganized its services: the `Korterra` MapServer moved under a new `Integration/` folder. The layer index (31, "Addresses", Point geometry) and full field schema are unchanged, so this updates only the `data` URL to `https://gismaps.cityofboise.org/arcgis/rest/services/Integration/Korterra/MapServer/31`.

Verified before committing:
- Layer returns 274,801 features with no auth errors
- All fields referenced in the existing conform (AddNum, StPreMod, StPreDir, StPrefix, StName, StSuffix, StPostDir, StPostMod, PrUnitType, PrUnitID, CommName, Zip4) are present with identical names/case
- No FeatureServer capability is exposed on this server, so MapServer remains correct (matches prior config)
- Schema validation passes via test/lib.js

Note: this KorTerra addressing layer is a shared regional dataset (CommName includes Boise, Meridian, Eagle, Kuna, Star, Garden City, Nampa, Melba) and is not filterable to Boise alone via the ESRI protocol in this repo — this is unchanged from how the source was already configured before it broke, not something introduced by this fix.