### PR TITLE
Fix unanchored postcode regexp in Carbon County, WY

### DIFF
--- a/sources/us/wy/carbon.json
+++ b/sources/us/wy/carbon.json
@@ -37,7 +37,7 @@
                     "postcode": {
                         "function": "regexp",
                         "field": "st_address",
-                        "pattern": "(?:\\()(\\d{5})(?:\\))",
+                        "pattern": "^.*(?:\\()(\\d{5})(?:\\)).*$",
                         "replace": "$1"
                     },
                     "format": "shapefile"


### PR DESCRIPTION
The `postcode` conform in `sources/us/wy/carbon.json` used a `regexp` function with `replace` on the `st_address` field, but the pattern was not anchored with `^`/`$`:

```
"pattern": "(?:\\()(\\d{5})(?:\\))",
"replace": "$1"
```

`replace` performs a find/replace against the whole string using the pattern's match span, not a clean extraction. Since the pattern only matched the parenthesized zip code substring (e.g. `(82301)`), only that substring was replaced with the captured digits — the rest of the original `st_address` value (e.g. `1500 E DALEY ST`) leaked straight through into the `postcode` field.

Confirmed against real sample data pulled from the source shapefile (`st_address` values look like `"1500 E DALEY ST (82301)"`):

| st_address | old postcode output | fixed postcode output |
|---|---|---|
| `953 HWY 13 (82083)` | `953 HWY 13 82083` | `82083` |
| `1500 E DALEY ST (82301)` | `1500 E DALEY ST 82301` | `82301` |
| `3 SHOSHONE DR (82331)` | `3 SHOSHONE DR 82331` | `82331` |

Fix: anchor the pattern to the full string so `replace` substitutes the entire match:

```
"pattern": "^.*(?:\\()(\\d{5})(?:\\)).*$",
"replace": "$1"
```

Verified with a standalone Python `re.sub` simulation against real sample values, and confirmed the file still passes schema validation (`test/lib.js`).

Scope: only the one `postcode` conform key in this file was changed; no other layers, fields, or sources were touched.