### PR TITLE
Fix broken Barber County KS addresses source

### DIFF
--- a/sources/us/ks/barber_county.json
+++ b/sources/us/ks/barber_county.json
@@ -16,20 +16,21 @@
                 "name": "county",
                 "conform": {
                     "format": "geojson",
-                    "number": "hno",
+                    "number": "HNO",
                     "street": [
-                        "prd",
-                        "rd",
-                        "sts",
-                        "pod"
+                        "PRD",
+                        "RD",
+                        "STS",
+                        "POD"
                     ],
-                    "unit": "unit",
-                    "city": "muni",
-                    "district": "county",
-                    "region": "state",
-                    "postcode": "zip"
+                    "unit": "UNIT",
+                    "city": "MUNI",
+                    "district": "COUNTY",
+                    "region": "STATE",
+                    "postcode": "ZIP"
                 },
-                "data": "https://72.205.198.131/ArcGIS/rest/services/Barber/Barber/MapServer/30",
+                "data": "https://services9.arcgis.com/zDY8zW24CdJKhVIw/arcgis/rest/services/BarberCountyGIS/FeatureServer/5",
+                "website": "https://atci.maps.arcgis.com/apps/webappviewer/index.html?id=2d2ff393a9c049c2be6c2389f323306b",
                 "protocol": "ESRI"
             }
         ]


### PR DESCRIPTION
The addresses source for Barber County, KS pointed at a bare-IP ArcGIS server (`https://72.205.198.131/ArcGIS/rest/services/Barber/Barber/MapServer/30`) that has been unreachable (connection timeout) for at least the last 6 weekly batch runs. This same dead IP is shared by at least 12 other Kansas county sources in this repo (elk, greenwood, harper, edwards, cheyenne, brown, thomas, marion, kingman, kearny, allen, wabaunsee), suggesting a shared vendor GIS server that has gone offline entirely.

Searched for a replacement:
- The dead IP has no earlier hostname in this file's git history to fall back to.
- Barber County's own site (barber.ks.gov) has no GIS/ArcGIS map viewer, only static PDF maps and a CIC tax/parcel lookup portal.
- Found the county's current GIS presence hosted by a third-party vendor, ATCiMaps, via ArcGIS Online: a "Barber County GIS" web app backed by a hosted Feature Service at `https://services9.arcgis.com/zDY8zW24CdJKhVIw/arcgis/rest/services/BarberCountyGIS/FeatureServer`.
- Layer 5 (`AddressPoints`) uses the standard NG911/NENA address schema (HNO, PRD, RD, STS, POD, MUNI, UNIT, ZIP, COUNTY, STATE) - the same field naming convention as the old broken source, just uppercase.
- Verified: 4306 features, no auth required, and a `COUNTY <> 'BARBER COUNTY'` filter returns 0 features, confirming the layer is scoped correctly to Barber County only.

Updated the source to point at this FeatureServer layer with a conform matching the verified field names.

Note for maintainers: the other ~12 Kansas counties sharing the dead `72.205.198.131` vendor IP likely need the same treatment - check each for an equivalent ATCiMaps-hosted (or similar third-party vendor) `<County>CountyGIS` Feature Service on ArcGIS Online, since these appear to use the same statewide NG911 address schema.