### PR TITLE
Fix broken Shawnee County, KS addresses source

### DIFF
--- a/sources/us/ks/shawnee_county.json
+++ b/sources/us/ks/shawnee_county.json
@@ -14,21 +14,22 @@
         "addresses": [
             {
                 "name": "county",
-                "note": "alternate source (origin unknown): https://services2.arcgis.com/2XE514jeVQMWNKHX/arcgis/rest/services/AddressPoints/FeatureServer/0",
+                "data": "https://services2.arcgis.com/2XE514jeVQMWNKHX/arcgis/rest/services/AddressPoints/FeatureServer/0",
+                "website": "https://gis.sncoapps.us/gisportal/apps/experiencebuilder/experience?id=1990e1bfb350412e8e37f6998ae7ce6b",
+                "protocol": "ESRI",
                 "conform": {
                     "format": "geojson",
-                    "number": "HOUSENUM",
+                    "number": "HNO",
                     "street": [
-                        "DIR_PRE",
-                        "STRT_NAM",
-                        "TYPE_SUF"
+                        "PRD",
+                        "RD",
+                        "STS",
+                        "POD"
                     ],
-                    "unit": "UNIT_NUM",
-                    "city": "PCITY",
-                    "postcode": "ZipCode"
-                },
-                "data": "https://gis.snco.us/arcgis2/rest/services/Basemap_Cached/MapServer/5",
-                "protocol": "ESRI"
+                    "unit": "UNIT",
+                    "city": "POSTCO",
+                    "postcode": "ZIP"
+                }
             }
         ]
     }


### PR DESCRIPTION
The existing source pointed at a cached basemap layer (`Basemap_Cached/MapServer/5`) rather than a real address point service, and was marked with a note about an untested alternate URL.

- Switched to `AddressPoints/FeatureServer/0` on the same ArcGIS Online org (75,607 features, confirmed live)
- Updated conform to the layer's actual field names (`HNO`, `PRD`/`RD`/`STS`/`POD`, `UNIT`, `POSTCO`, `ZIP`) — `POSTCO` (postal community) is used for city since the layer's `PCITY` field is blank on sampled records
- Added `website` pointing to the county's GIS portal