### PR TITLE
Fix unanchored postcode regexp in Kankakee County, IL addresses conform

### DIFF
--- a/sources/us/il/kankakee.json
+++ b/sources/us/il/kankakee.json
@@ -40,7 +40,7 @@
                     "postcode": {
                         "function": "regexp",
                         "field": "site_csz",
-                        "pattern": "^(?:.*?)([0-9]+(?:\\-[0-9]+)?)",
+                        "pattern": "^(?:.*?)([0-9]+(?:\\-[0-9]+)?)$",
                         "replace": "$1"
                     },
                     "id": "pin",


### PR DESCRIPTION
Follow-up fix to the addresses conform introduced in #8513, which reworked this source to derive addresses from parcel situs-address fields (\`site_addre\`/\`site_csz\`, format \`shapefile-polygon\`).

## Bug

The \`postcode\` conform's \`regexp\` function used a \`replace\` key with a pattern anchored only on the left (\`^\`), not the right:

\`\`\`json
"pattern": "^(?:.*?)([0-9]+(?:\\-[0-9]+)?)"
\`\`\`

A \`regexp\` function with \`replace\` performs a find-and-replace on the whole matched string, not a clean extraction — text after the end of the match that isn't consumed by the pattern is left in place. Since this pattern has no \`\$\` anchor, any trailing content in \`site_csz\` after the ZIP digits (e.g. a trailing space or extra text) would leak into the postcode output instead of being stripped.

## Fix

Anchor the pattern on both ends so the whole remaining string is consumed by the match:

\`\`\`json
"pattern": "^(?:.*?)([0-9]+(?:\\-[0-9]+)?)\$"
\`\`\`

This is a static/schema-level fix based on the field semantics (\`site_csz\` = combined "city, state zip" string) and the known behavior of unanchored \`regexp\`+\`replace\` patterns elsewhere in this codebase. I wasn't able to pull a live sample of \`site_csz\` values from this shapefile-polygon source to directly confirm trailing content exists, so this defensively closes the same bug class already seen in other unanchored regexp conforms.

Note: this \`addresses\` layer currently has \`"skip": true\` set, so this fix doesn't change production output today, but corrects the conform for whenever the skip is lifted.