### PR TITLE
fix broken cowley county ks addresses source with new AddressPoints FeatureServer

### DIFF
--- a/sources/us/ks/cowley_county.json
+++ b/sources/us/ks/cowley_county.json
@@ -32,7 +32,8 @@
                     "district": "COUNTY",
                     "region": "STATE"
                 },
-                "data": "https://gis.cowleycounty.org/countymap/rest/services/CL_General/Deeds_Map/MapServer/0",
+                "data": "https://services2.arcgis.com/duYcbdxVVOdnGdbq/arcgis/rest/services/AddressPoints/FeatureServer/1",
+                "website": "https://www.cowleycountyks.gov/",
                 "protocol": "ESRI"
             }
         ]


### PR DESCRIPTION
The old ESRI source at `gis.cowleycounty.org/countymap/rest/services/CL_General/Deeds_Map/MapServer/0` has been consistently failing with a connection timeout for many months (every job back to at least mid-2025) — the `gis.cowleycounty.org` host itself is unreachable on both http and https (connection timeout, no TCP response), indicating the old GIS server has been decommissioned.

Found the county's current GIS hosting on ArcGIS Online: a "Countywide Address Points, editing from NG911 feature layer" service at `https://services2.arcgis.com/duYcbdxVVOdnGdbq/arcgis/rest/services/AddressPoints/FeatureServer/1`. It uses the same NG911 field schema as the old source (HNO/HNS/PRD/RD/STS/POD/UNIT/POSTCO/ZIP/COUNTY/STATE), so the existing conform mapping carries over unchanged.

Verified before writing the conform:
- 20,661 features, all with `COUNTY = 'COWLEY COUNTY'` and `STATE = 'KS'` (0 records outside Cowley County) — correctly scoped, not a shared/regional layer.
- Feature count and fields confirmed via `esri-explore.py`.
- Schema validated with `test/lib.js`.

- Layer: addresses
- Source: https://services2.arcgis.com/duYcbdxVVOdnGdbq/arcgis/rest/services/AddressPoints/FeatureServer/1
- Website: https://www.cowleycountyks.gov/