### PR TITLE
Fix unanchored number regexps in Geelong VIC addresses conform

### DIFF
--- a/sources/au/vic/city_of_greater_geelong.json
+++ b/sources/au/vic/city_of_greater_geelong.json
@@ -40,7 +40,7 @@
                             {
                                 "function": "regexp",
                                 "field": "oa:number_wip",
-                                "pattern": "^(.*)[ ]+VIC",
+                                "pattern": "^(.*)[ ]+VIC.*$",
                                 "replace": "$1"
                             },
                             {
@@ -51,7 +51,7 @@
                             {
                                 "function": "regexp",
                                 "field": "oa:number_wip",
-                                "pattern": "^(.*),",
+                                "pattern": "^(.*),.*$",
                                 "replace": "$1"
                             },
                             {


### PR DESCRIPTION
Replaces #8522, which accidentally picked up an unrelated Alpine County, CA change from a concurrent parallel fix run sharing the same working directory. This branch contains only the Geelong fix.

Two `regexp` steps in the `number` chain were anchored on the left only, letting unmatched trailing text (a stray space and following text) leak through and cascade into a downstream `remove_postfix` step failing to match — corrupting `number` with the entire street and suburb name in some cases. Fixed by anchoring both patterns on the right.