### PR TITLE
Fix unanchored unit regexp in Alpine County, CA source

### DIFF
--- a/sources/us/ca/alpine.json
+++ b/sources/us/ca/alpine.json
@@ -32,7 +32,7 @@
                     "unit": {
                         "function": "regexp",
                         "field": "Situs",
-                        "pattern": "([A-Za-z0-9/\\- ]*)( +##? *(.*))?$",
+                        "pattern": "^([A-Za-z0-9/\\- ]*)( +##? *(.*))?$",
                         "replace": "$3"
                     },
                     "city": {


### PR DESCRIPTION
A static lint pass found that the \`unit\` conform in \`sources/us/ca/alpine.json\` uses a \`regexp\` function with a \`replace\` key but an unanchored pattern.

The \`regexp\`+\`replace\` conform is implemented as a whole-string \`re.sub\`, not a clean extraction (see \`row_fxn_regexp\` in batch-machine's \`conform.py\`). Without a \`^\` anchor at the start of the pattern, \`re.sub\` can match starting partway through the string, leaving the unmatched leading text untouched and leaking it into the output value instead of the intended captured group.

In this file, the pattern was:
\`\`\`
([A-Za-z0-9/\\- ]*)( +##? *(.*))?$
\`\`\`
anchored on the right (\`$\`) but not the left. The character class excludes punctuation like commas, so for a \`Situs\` value such as \`"400, 590 LAKE ALPINE RD"\` (a real value in this dataset), the old pattern left \`unit\` as \`"400,"\` instead of empty. Verified with a standalone Python simulation of the actual \`re.sub\` conform logic against real sample \`Situs\` values pulled from the live FeatureServer — normal unit values (e.g. \`"100 CREEKSIDE DR ## 49"\` -> \`49\`) are unaffected, and the leaking case is fixed to produce an empty string as intended.

Fix: added \`^\` to anchor the pattern at the start, so the whole field must match left-to-right and no unmatched prefix can leak through.

Verified schema validity with \`npm test\` / the compiled v2 schema validator.

No other files touched.