### PR TITLE
Fix broken Town of New Milford, CT addresses source

### DIFF
--- a/sources/us/ct/town_of_new_milford.json
+++ b/sources/us/ct/town_of_new_milford.json
@@ -15,12 +15,12 @@
             {
                 "name": "county",
                 "attribution": "Town of New Milford, CT",
-                "data": "https://mapgeo.s3.amazonaws.com/clients/newmilfordct/files/HostedDownloadableData.zip",
+                "data": "https://mapgeo.s3.amazonaws.com/clients/newmilfordct/files/HostedDownloadedData2026.zip",
                 "protocol": "http",
                 "compression": "zip",
                 "conform": {
-                    "file": "HostedDownloadableData/Parcels.shp",
-                    "format": "shapefile-polygon",
+                    "file": "20260326/Parcels.shp",
+                    "format": "shapefile",
                     "number": {
                         "function": "prefixed_number",
                         "field": "StreetAddr"


### PR DESCRIPTION
## What was broken

The `data` URL (`https://mapgeo.s3.amazonaws.com/clients/newmilfordct/files/HostedDownloadableData.zip`) has been returning HTTP 404 for at least the last several batch runs (jobs 900393, 905289, 910239, 912356, 912366), consistently failing with `openaddr.cache.DownloadError: 404 response from ...`.

## What was searched

- The town's MapGeo instance (`newmilfordct.mapgeo.io`) is still live.
- Listed the same S3 prefix (`clients/newmilfordct/files/`) that hosted the old file and found the town has continued publishing dated GIS exports there under new filenames: `HostedDownloadedData.zip` (2024), `HostedDownloadedData2025.zip`, `HostedDownloadedData2026.zip` (most recent, dated 2026-04-01), plus an older `NewMilfordGISData.zip`.
- Checked New Milford's parcel layer in the regional ArcGIS org (`services6.arcgis.com/drkDXByy6E3bYW3a/.../new_milford_ct_parcels`) that hosts several neighboring CT towns publicly — that specific service returns `499 Token Required`, so it's not usable.

## The fix

Downloaded and inspected `HostedDownloadedData2026.zip` directly:
- Contains a dated `20260326/` folder with `Parcels.shp` (and other layers: Contours, FEMA_FloodZone, Inland_Wetland_Soils, RoadCenterlines, Structures, ZoningPolygon).
- `Parcels.dbf` has 13,707 records with the same field names as before (`Parcel_ID`, `StreetAddr`), and sample values (e.g. `576 DANBURY RD`, `12 GRETL LN`) confirm real New Milford, CT street addresses.
- Valid CT State Plane projection (`.prj`), no auth required.

Updated `data` to point at `HostedDownloadedData2026.zip` and the internal `conform.file` path to `20260326/Parcels.shp`. The `number`/`street`/`id` conform logic (deriving addresses from parcel `StreetAddr` via `prefixed_number`/`postfixed_street`) is unchanged since the field names didn't change.

Also normalized the stale `"format": "shapefile-polygon"` to `"format": "shapefile"` while touching this file, consistent with the unrelated cleanup already in flight (`shapefile-polygon` is being removed from the schema).

Note: the vendor renames this export file by year (`HostedDownloadedData2025.zip` → `HostedDownloadedData2026.zip`), so this source will likely need the filename bumped again next year.