### PR TITLE
Fix broken conform regexps in Douglas County, IL addresses

### DIFF
--- a/sources/au/vic/city_of_greater_geelong.json
+++ b/sources/au/vic/city_of_greater_geelong.json
@@ -40,7 +40,7 @@
                             {
                                 "function": "regexp",
                                 "field": "oa:number_wip",
-                                "pattern": "^(.*)[ ]+VIC",
+                                "pattern": "^(.*)[ ]+VIC.*$",
                                 "replace": "$1"
                             },
                             {
@@ -51,7 +51,7 @@
                             {
                                 "function": "regexp",
                                 "field": "oa:number_wip",
-                                "pattern": "^(.*),",
+                                "pattern": "^(.*),.*$",
                                 "replace": "$1"
                             },
                             {

--- a/sources/us/ca/alpine.json
+++ b/sources/us/ca/alpine.json
@@ -32,7 +32,7 @@
                     "unit": {
                         "function": "regexp",
                         "field": "Situs",
-                        "pattern": "([A-Za-z0-9/\\- ]*)( +##? *(.*))?$",
+                        "pattern": "^([A-Za-z0-9/\\- ]*)( +##? *(.*))?$",
                         "replace": "$3"
                     },
                     "city": {

--- a/sources/us/il/douglas.json
+++ b/sources/us/il/douglas.json
@@ -38,13 +38,13 @@
                     "region": {
                         "function": "regexp",
                         "field": "site_csz",
-                        "pattern": "(IL)",
+                        "pattern": "^.*\\s(IL)\\s\\d{5}$",
                         "replace": "$1"
                     },
                     "postcode": {
                         "function": "regexp",
-                        "field": "ite_csz",
-                        "pattern": "(\\d{5})",
+                        "field": "site_csz",
+                        "pattern": "^.*\\s(\\d{5})$",
                         "replace": "$1"
                     }
                 }


### PR DESCRIPTION
The addresses conform for Douglas County, IL had two regexp bugs found by a static conform lint:

- **`region`**: pattern `(IL)` with `replace: "$1"` was completely unanchored, so the whole `site_csz` string (e.g. `"ARCOLA IL 61910"`) passed through mostly unchanged instead of being reduced to just `"IL"`.
- **`postcode`**: pattern `(\d{5})` with `replace: "$1"` had the same unanchored-regex bug, and additionally referenced field `ite_csz`, which does not exist on the source layer (confirmed against the live ArcGIS FeatureServer field list — the real field is `site_csz`, same as `city` and `region` already use in this file). This meant postcode was being extracted from an undefined field entirely.

Fix:
- `postcode` now reads from `site_csz` (matching `city`/`region`) instead of the nonexistent `ite_csz`.
- Both `region` and `postcode` patterns are now anchored (`^...$`) so they extract a clean value instead of doing a partial in-place replace, consistent with the already-correct anchored pattern already used for `city`.

Verified the field name and sample values live via `esri-explore.py fields/sample` against the source FeatureServer (e.g. `site_csz: "ARCOLA IL 61910"`), and simulated the new regexes in Python against several real sample values to confirm `city`, `region`, and `postcode` all extract correctly.