### PR TITLE
Fix broken chain reference in Philadelphia postcode conform

### DIFF
--- a/sources/us/pa/philadelphia.json
+++ b/sources/us/pa/philadelphia.json
@@ -49,7 +49,7 @@
                             },
                             {
                                 "function": "regexp",
-                                "field": "full_zip",
+                                "field": "oa:full_zip",
                                 "pattern": "^(.*?)-?$"
                             }
                         ]


### PR DESCRIPTION
The \`postcode\` conform for \`sources/us/pa/philadelphia.json\` uses a \`chain\` function with \`variable: "full_zip"\` to normalize \`zip_code\` into a clean 5 or 5+4 digit postcode:

1. Step 1 regexes \`zip_code\` into \`NNNNN-\` or \`NNNNN-NNNN\` form, storing the result as the \`full_zip\` intermediate variable.
2. Step 2 is supposed to strip a bare trailing dash (e.g. \`19143-\` -> \`19143\`) while leaving a real zip+4 (e.g. \`19143-2010\`) untouched.

Per \`ATTRIBUTE_FUNCTIONS.md\`, any step after the first in a chain must reference the intermediate value with an \`oa:\` prefix (\`oa:full_zip\`), not the bare variable name. Step 2 was reading \`"field": "full_zip"\` — the bare, unprefixed name — so it was never actually reading step 1's output. This silently discarded step 1's cleanup, and depending on how the batch pipeline handles a missing bare-named field, likely produced incorrect or empty postcode values.

Fix: change step 2's \`field\` to \`"oa:full_zip"\`.

Verified:
- Traced the chain logic by hand against the file's own \`acceptance-tests\` fixtures (5-digit zip, 9-digit zip, zip with trailing dash, zip+4 with dash, empty zip) — all now produce the expected output with the fix applied.
- Queried the live Carto SQL endpoint (\`phl.carto.com\`) backing this source — current production data is 100% 5-digit \`zip_code\` values (with a small number of nulls), so today's practical impact is limited, but the chain is written to also handle zip+4 values if/when they appear.
- Schema validation passes (\`node\` script using \`test/lib.js\`).

No other files touched.