### PR TITLE
Fix unanchored regexp in Garfield County, WA addresses conform

### DIFF
--- a/sources/us/wa/garfield.json
+++ b/sources/us/wa/garfield.json
@@ -29,13 +29,13 @@
                     "postcode": {
                         "function": "regexp",
                         "field": "ADD_3",
-                        "pattern": "(.*)(\\d{5})$",
+                        "pattern": "^(.*)(\\d{5})$",
                         "replace": "$2"
                     },
                     "city": {
                         "function": "regexp",
                         "field": "ADD_3",
-                        "pattern": "(.*?)(, WA)(.*)",
+                        "pattern": "^(.*?)(, WA)(.*)$",
                         "replace": "$1"
                     }
                 }


### PR DESCRIPTION
A static lint pass found an unanchored-regexp bug in this source's addresses conform, the same bug class flagged in `sources/us/wa/garfield.json`.

The `regexp` function with a `replace` key does a find/replace on the whole string rather than a clean extraction unless the pattern is anchored with `^` and `$` around the capture group. Both regexes on field `ADD_3` (a combined "City, WA ZIP" value) were only partially anchored:

- `postcode`: `(.*)(\\d{5})$` — anchored on the right only
- `city`: `(.*?)(, WA)(.*)` — anchored on neither side

Fixed both by anchoring both ends:
- `postcode`: `^(.*)(\\d{5})$`
- `city`: `^(.*?)(, WA)(.*)$`

Verified schema validity with the project's schema test.

Note: this source's underlying ArcGIS service (`Garfield_County_Geodatabase/FeatureServer/7`) currently returns `Invalid URL` errors and recent batch jobs for both the `addresses` and `parcels` layers are failing — the server now only exposes `YieldAreas`, `Garfield_Tax_Codes`, and `Garfield_Online_gdb` services, none of which have a matching address layer. That's a separate, pre-existing breakage out of scope for this regexp fix.