### PR TITLE
Fix broken conform chain in Lee County, AL addresses source

### DIFF
--- a/sources/us/al/lee.json
+++ b/sources/us/al/lee.json
@@ -33,7 +33,7 @@
                             },
                             {
                                 "function": "remove_prefix",
-                                "field": "unit_wip",
+                                "field": "oa:unit_wip",
                                 "field_to_remove": "STREET"
                             }
                         ]


### PR DESCRIPTION
## Bug class

A `chain` function with a `variable` key names an intermediate result that later steps must reference as `oa:<variable-name>` in their `field`/`fields`. If a later step instead references the bare variable name (or the original raw source field), that step never actually sees the prior step's output and the chain is silently broken.

## This instance

`sources/us/al/lee.json` — `layers.addresses[0].conform.unit` is a `chain` with `variable: "unit_wip"`:

1. `remove_prefix` strips `NUMBER` from `ADDR1`, producing the working value `unit_wip` (e.g. `"600 AVENUE A   APT A"` minus `"600"`).
2. The second step was supposed to strip `STREET` from that intermediate value, but referenced `field: "unit_wip"` instead of `field: "oa:unit_wip"`. Since `unit_wip` isn't a field in the shapefile, this step didn't operate on the first step's output at all.

Fixed by changing the second step's `field` to `"oa:unit_wip"`.

## Verification

Downloaded and inspected the actual shapefile (`Address911.shp` from the `data` URL) with `ogrinfo`:
- Confirmed `NUMBER`, `STREET`, `ADDR1`, `ZIP`, `COMMUNITY` fields exist as referenced in the conform.
- Sampled records containing unit designators, e.g. `NUMBER=600`, `STREET="AVENUE A"`, `ADDR1="600 AVENUE A   APT A"`. With the fix, step 1 yields `"AVENUE A   APT A"` and step 2 strips the `STREET` prefix to yield `"APT A"` — the correct unit value. Before the fix, step 2 was a no-op, so `unit` would have incorrectly included the street name.
- Ran the schema validator against the fixed file: `VALID`.

No other files touched.