### PR TITLE
Fix broken conform regexps and field typo in Douglas County, IL addresses

### DIFF
--- a/sources/us/il/douglas.json
+++ b/sources/us/il/douglas.json
@@ -38,13 +38,13 @@
                     "region": {
                         "function": "regexp",
                         "field": "site_csz",
-                        "pattern": "(IL)",
+                        "pattern": "^.*\\s(IL)\\s\\d{5}$",
                         "replace": "$1"
                     },
                     "postcode": {
                         "function": "regexp",
-                        "field": "ite_csz",
-                        "pattern": "(\\d{5})",
+                        "field": "site_csz",
+                        "pattern": "^.*\\s(\\d{5})$",
                         "replace": "$1"
                     }
                 }


### PR DESCRIPTION
Replaces #8524, which accidentally picked up unrelated Geelong VIC and Alpine County, CA changes from a concurrent parallel fix run sharing the same working directory. This branch contains only the Douglas fix.

`postcode` referenced a nonexistent field `ite_csz` (confirmed via live service field listing — the real field is `site_csz`, as used by `city`/`region` in the same file). Both `region` and `postcode` also used unanchored `regexp`+`replace` patterns that would leak the raw combined city/state/zip string through unmodified. Fixed the field name and anchored both patterns.