### PR TITLE
Fix unanchored regexp in Kent County, MI conform

### DIFF
--- a/sources/us/mi/kent.json
+++ b/sources/us/mi/kent.json
@@ -26,13 +26,13 @@
                     "region": {
                         "function": "regexp",
                         "field": "PROPADDRESSSTATE_ZIPCODE",
-                        "pattern": "^([A-Z]{2})([0-9]{5})",
+                        "pattern": "^([A-Z]{2})([0-9]{5})\\s*$",
                         "replace": "$1"
                     },
                     "postcode": {
                         "function": "regexp",
                         "field": "PROPADDRESSSTATE_ZIPCODE",
-                        "pattern": "^([A-Z]{2})([0-9]{5})",
+                        "pattern": "^([A-Z]{2})([0-9]{5})\\s*$",
                         "replace": "$2"
                     }
                 }


### PR DESCRIPTION
The addresses layer's \`region\` and \`postcode\` conform entries use a \`regexp\` function on \`PROPADDRESSSTATE_ZIPCODE\` with pattern \`^([A-Z]{2})([0-9]{5})\`. The source field is fixed-width and padded with trailing spaces (e.g. \`"MI49330     "\`), and the pattern was anchored only on the left, not the right.

Since \`regexp\`/\`replace\` only replaces the matched substring within the field rather than fully re-extracting it, the unmatched trailing whitespace after the 5-digit zip code leaked through into both the \`region\` and \`postcode\` output values (e.g. \`region\` became \`"MI     "\` and \`postcode\` became \`"49330     "\`).

Fix: anchor the pattern on the right with \`\s*$\` so it matches through the trailing padding, cleanly producing \`"MI"\` and \`"49330"\`.

Verified with real sample records pulled from the FeatureServer and a standalone Python \`re.sub\` simulation against the old and new patterns.