### PR TITLE
Fix unanchored regexp leaking text in Moultrie County, IL addresses conform

### DIFF
--- a/sources/us/il/moultrie.json
+++ b/sources/us/il/moultrie.json
@@ -21,25 +21,25 @@
                     "number": {
                         "function": "regexp",
                         "field": "Site_Address",
-                        "pattern": "([0-9]+)(.*)",
+                        "pattern": "^([0-9]+)(.*)$",
                         "replace": "$1"
                     },
                     "street": {
                         "function": "regexp",
                         "field": "Site_Address",
-                        "pattern": "([0-9]+)(.*)~(.*), IL ([0-9]+)",
+                        "pattern": "^([0-9]+)(.*)~(.*), IL ([0-9]{5})(?:-[0-9]{4})?$",
                         "replace": "$2"
                     },
                     "city": {
                         "function": "regexp",
                         "field": "Site_Address",
-                        "pattern": "([0-9]+)(.*)~(.*), IL ([0-9]+)",
+                        "pattern": "^([0-9]+)(.*)~(.*), IL ([0-9]{5})(?:-[0-9]{4})?$",
                         "replace": "$3"
                     },
                     "postcode": {
                         "function": "regexp",
                         "field": "Site_Address",
-                        "pattern": "([0-9]+)(.*)~(.*), IL ([0-9]+)",
+                        "pattern": "^([0-9]+)(.*)~(.*), IL ([0-9]{5})(?:-[0-9]{4})?$",
                         "replace": "$4"
                     }
                 },


### PR DESCRIPTION
The addresses layer's conform uses four separate `regexp` calls against the same `Site_Address` field (number, street, city, postcode), all unanchored — no `^`/`$` around the capture groups. The `regexp` function's `replace` behavior is a Python `re.sub`, which only replaces the matched substring and leaves any unmatched leading/trailing text from the original field untouched. Without anchors, a partial match anywhere in the string lets unmatched text leak into the output.

I confirmed this against real production data: job 530428 (a past successful run of this source, before its ArcGIS host went dead) shows exactly this failure mode, e.g. `Site_Address` values like `"~LOVINGTON, IL 61937"` or `"IVY~LOVINGTON, IL 61937"` (no leading house number) produce the entire raw string leaking unchanged into `number`, `street`, `city`, and `postcode` alike, and reproducing the old patterns against reconstructed raw values (e.g. `"527A US HWY 36~LOVINGTON, IL 61937"`) byte-for-byte matches the bad output on record.

Fix: anchor all four patterns with `^` at the start and `$` at the end so each match must consume the entire `Site_Address` value, with no leftover text able to leak through. Also widened the ZIP capture to `([0-9]{5})(?:-[0-9]{4})?` since real data includes ZIP+4 values (e.g. `61925-6191`) that would otherwise fail to match under a strict 5-digit-only anchor and regress into full-string leakage.

Verified against reconstructed real Site_Address values with a standalone Python `re.sub` simulation — clean extraction for well-formed addresses, and schema validation passes (`npm test`).

This source's addresses layer is currently `"skip": true` (host dead since 2026-04), so this fix doesn't reactivate anything — it only corrects the conform for whenever the host is restored or replaced.