### PR TITLE
fix broken kankakee county il addresses source

### DIFF
--- a/sources/us/il/kankakee.json
+++ b/sources/us/il/kankakee.json
@@ -16,38 +16,23 @@
                 "name": "county",
                 "website": "https://www.k3gis.com/",
                 "license": "https://www.k3gis.com/#contact",
-                "compression": "zip",
-                "data": "https://webfiles.k3gis.com/download/cadastral/Parcels.zip",
-                "protocol": "http",
+                "data": "https://k3gis.net/arcgis/rest/services/Cadastral/Tax_Parcels_and_Subdivisions/MapServer/0",
+                "protocol": "ESRI",
                 "conform": {
-                    "format": "shapefile-polygon",
+                    "format": "geojson",
                     "number": {
-                        "function": "regexp",
-                        "field": "site_addre",
-                        "pattern": "^([0-9]+)"
+                        "function": "prefixed_number",
+                        "field": "site_address"
                     },
                     "street": {
-                        "function": "regexp",
-                        "field": "site_addre",
-                        "pattern": "^(?:[0-9]+ )(.*)",
-                        "replace": "$1"
+                        "function": "postfixed_street",
+                        "field": "site_address"
                     },
-                    "city": {
-                        "function": "regexp",
-                        "field": "site_csz",
-                        "pattern": "^(.*?),(?:.*)"
-                    },
-                    "postcode": {
-                        "function": "regexp",
-                        "field": "site_csz",
-                        "pattern": "^(?:.*?)([0-9]+(?:\\-[0-9]+)?)",
-                        "replace": "$1"
-                    },
+                    "city": "site_city",
+                    "postcode": "site_zip",
                     "id": "pin",
                     "accuracy": 2
-                },
-                "skip": true,
-                "note": "This source is broken; TODO use parcels below for addresses"
+                }
             }
         ],
         "parcels": [


### PR DESCRIPTION
The `addresses` layer of `sources/us/il/kankakee.json` had been marked `skip: true` because its HTTP download (`https://webfiles.k3gis.com/download/cadastral/Parcels.zip`) is broken — the host presents a TLS certificate for `s3.amazonaws.com` that does not match the `webfiles.k3gis.com` hostname, so the download fails entirely. Batch job history confirms this: the addresses layer has failed on every recent run (e.g. jobs 909584, 904634, 899738, 894811), while the sibling `parcels` layer on the same K3GIS ArcGIS server has succeeded every run with a real feature count (54,906 parcels, pmtiles produced).

Since the parcel service is healthy, this switches the addresses layer to pull from that same ESRI service (`Cadastral/Tax_Parcels_and_Subdivisions/MapServer/0`) instead of the dead ZIP download — this was already the plan noted in a TODO left on the source file ("use parcels below for addresses").

Verified via `esri-explore.py` before writing the conform:
- Service returns a valid `fields` array, no auth error.
- Feature count: 54,906 (of which ~43,556 have a non-empty `site_address`; the rest are vacant/farm parcels with no assigned address, which is expected for this rural county).
- Sampled records confirm `site_address` is a combined "<number> <street>" string (e.g. "300  E KANKAKEE AV"), `site_city`, and `site_zip` are populated and scoped to Kankakee County, IL.

Conform changes:
- `protocol` changed from `http`/`shapefile-polygon` to `ESRI`/`geojson`.
- `number`/`street` now use `prefixed_number`/`postfixed_street` on `site_address` (replacing the old regexp pair, which was built against a truncated shapefile field name that no longer applies).
- `city`/`postcode` now use the correctly-cased `site_city`/`site_zip` fields directly instead of parsing a combined `site_csz` string.
- Removed `skip`/`note`, since the source now works.

Validated with `test/lib.js` (schema v2) — passes.