### PR TITLE
Move esri-explore tool, add PR/source verification scripts

### DIFF
--- a/.claude/agents/oa-source-agent.md
+++ b/.claude/agents/oa-source-agent.md
@@ -3,6 +3,7 @@ name: oa-source-agent
 description: |
   Use this agent for any OpenAddresses source work: adding new sources, updating broken or outdated sources, or researching data availability for a location. Handles the full workflow from reading a GitHub issue or location description through finding and inspecting geodata, writing valid source JSON, and opening a pull request. Examples: <example>Context: User has a GitHub issue number for a missing county source. user: "Can you look at issue #8026 and add that source?" assistant: "I'll use the oa-source-agent to research and add that source." <commentary>The user wants to add an OA source from a GitHub issue — delegate to oa-source-agent.</commentary></example> <example>Context: User names a location with no issue. user: "Add addresses for Blount County, AL" assistant: "I'll use the oa-source-agent to find and add Blount County addresses." <commentary>User gave a location description — oa-source-agent handles the full discovery-to-PR workflow.</commentary></example> <example>Context: A source is returning errors in CI. user: "Fix the broken Winnebago County IL source" assistant: "Let me use oa-source-agent to investigate and fix it." <commentary>Broken source fix — oa-source-agent researches replacements and updates the file.</commentary></example>
 model: inherit
+isolation: worktree
 ---
 
 You are an OpenAddresses source agent. Your job is to automate the full workflow for adding or updating an OpenAddresses source: from reading a GitHub issue or location description, through finding and inspecting the data, to writing valid source JSON and opening a pull request.
@@ -11,7 +12,7 @@ You are an OpenAddresses source agent. Your job is to automate the full workflow
 
 - Repo root: the root of this checkout (all paths below are relative to it)
 - Sources directory: `sources/<country>/<state|region>/<coverage>.json`
-- ESRI explorer tool: `scripts/esri-explore.py` (always run with `uv run`)
+- ESRI explorer tool: `.claude/bin/esri-explore.py` (always run with `uv run`)
 - Schema validator: `test/lib.js`
 - Reference: `CONTRIBUTING.md`, `REVIEW.md`
 
@@ -131,19 +132,19 @@ If the dataset can't be filtered and doesn't cleanly match, treat it the same as
 #### For ESRI (ArcGIS) sources — always use `esri-explore.py`, never raw curl:
 ```bash
 # List all services on a server
-uv run scripts/esri-explore.py services <server_url>/arcgis/rest/services
+uv run .claude/bin/esri-explore.py services <server_url>/arcgis/rest/services
 
 # List layers in a service
-uv run scripts/esri-explore.py layers <service_url>/FeatureServer
+uv run .claude/bin/esri-explore.py layers <service_url>/FeatureServer
 
 # Get suggested conform for a layer
-uv run scripts/esri-explore.py suggest <layer_url>
+uv run .claude/bin/esri-explore.py suggest <layer_url>
 
 # Confirm feature count > 0
-uv run scripts/esri-explore.py count <layer_url>
+uv run .claude/bin/esri-explore.py count <layer_url>
 
 # Sample records to verify fields
-uv run scripts/esri-explore.py sample <layer_url> --count 3
+uv run .claude/bin/esri-explore.py sample <layer_url> --count 3
 ```
 
 Check for:
@@ -291,11 +292,11 @@ Fix any schema errors before continuing. Common mistakes:
 
 ### Step 6 — Create a Branch and Commit
 
