### PR TITLE
Fix broken street chain in Inyo County, CA addresses source

### DIFF
--- a/sources/us/ca/inyo.json
+++ b/sources/us/ca/inyo.json
@@ -30,7 +30,7 @@
                             },
                             {
                                 "function": "remove_postfix",
-                                "field": "street_wip",
+                                "field": "oa:street_wip",
                                 "field_to_remove": "UNIT2"
                             }
                         ]


### PR DESCRIPTION
Fixes a broken chain conform in sources/us/ca/inyo.json.

The addresses layer's street conform is a chain with variable "street_wip" and two steps:

1. postfixed_street on FULL_ADDR (strips the leading house number)
2. remove_postfix to strip the trailing unit suffix using UNIT2

Per ATTRIBUTE_FUNCTIONS.md, any step after the first in a chain must reference the working value as oa:<variable>, not the bare variable name. Step 2 referenced the field as "street_wip" instead of "oa:street_wip", so it was reading directly from the raw source data (no field named street_wip exists on the source), meaning the unit suffix was never actually stripped from the street value.

Fix: change step 2's field from "street_wip" to "oa:street_wip" so it reads the first step's output as intended.

Verified against live sample data from the ArcGIS FeatureServer (e.g. FULL_ADDR: "2814 N SIERRA HWY A", UNIT2: "A") - with the fix, the chain now correctly produces "N SIERRA HWY" instead of leaking the unit suffix into the street field.

npm test passes for this file (schema validation confirmed independently via test/lib.js).