### PR TITLE
Fix broken Canyon County, ID addresses source

### DIFF
--- a/sources/us/id/canyon.json
+++ b/sources/us/id/canyon.json
@@ -29,7 +29,7 @@
                     "city": {
                         "function": "regexp",
                         "field": "InCity",
-                        "pattern": "CITY OF (.+)$",
+                        "pattern": "^.*CITY OF (.+)$",
                         "replace": "$1"
                     },
                     "postcode": "SiteZIP"

--- a/sources/us/id/canyon.json
+++ b/sources/us/id/canyon.json
@@ -14,26 +14,25 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://maps.canyonco.org/arcgisserver/rest/services/Hosted/Taxparcels/FeatureServer/0",
+                "data": "https://maps.canyonco.org/arcgisserver/rest/services/General/Canyon_County_Public_Tax_Parcels/FeatureServer/0",
                 "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
-                    "number": [
-                        "sitenum",
-                        "sitenumsfx"
-                    ],
-                    "street": [
-                        "predir",
-                        "sitestreet",
-                        "streettype",
-                        "postdir"
-                    ],
-                    "unit": [
-                        "sitesuite",
-                        "SiteSubNum"
-                    ],
-                    "city": "sitecity",
-                    "postcode": "sitezip"
+                    "number": {
+                        "function": "prefixed_number",
+                        "field": "SiteAddress"
+                    },
+                    "street": {
+                        "function": "postfixed_street",
+                        "field": "SiteAddress"
+                    },
+                    "city": {
+                        "function": "regexp",
+                        "field": "InCity",
+                        "pattern": "CITY OF (.+)$",
+                        "replace": "$1"
+                    },
+                    "postcode": "SiteZIP"
                 }
             }
         ]


### PR DESCRIPTION
The addresses/county source pointed at `Hosted/Taxparcels/FeatureServer/0` on `maps.canyonco.org`, which now returns `Token Required` (the whole `Hosted/` folder became private) — confirmed via the last 8 batch jobs all failing with this error, and reproduced directly with `esri-explore.py`.

Checked the server's root services listing for a public replacement. The `Hosted/` and a couple of other folders are now token-gated, but the county's tax parcel data (which is what this source has always used as an address-point proxy, since the county has no dedicated address-point layer) is still public under two other paths:

- `Assessor/CCPublicTaxparcels` (MapServer only, 110,819 records, has separate `SiteNum`/`SiteStreet` fields but those drop directionals/suffix)
- `General/Canyon_County_Public_Tax_Parcels` (FeatureServer, 103,060 records, single combined `SiteAddress" string field)

Used the FeatureServer service (preferred over MapServer per repo convention) and parsed the combined `SiteAddress` field with `prefixed_number`/`postfixed_street` to avoid losing directionals/suffixes. `SiteCity" is a 2-letter internal code (not a usable city name), so city is derived instead from the `InCity` field (e.g. "676 CITY OF NAMPA") via regexp, which naturally leaves unincorporated parcels without a city rather than mislabeling them.

Verified before writing the conform:
- Feature count > 0 (103,060), no auth error
- Sampled records confirm field names/case and address format
- ~5% of parcels (5,211) have no site address (vacant land), consistent between address and zip null counts

Validated against `test/lib.js`.