### PR TITLE
Fix unanchored regexp in Mason County, MI conform

### DIFF
--- a/sources/us/mi/mason.json
+++ b/sources/us/mi/mason.json
@@ -32,13 +32,13 @@
                     "city": {
                         "function": "regexp",
                         "field": "PropCitySt",
-                        "pattern": "(.*),.*",
+                        "pattern": "^(.*),.*$",
                         "replace": "$1"
                     },
                     "postcode": {
                         "function": "regexp",
                         "field": "PropCitySt",
-                        "pattern": ".*([0-9]{5})$",
+                        "pattern": "^.*([0-9]{5})$",
                         "replace": "$1"
                     }
                 }


### PR DESCRIPTION
The `city` and `postcode` conform attributes for `sources/us/mi/mason.json` use the `regexp` function with a `replace` key against the combined `PropCitySt` field (e.g. `"LUDINGTON, MI 49431-9402"`).

An unanchored `regexp`/`replace` pattern does a find/replace on the whole string rather than a clean extraction unless the capture group is anchored with `^` and `$`. Both patterns here relied on the greedy `.*` happening to consume from the start of the string:

- `city`: pattern `(.*),.*` -> anchored to `^(.*),.*$`
- `postcode`: pattern `.*([0-9]{5})$` (anchored on the right only) -> anchored to `^.*([0-9]{5})$`

I downloaded the source shapefile and inspected real `PropCitySt` values (e.g. `"FREE SOIL, MI 49411"`, `"BRANCH, MI 49402-9627"`) to confirm both patterns still produce the same clean output after anchoring, with no leaked text.

- Layer: addresses
- No data source or field changes, conform-only fix
- Verified via `npm test` schema validation