+You run in an isolated git worktree (`isolation: worktree`), already checked out on a fresh branch off the default branch — do NOT run `git checkout master` or `git pull` yourself; `master` is likely checked out elsewhere (the main checkout or a sibling worktree) and switching to it will fail or conflict. Just rename your current branch and commit:
+
 ```bash
 # Branch naming: add-<country>-<state>-<coverage> or update-<country>-<state>-<coverage>
-git checkout master
-git pull
-git checkout -b add-us-wi-chippewa   # or update-us-wi-chippewa
+git branch -m add-us-wi-chippewa   # or update-us-wi-chippewa
 
 git add sources/<country>/<state>/<coverage>.json
 git commit -m "Add Chippewa County, WI address source"
@@ -353,10 +354,10 @@ gh pr create \
 
 ## Notes
 
-- Always run `git pull` before creating a new branch
+- You run in an isolated worktree already branched fresh off the default branch — don't `git checkout master`/`git pull` yourself, just `git branch -m` to rename your branch
 - Always validate schema before committing
 - Field names are case-sensitive — never assume, always verify with esri-explore.py
 - One PR per source file
-- Use `uv run scripts/esri-explore.py suggest` to get conform suggestions, then verify with `sample`
+- Use `uv run .claude/bin/esri-explore.py suggest` to get conform suggestions, then verify with `sample`
 - ArcGIS Online URLs with `/ArcGIS/rest/services` and `/arcgis/rest/services` may both work — try both if one fails
 - Use `esri-explore.py` for ALL ESRI endpoint inspection — never raw curl for ESRI

--- a/.claude/bin/esri-explore.py
+++ b/.claude/bin/esri-explore.py
@@ -10,14 +10,14 @@
 Compact output optimized for LLM token consumption.
 
 Usage:
-  uv run scripts/esri-explore.py services <server_url>
-  uv run scripts/esri-explore.py layers <service_url>
-  uv run scripts/esri-explore.py fields <layer_url>
-  uv run scripts/esri-explore.py sample <layer_url> [--count N]
-  uv run scripts/esri-explore.py count <layer_url>
-  uv run scripts/esri-explore.py suggest <layer_url>
-  uv run scripts/esri-explore.py search <server_url> <keyword>
-  uv run scripts/esri-explore.py values <layer_url> <field> [--limit N]
+  uv run .claude/bin/esri-explore.py services <server_url>
+  uv run .claude/bin/esri-explore.py layers <service_url>
+  uv run .claude/bin/esri-explore.py fields <layer_url>
+  uv run .claude/bin/esri-explore.py sample <layer_url> [--count N]
+  uv run .claude/bin/esri-explore.py count <layer_url>
+  uv run .claude/bin/esri-explore.py suggest <layer_url>
+  uv run .claude/bin/esri-explore.py search <server_url> <keyword>
+  uv run .claude/bin/esri-explore.py values <layer_url> <field> [--limit N]
 """
 
 import argparse

--- a/.claude/bin/oa-conform-lint.py
+++ b/.claude/bin/oa-conform-lint.py
@@ -1,0 +1,495 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.10"
+# ///
+"""Statically lint OpenAddresses source `conform` blocks for known bug classes.
+
+This is a pure static text/JSON linter: it never downloads data or hits a
+network endpoint. It exists to catch a handful of conform-authoring mistakes
+that keep recurring across sources/*.json, purely from the JSON text itself,
+so they don't have to be rediscovered one at a time by manually sampling
+production job output.
+
+Rules implemented:
+
+  1. Unanchored `regexp` + `replace` used as a disguised full-value
+     extraction (a capture-group backreference like "$1" in `replace`, but
+     the `pattern` doesn't effectively anchor both ends of the string). The
+     `regexp` function with `replace` does a Python-style in-place
+     substring replace, not a clean full-string extraction, unless the
+     match is forced to span the whole value. A pattern like
+     "CITY OF (.+)$" (no anchor on the left) applied via replace "$1" to
+     "675 CITY OF CALDWELL" produces "675 CALDWELL" -- the unmatched "675 "
+     prefix leaks through untouched -- instead of the intended "CALDWELL".
+     [BUG] severity. A `regexp` used WITHOUT `replace` (pure capture-group
+     extraction, where only the captured groups are returned regardless of
+     what surrounds them) is far more forgiving, so it's only flagged
+     [WARN] and only when it has no anchoring at either end.
+
+  2. ESRI number/postcode fields at risk of a leaked ".0" suffix. ESRI
+     `esriFieldTypeDouble` fields serialize as e.g. "78209.0" in
+     production. We can't know a field's real ESRI type without hitting
+     the network, so this is a heuristic [WARN]. A first pass that fires on
+     every bare `conform.number`/`conform.postcode` field name on a
+     `protocol: ESRI` layer turned out to match roughly a third of every
+     ESRI source in the repo (field names like "zip"/"ZipCode" are simply
+     how most sources spell these) -- far too noisy to be worth skimming.
+     To cut that down to something worth reading, this is additionally
+     gated on corpus rarity: it only fires when the exact field name (case
+     insensitive) is used for that same attribute by very few *other*
+     sources anywhere in sources/**/*.json. The reasoning: OpenAddresses
+     rebuilds weekly and has for years, so a field-naming convention shared
+     by dozens/hundreds of sources (zip, zipcode, post_code, ...) would
+     very likely have already surfaced and been fixed if it commonly
+     produced ".0"-suffixed garbage; a field name that's unique or nearly
+     unique in the corpus is comparatively unreviewed territory and worth
+     a quick check, e.g. with esri-explore.py fields <url>. This is a
+     proxy for "reviewed by many other sources," not for the field's
+     actual ESRI type, so false positives (and the rare false negative)
+     are still expected -- treat it as a nudge, not a verdict.
+
+  3. Broken `chain` linkage. Per ATTRIBUTE_FUNCTIONS.md, steps after the
+     first in a `chain` must reference the prior step's output via
+     `oa:<variable>` (or `oa:<attribute-name>` if `variable` is omitted).
+     A chain with 2+ steps where no step after the first references that
+     `oa:`-prefixed name anywhere suggests the steps were never actually
+     wired together -- often because the author forgot the `oa:` prefix
+     and just reused the raw source field name again. [BUG] severity.
+
+  4. NOT IMPLEMENTED (by design): duplicate-looking field lists in
+     `street`/name-composition arrays (e.g. ["StreetName", "StreetType"]
+     where StreetName might already embed the type). This can't be
+     detected from the source JSON alone -- it requires sampling real
+     data values. See the sibling script oa-verify-output.py, which
+     samples actual output for this kind of check.
+
+  5. Coded-looking field mapped straight to city/region/district. On a
+     `protocol: ESRI` layer, if `city`/`region`/`district` is a bare
+     field-name string whose name looks like it holds a code/id rather
+     than a display string (a whole "code"/"type"/"id"/"num" segment,
+     case-insensitive -- e.g. "CityCode" or "CityID", but not
+     "SitusAddCity") with no `map`/`constant`/regexp cleanup, that's
+     probably an uncleaned coded value. [WARN] severity, deliberately
+     narrow to keep false positives rare.
+
+Usage:
+  uv run .claude/bin/oa-conform-lint.py                  # scan all of sources/**/*.json
+  uv run .claude/bin/oa-conform-lint.py sources/us/ca/*.json
+  uv run .claude/bin/oa-conform-lint.py path/to/one.json
+  uv run .claude/bin/oa-conform-lint.py --staged          # only files staged with `git add`
+  uv run .claude/bin/oa-conform-lint.py --changed         # only files that differ from master
+
+Exit code is non-zero if any [BUG]-severity finding exists; warnings alone
+exit 0. Parse errors (invalid JSON) are reported but don't affect the exit
+code by themselves and don't crash the run.
+"""
+
+import argparse
+import glob
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+BUG = "BUG"
+WARN = "WARN"
+PARSE_ERROR = "PARSE_ERROR"
+
+# Attribute keys that get the ESRI ".0"-leak heuristic (rule 2).
+NUMERIC_LEAK_ATTRS = {"number", "postcode"}
+
+# Rule 2 only fires when the field name is used by this many OTHER sources
+# (i.e. corpus frequency <= this, not counting the source at hand) or fewer
+# for the same attribute across the whole corpus. See rule 2 docstring above.
+RARE_FIELD_THRESHOLD = 1
+
+# Attribute keys that get the coded-field heuristic (rule 5).
+NAME_ATTRS = {"city", "region", "district"}
+
+# Whole-segment tokens (case-insensitive) that suggest a coded/id field
+# rather than a human-readable name, for rule 5.
+CODED_TOKENS = {"code", "type", "id", "num"}
+
+# Keys inside a function object whose string value(s) name source fields
+# (as opposed to output values, formats, etc.) -- used when checking
+# whether a chain step references a prior step's `oa:` variable.
+FIELD_REF_KEYS = ("field", "fields", "field_to_remove")
+
+
+class Finding:
+    __slots__ = ("severity", "path", "message")
+
+    def __init__(self, severity, path, message):
+        self.severity = severity
+        self.path = path
+        self.message = message
+
+
+def effective_start_anchored(pattern):
+    """True if the pattern is forced to match from the start of the string.
+
+    A literal '^' obviously does this. So, effectively, does a pattern that
+    opens with a greedy '.*'/'.+' -- since re.search always tries position 0
+    first, and a leading .*/.+ can absorb any prefix, the leftmost successful
+    match will start at position 0 whenever the rest of the pattern matches
+    at all. Treating those as anchored avoids flagging the very common
+    "$1"-strips-a-prefix idiom that's actually fine.
+    """
+    return bool(re.match(r"^(\^|\(?\?:?\.[*+])", pattern))
+
+
+def effective_end_anchored(pattern):
+    """True if the pattern is forced to match to the end of the string.
+
+    Mirrors effective_start_anchored: a literal '$', or a trailing greedy
+    '.*'/'.+' (optionally inside closing group parens), consumes to the end
+    of the string so nothing trails off unmatched.
+    """
+    trimmed = pattern.rstrip(")")
+    return trimmed.endswith("$") or bool(re.search(r"\.[*+]\??$", trimmed))
+
+
+def check_regexp(value, path, findings):
+    pattern = value.get("pattern")
+    if not isinstance(pattern, str):
+        return
+    field = value.get("field", "?")
+    has_replace = "replace" in value
+    replace = value.get("replace", "")
+    start_ok = effective_start_anchored(pattern)
+    end_ok = effective_end_anchored(pattern)
+    anchored = start_ok and end_ok
+
+    if has_replace:
+        has_backref = bool(re.search(r"\$\d", replace)) if isinstance(replace, str) else False
+        if has_backref and not anchored:
+            side = (
+                "the left"
+                if not start_ok and end_ok
+                else "the right"
+                if start_ok and not end_ok
+                else "both sides"
+            )
+            findings.append(
+                Finding(
+                    BUG,
+                    path,
+                    f"regexp on field {field!r} has pattern {pattern!r} with replace {replace!r}, "
+                    f"unanchored on {side}: this is a find/replace, not a full-string extraction, so "
+                    f"any part of the value the pattern doesn't match stays in the output untouched. "
+                    f"E.g. a pattern like 'CITY OF (.+)$' applied to '675 CITY OF CALDWELL' produces "
+                    f"'675 CALDWELL' instead of 'CALDWELL' because the leading '675 ' never matched. "
+                    f"Anchor both ends around the capture, e.g. '^.*CITY OF (.+)$'.",
+                )
+            )
+    else:
+        if not start_ok and not end_ok:
+            findings.append(
+                Finding(
+                    WARN,
+                    path,
+                    f"regexp on field {field!r} with pattern {pattern!r} has no replace (only captured "
+                    f"groups are returned, so this is more forgiving than a replace-based extraction), "
+                    f"but it's anchored at neither end -- worth a quick check that it can't match an "
+                    f"unintended substring elsewhere in the value.",
+                )
+            )
+
+
+def collect_field_refs(step):
+    """All source-field-name strings a single conform function step references."""
+    refs = []
+    for key in FIELD_REF_KEYS:
+        val = step.get(key)
+        if isinstance(val, str):
+            refs.append(val)
+        elif isinstance(val, list):
+            refs.extend(v for v in val if isinstance(v, str))
+    return refs
+
+
+def check_chain(value, path, attr_name, findings):
+    functions = value.get("functions")
+    if not isinstance(functions, list) or len(functions) < 2:
+        return
+    variable = value.get("variable")
+    ref_name = f"oa:{variable}" if isinstance(variable, str) and variable else f"oa:{attr_name}"
+
+    linked = False
+    for step in functions[1:]:
+        if not isinstance(step, dict):
+            continue
+        if any(ref_name in ref for ref in collect_field_refs(step)):
+            linked = True
+            break
+
+    if not linked:
+        findings.append(
+            Finding(
+                BUG,
+                path,
+                f"chain has {len(functions)} steps but no step after the first references "
+                f"{ref_name!r} in its field(s) -- the steps don't look like they're actually "
+                f"chained together. Each step after the first must read the prior step's result "
+                f"via the {ref_name!r} field name, not the raw source field again, or its output "
+                f"is silently ignored.",
+            )
+        )
+
+
+def walk_functions(value, path, attr_name, findings):
+    """Recursively find regexp/chain function objects anywhere in a conform value."""
+    if isinstance(value, dict):
+        func = value.get("function")
+        if func == "regexp":
+            check_regexp(value, path, findings)
+        elif func == "chain":
+            check_chain(value, path, attr_name, findings)
+            for i, step in enumerate(value.get("functions", []) or []):
+                walk_functions(step, f"{path}.functions[{i}]", attr_name, findings)
+        else:
+            # Other function kinds (join/first_non_empty/format/map/etc.) only
+            # hold plain field-name strings/lists, not nested function objects,
+            # per schema/util/functions/*.json -- nothing further to recurse into.
+            pass
+    elif isinstance(value, list):
+        for i, item in enumerate(value):
+            walk_functions(item, f"{path}[{i}]", attr_name, findings)
+
+
+def looks_coded(field_name):
+    """Rule 5 heuristic: does this field name look like a code/id, not a display value?"""
+    tokens = re.findall(r"[A-Z]+(?=[A-Z][a-z])|[A-Z]?[a-z]+|[A-Z]+|[0-9]+", field_name)
+    return any(t.lower() in CODED_TOKENS for t in tokens)
+
+
+def lint_conform(conform, layer_type, layer_index, protocol, findings, field_freq):
+    if not isinstance(conform, dict):
+        return
+    for attr_name, attr_value in conform.items():
+        path = f"layers.{layer_type}[{layer_index}].conform.{attr_name}"
+
+        if protocol == "ESRI" and isinstance(attr_value, str):
+            if attr_name in NUMERIC_LEAK_ATTRS:
+                freq = field_freq.get(attr_name, {}).get(attr_value.lower(), 0)
+                # freq includes this source itself, so "other sources" is freq - 1.
+                if freq - 1 <= RARE_FIELD_THRESHOLD:
+                    findings.append(
+                        Finding(
+                            WARN,
+                            path,
+                            f"ESRI field {attr_value!r} used directly for {attr_name!r} with no "
+                            f"'.0'-stripping step, and this field name is used by only "
+                            f"{max(freq - 1, 0)} other source(s) in the corpus for {attr_name!r} "
+                            f"(uncommon enough to be unreviewed territory). If this is an "
+                            f"esriFieldTypeDouble field on the server, production output may "
+                            f"render values like '78209.0'. Worth checking the field type (e.g. "
+                            f"esri-explore.py fields <url>) and, if needed, wrapping in a regexp "
+                            f"that strips a trailing '.0'.",
+                        )
+                    )
+            elif attr_name in NAME_ATTRS and looks_coded(attr_value):
+                findings.append(
+                    Finding(
+                        WARN,
+                        path,
+                        f"ESRI field {attr_value!r} mapped directly to {attr_name!r} with no "
+                        f"map/constant/regexp cleanup, but the field name looks like it may hold "
+                        f"a coded/numeric value rather than a display string. Worth sampling the "
+                        f"field's real values (e.g. esri-explore.py values <url> {attr_value}) and "
+                        f"adding a `map` if it turns out to be coded.",
+                    )
+                )
+
+        walk_functions(attr_value, path, attr_name, findings)
+
+
+def lint_source(data, findings, field_freq):
+    layers = data.get("layers")
+    if not isinstance(layers, dict):
+        return
+    for layer_type, layer_list in layers.items():
+        if not isinstance(layer_list, list):
+            continue
+        for i, layer in enumerate(layer_list):
+            if not isinstance(layer, dict):
+                continue
+            lint_conform(layer.get("conform"), layer_type, i, layer.get("protocol"), findings, field_freq)
+
+
+def parse_source(path):
+    """Parse one source JSON file. Returns (data, None) or (None, error-message)."""
+    try:
+        text = path.read_text()
+    except OSError as e:
+        return None, f"could not read file: {e}"
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as e:
+        return None, f"invalid JSON: {e}"
+    if not isinstance(data, dict):
+        return None, "top-level JSON value is not an object"
+    return data, None
+
+
+def lint_file(path, field_freq):
+    """Return a list of Finding for one source JSON file (or a single PARSE_ERROR finding)."""
+    data, error = parse_source(path)
+    if error:
+        return [Finding(PARSE_ERROR, "-", error)]
+    findings = []
+    lint_source(data, findings, field_freq)
+    return findings
+
+
+def build_field_frequency(sources_dir):
+    """Corpus-wide count of how many ESRI address sources use each bare
+    number/postcode field name (lowercased), for the rule 2 rarity gate.
+    Always scans the full corpus regardless of which files are being linted,
+    since rarity is a property of the whole corpus, not of the lint target.
+    """
+    freq = {"number": {}, "postcode": {}}
+    if not sources_dir.is_dir():
+        return freq
+    for path in sources_dir.rglob("*.json"):
+        data, error = parse_source(path)
+        if error or not isinstance(data, dict):
+            continue
+        layers = data.get("layers")
+        if not isinstance(layers, dict):
+            continue
+        for layer in layers.get("addresses", []) or []:
+            if not isinstance(layer, dict) or layer.get("protocol") != "ESRI":
+                continue
+            conform = layer.get("conform")
+            if not isinstance(conform, dict):
+                continue
+            for attr_name in NUMERIC_LEAK_ATTRS:
+                value = conform.get(attr_name)
+                if isinstance(value, str):
+                    key = value.lower()
+                    freq[attr_name][key] = freq[attr_name].get(key, 0) + 1
+    return freq
+
+
+def repo_root():
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, check=True,
+        )
+        return Path(out.stdout.strip())
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return Path(__file__).resolve().parent.parent.parent
+
+
+def git_ref_exists(root, ref):
+    return subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", ref],
+        cwd=root, capture_output=True,
+    ).returncode == 0
+
+
+def files_from_git_diff(root, args_list):
+    out = subprocess.run(
+        ["git", "diff"] + args_list,
+        cwd=root, capture_output=True, text=True, check=True,
+    ).stdout
+    return [root / line for line in out.splitlines() if line.strip()]
+
+
+def resolve_files(args, root):
+    if args.staged:
+        files = files_from_git_diff(root, ["--cached", "--name-only", "--", "sources/"])
+    elif args.changed:
+        base = None
+        for candidate in ("origin/master", "master"):
+            if git_ref_exists(root, candidate):
+                base = candidate
+                break
+        if base is None:
+            print("ERROR: --changed needs a 'master' or 'origin/master' ref to diff against", file=sys.stderr)
+            sys.exit(2)
+        files = files_from_git_diff(root, [f"{base}...HEAD", "--name-only", "--", "sources/"])
+    elif args.paths:
+        files = []
+        for p in args.paths:
+            matches = glob.glob(p, recursive=True)
+            if matches:
+                files.extend(Path(m) for m in matches)
+            elif Path(p).exists():
+                files.append(Path(p))
+            else:
+                print(f"WARNING: no match for {p!r}", file=sys.stderr)
+    else:
+        files = sorted((root / "sources").rglob("*.json"))
+
+    # Only lint .json files that actually exist (git diff can list deletions).
+    return [f for f in files if f.suffix == ".json" and f.exists()]
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "paths", nargs="*",
+        help="specific source JSON file paths or globs to lint (default: all of sources/**/*.json)",
+    )
+    parser.add_argument(
+        "--staged", action="store_true",
+        help="lint only files staged for commit (git diff --cached --name-only)",
+    )
+    parser.add_argument(
+        "--changed", action="store_true",
+        help="lint only files changed vs. origin/master or master (git diff --name-only <base>...HEAD)",
+    )
+    args = parser.parse_args()
+
+    if args.staged and args.changed:
+        parser.error("--staged and --changed are mutually exclusive")
+
+    root = repo_root()
+    files = resolve_files(args, root)
+    field_freq = build_field_frequency(root / "sources")
+
+    total_bug = 0
+    total_warn = 0
+    total_parse_error = 0
+
+    for path in files:
+        findings = lint_file(path, field_freq)
+        if not findings:
+            continue
+
+        try:
+            display_path = path.relative_to(Path.cwd())
+        except ValueError:
+            display_path = path
+
+        print(f"{display_path}")
+        for f in findings:
+            if f.severity == BUG:
+                total_bug += 1
+            elif f.severity == WARN:
+                total_warn += 1
+            else:
+                total_parse_error += 1
+            marker = f"[{f.severity}]"
+            if f.severity == PARSE_ERROR:
+                print(f"  {marker} {f.message}")
+            else:
+                print(f"  {marker} {f.path}: {f.message}")
+        print()
+
+    print(
+        f"Scanned {len(files)} file(s): {total_bug} bug(s), {total_warn} warning(s), "
+        f"{total_parse_error} parse error(s)."
+    )
+
+    sys.exit(1 if total_bug else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/bin/oa-verify-output.py
+++ b/.claude/bin/oa-verify-output.py
@@ -1,0 +1,459 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""Sanity-check real batch job output for an OpenAddresses source.
+
+Downloads the actual GeoJSON produced by batch.openaddresses.io for a job (or
+set of jobs) and reports field population rates, sample values, and automated
+flags for known bug patterns (unstripped ESRI ".0" suffixes, unanchored-regexp
+leaks, duplicated street-type words, suspiciously-constant fields, etc). This
+replaces doing the same thing by hand with curl + gunzip + ad-hoc python.
+
+Compact, human/LLM-readable plain text output (not JSON).
+
+Usage:
+  uv run .claude/bin/oa-verify-output.py <job_id>
+  uv run .claude/bin/oa-verify-output.py <source_path>
+  uv run .claude/bin/oa-verify-output.py --pr <pr_number>
+  uv run .claude/bin/oa-verify-output.py '#8514'
+
+Examples:
+  uv run .claude/bin/oa-verify-output.py 912317
+  uv run .claude/bin/oa-verify-output.py us/tx/city_of_amarillo
+  uv run .claude/bin/oa-verify-output.py --pr 8514
+  uv run .claude/bin/oa-verify-output.py --sample-size 2000 us/ca/alameda
+"""
+
+import argparse
+import gzip
+import io
+import json
+import random
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+
+API_BASE = "https://batch.openaddresses.io/api"
+USER_AGENT = "oa-verify-output/1.0 (+openaddresses/addresses tooling)"
+
+# A bare numeric-with-decorations string that looks like a PR reference:
+# "#8514", "pr8514", "pr:8514", "pr-8514", "PR 8514", etc.
+PR_PATTERN = re.compile(r"^(?:#|pr[:\-_ ]?)(\d+)$", re.IGNORECASE)
+
+DEFAULT_SAMPLE_SIZE = 5000
+DEFAULT_HISTORY = 100
+
+# Known content fields per layer type (from schema/layers/*_conform.json),
+# excluding structural/geometry keys. "hash" is always present but is a
+# content hash, not a conformed value, so it's never reported on.
+LAYER_FIELDS = {
+    "addresses": ["number", "street", "unit", "city", "district", "region", "postcode", "id", "accuracy"],
+    "parcels": ["pid"],
+    "buildings": ["height", "levels", "id"],
+    "centerlines": [
+        "name", "oneway", "speed", "classification", "surface",
+        "addr_from_left", "addr_to_left", "addr_from_right", "addr_to_right",
+        "zip_left", "zip_right", "id",
+    ],
+}
+ALWAYS_IGNORE_FIELDS = {"hash"}
+
+# Fields where a single distinct value across a big sample is unremarkable
+# enough that flagging it is more noise than signal.
+CONSTANT_OK_FIELDS = {"accuracy"}
+
+
+def api_get(path):
+    """GET a JSON endpoint from the batch API."""
+    url = f"{API_BASE}{path}"
+    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        print(f"ERROR: HTTP {e.code} fetching {url}", file=sys.stderr)
+        return None
+    except urllib.error.URLError as e:
+        print(f"ERROR: {e.reason} fetching {url}", file=sys.stderr)
+        return None
+    except Exception as e:
+        print(f"ERROR: {e} fetching {url}", file=sys.stderr)
+        return None
+
+
+def get_job_detail(job_id):
+    """Fetch full detail for a single job id."""
+    return api_get(f"/job/{job_id}")
+
+
+def get_latest_jobs_for_source(source_path, history=DEFAULT_HISTORY):
+    """Return the most recent job summary per (layer, name) group for a source path."""
+    data = api_get(f"/job?source={source_path}&order=desc&limit={history}")
+    if not data:
+        return []
+    jobs = data.get("jobs", [])
+    if not jobs:
+        return []
+    groups = {}
+    for j in jobs:
+        key = (j.get("layer"), j.get("name"))
+        # Jobs come back newest-first, so the first one seen per group wins.
+        if key not in groups:
+            groups[key] = j
+    return list(groups.values())
+
+
+def source_paths_from_pr(pr_number):
+    """Use `gh pr diff --name-only` to find changed sources/**/*.json files
+    and map each to its <country>/<state>/<coverage> source path.
+    """
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "diff", str(pr_number), "--name-only"],
+            capture_output=True, text=True, timeout=30, check=False,
+        )
+    except FileNotFoundError:
+        print("ERROR: `gh` CLI not found. Install/authenticate GitHub CLI to use --pr.", file=sys.stderr)
+        return []
+    except Exception as e:
+        print(f"ERROR: failed to run `gh pr diff`: {e}", file=sys.stderr)
+        return []
+
+    if result.returncode != 0:
+        print(f"ERROR: `gh pr diff {pr_number} --name-only` failed: {result.stderr.strip()}", file=sys.stderr)
+        return []
+
+    paths = []
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if line.startswith("sources/") and line.endswith(".json"):
+            # sources/us/id/canyon.json -> us/id/canyon
+            source_path = line[len("sources/"):-len(".json")]
+            paths.append(source_path)
+
+    if not paths:
+        print(f"No changed sources/**/*.json files found in PR #{pr_number}.", file=sys.stderr)
+    return paths
+
+
+def resolve_url(job_detail):
+    """Pick the best available output URL for a job, preferring validated output.
+
+    s3:// URIs are converted to https:// since the bucket is served directly
+    over HTTPS at the same path.
+    """
+    for key in ("s3_validated", "s3"):
+        uri = job_detail.get(key)
+        if uri:
+            if uri.startswith("s3://"):
+                return "https://" + uri[len("s3://"):]
+            return uri
+    # Defensive fallback in case the API nests these under "output" instead.
+    output = job_detail.get("output") or {}
+    for key in ("s3_validated", "s3"):
+        uri = output.get(key)
+        if uri:
+            if uri.startswith("s3://"):
+                return "https://" + uri[len("s3://"):]
+            return uri
+    return None
+
+
+def stream_sample_features(url, sample_size):
+    """Stream-download and gunzip a job's output, reservoir-sampling up to
+    sample_size features without holding the whole file in memory.
+
+    Returns (sample, total_count, parse_errors) or raises on network failure.
+    """
+    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    sample = []
+    total_count = 0
+    parse_errors = 0
+
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        with gzip.GzipFile(fileobj=resp) as gz:
+            text = io.TextIOWrapper(gz, encoding="utf-8", errors="replace")
+            for line in text:
+                line = line.strip()
+                if not line:
+                    continue
+                total_count += 1
+                try:
+                    feature = json.loads(line)
+                except json.JSONDecodeError:
+                    parse_errors += 1
+                    continue
+                if len(sample) < sample_size:
+                    sample.append(feature)
+                else:
+                    j = random.randint(0, total_count - 1)
+                    if j < sample_size:
+                        sample[j] = feature
+
+    return sample, total_count, parse_errors
+
+
+def is_empty(value):
+    return value is None or (isinstance(value, str) and value.strip() == "")
+
+
+TRAILING_DOT_ZERO = re.compile(r"^\d+\.0$")
+LEAKED_NUMERIC_PREFIX = re.compile(r"^\d+\s+\D")
+
+
+def check_trailing_dot_zero(field, values):
+    bad = [v for v in values if isinstance(v, str) and TRAILING_DOT_ZERO.match(v)]
+    if bad:
+        examples = ", ".join(repr(v) for v in bad[:5])
+        return f'trailing ".0" artifact on {len(bad)} sampled value(s) (ESRI Double field not stripped) e.g. {examples}'
+    return None
+
+
+def check_leaked_numeric_prefix(field, values):
+    bad = [v for v in values if isinstance(v, str) and LEAKED_NUMERIC_PREFIX.match(v)]
+    if bad:
+        examples = ", ".join(repr(v) for v in bad[:5])
+        return (
+            f"possible unanchored regexp leak: {len(bad)} sampled value(s) start with a digit run "
+            f"then text (not necessarily wrong, but worth eyeballing) e.g. {examples}"
+        )
+    return None
+
+
+def check_duplicated_trailing_word(field, values):
+    bad = []
+    for v in values:
+        if not isinstance(v, str):
+            continue
+        tokens = v.split()
+        if len(tokens) >= 2 and tokens[-1].lower() == tokens[-2].lower():
+            bad.append(v)
+    if bad:
+        examples = ", ".join(repr(v) for v in bad[:5])
+        return f"duplicated trailing word on {len(bad)} sampled value(s) e.g. {examples}"
+    return None
+
+
+# Which heuristic checks apply to which fields.
+FIELD_CHECKS = {
+    "number": [check_trailing_dot_zero],
+    "postcode": [check_trailing_dot_zero],
+    "city": [check_leaked_numeric_prefix],
+    "region": [check_leaked_numeric_prefix],
+    "district": [check_leaked_numeric_prefix],
+    "street": [check_duplicated_trailing_word],
+}
+
+
+def format_pct(n, d):
+    if d == 0:
+        return "n/a"
+    return f"{100.0 * n / d:.1f}%"
+
+
+def report_job(job_detail, sample_size):
+    job_id = job_detail.get("id")
+    source_name = job_detail.get("source_name", "?")
+    layer = job_detail.get("layer", "?")
+    name = job_detail.get("name", "?")
+    status = job_detail.get("status", "?")
+
+    print("=" * 78)
+    print(f"Job {job_id} | {source_name} | layer={layer} name={name} | status={status}")
+    print("=" * 78)
+
+    url = resolve_url(job_detail)
+    if not url:
+        print(f"  No output available for this job (status: {status}). Skipping.")
+        print()
+        return
+
+    validated_used = bool(job_detail.get("s3_validated"))
+    print(f"  Output: {url}{'  (validated)' if validated_used else '  (unvalidated/raw)'}")
+
+    try:
+        sample, total_count, parse_errors = stream_sample_features(url, sample_size)
+    except urllib.error.HTTPError as e:
+        print(f"  ERROR: HTTP {e.code} downloading output. Skipping.")
+        print()
+        return
+    except urllib.error.URLError as e:
+        print(f"  ERROR: {e.reason} downloading output. Skipping.")
+        print()
+        return
+    except Exception as e:
+        print(f"  ERROR: failed to download/parse output ({e}). Skipping.")
+        print()
+        return
+
+    if total_count == 0:
+        print("  Job output contains zero features.")
+        print()
+        return
+
+    print(f"  Total features: {total_count}  |  Sampled: {len(sample)}"
+          + (f"  |  Unparseable lines skipped: {parse_errors}" if parse_errors else ""))
+    print()
+
+    # Gather every property key actually present in the sample.
+    keys_seen = set()
+    for feat in sample:
+        props = feat.get("properties") or {}
+        keys_seen.update(props.keys())
+    keys_seen -= ALWAYS_IGNORE_FIELDS
+
+    known_for_layer = LAYER_FIELDS.get(layer)
+    if known_for_layer:
+        fields_to_check = [f for f in known_for_layer if f in keys_seen]
+    else:
+        # Unknown layer type: fall back to whatever keys are present.
+        fields_to_check = sorted(keys_seen)
+
+    if not fields_to_check:
+        print("  (No attribute fields present in output — expected for buildings/geometry-only layers.)")
+        print()
+        return
+
+    all_flags = []
+
+    for field in fields_to_check:
+        values = [ (feat.get("properties") or {}).get(field) for feat in sample ]
+        non_empty = [v for v in values if not is_empty(v)]
+        pop_rate = format_pct(len(non_empty), len(values))
+
+        counts = {}
+        for v in non_empty:
+            key = str(v)
+            counts[key] = counts.get(key, 0) + 1
+        distinct = sorted(counts.items(), key=lambda kv: -kv[1])
+        distinct_count = len(distinct)
+        top_values = ", ".join(repr(v) for v, _ in distinct[:5])
+
+        print(f"  {field:<12s} populated={pop_rate:>6s}  distinct={distinct_count:<6d}  samples: {top_values}")
+
+        # Defect flags for this field.
+        field_flags = []
+        for check in FIELD_CHECKS.get(field, []):
+            result = check(field, non_empty)
+            if result:
+                field_flags.append(result)
+
+        if (
+            len(sample) > 100
+            and len(non_empty) == len(values)
+            and distinct_count == 1
+            and field not in CONSTANT_OK_FIELDS
+        ):
+            field_flags.append(
+                f'check: "{field}" is 100% populated but only has one distinct value '
+                f"across {len(sample)} sampled features — verify this isn't a mapping bug"
+            )
+
+        for flag in field_flags:
+            all_flags.append(f"{field}: {flag}")
+
+    print()
+    if all_flags:
+        print("  Flags:")
+        for flag in all_flags:
+            print(f"    - {flag}")
+    else:
+        print("  Flags: none of the known defect patterns detected.")
+    print()
+
+
+def classify_target(target, pr_flag):
+    if pr_flag is not None:
+        return ("pr", pr_flag)
+    if target is None:
+        return (None, None)
+
+    target = target.strip()
+    m = PR_PATTERN.match(target)
+    if m:
+        return ("pr", int(m.group(1)))
+    if "/" in target:
+        return ("source", target.strip("/"))
+    if target.isdigit():
+        return ("job", int(target))
+    return (None, target)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "target", nargs="?",
+        help="Job id (e.g. 912317), source path (e.g. us/tx/city_of_amarillo), "
+             "or a PR reference (e.g. '#8514' or 'pr8514')",
+    )
+    parser.add_argument("--pr", type=int, default=None, help="GitHub PR number to check changed sources for")
+    parser.add_argument(
+        "--sample-size", type=int, default=DEFAULT_SAMPLE_SIZE,
+        help=f"Max features to sample per job (default: {DEFAULT_SAMPLE_SIZE})",
+    )
+    parser.add_argument(
+        "--history", type=int, default=DEFAULT_HISTORY,
+        help=f"How many recent jobs to scan per source when looking up by source path (default: {DEFAULT_HISTORY})",
+    )
+    args = parser.parse_args()
+
+    mode, value = classify_target(args.target, args.pr)
+
+    if mode is None:
+        if value is None:
+            print("ERROR: provide a job id, source path, or --pr <number>.", file=sys.stderr)
+        else:
+            print(f"ERROR: could not classify target {value!r} as a job id, source path, or PR reference.", file=sys.stderr)
+        sys.exit(1)
+
+    job_details = []
+
+    if mode == "job":
+        detail = get_job_detail(value)
+        if detail is None:
+            print(f"ERROR: could not fetch job {value}.", file=sys.stderr)
+            sys.exit(1)
+        job_details.append(detail)
+
+    elif mode == "source":
+        summaries = get_latest_jobs_for_source(value, history=args.history)
+        if not summaries:
+            print(f"No jobs found for source {value!r}.")
+            sys.exit(1)
+        for summary in summaries:
+            detail = get_job_detail(summary["id"])
+            if detail is not None:
+                job_details.append(detail)
+
+    elif mode == "pr":
+        source_paths = source_paths_from_pr(value)
+        if not source_paths:
+            sys.exit(1)
+        print(f"PR #{value}: found {len(source_paths)} changed source(s): {', '.join(source_paths)}")
+        print()
+        for source_path in source_paths:
+            summaries = get_latest_jobs_for_source(source_path, history=args.history)
+            if not summaries:
+                print(f"No jobs found for source {source_path!r}.")
+                continue
+            for summary in summaries:
+                detail = get_job_detail(summary["id"])
+                if detail is not None:
+                    job_details.append(detail)
+
+    if not job_details:
+        print("No jobs to report on.", file=sys.stderr)
+        sys.exit(1)
+
+    for detail in job_details:
+        report_job(detail, args.sample_size)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Internal dev tooling changes for AI-assisted source fixing, no address data changes:

- Moved `scripts/esri-explore.py` → `.claude/bin/esri-explore.py` — `scripts/` is for address-source data preprocessing (per its own README), not tooling.
- Added `.claude/bin/oa-verify-output.py`: samples a batch job's real production output (by job ID, source path, or `--pr <n>`) and flags known conform defect patterns (ESRI Double-field `.0` artifacts, unanchored-regexp leaks, duplicated street words, suspicious single-value fields) — replaces ad-hoc curl/gunzip/python one-liners for verifying a fix's real output before merging.
- Added `.claude/bin/oa-conform-lint.py`: static scan across `sources/**/*.json` for the same recurring bug classes (unanchored `regexp`+`replace`, broken `chain` `oa:` references, likely-coded city/region fields), with `--staged`/`--changed` modes for pre-PR checks.
- Set `isolation: worktree` on the `oa-source-agent` definition so each invocation runs in its own isolated git worktree, and updated its branch-creation steps accordingly (no longer checks out `master`/pulls itself, since the worktree already starts fresh off the default branch).