### PR TITLE
Fix broken Clarke County, VA addresses source

### DIFF
--- a/sources/us/va/clarke.json
+++ b/sources/us/va/clarke.json
@@ -14,24 +14,25 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "ftp://ftp.clarkecounty.gov/gis/buildings.zip",
+                "data": "https://services7.arcgis.com/1uNEgmtBVWGKSY5Q/arcgis/rest/services/Addresses/FeatureServer/0",
+                "website": "https://clarkeva.maps.arcgis.com/home/item.html?id=ebf6a93b1c5b4c02842acba28f9e96e2",
                 "license": {
                     "text": "Public Domain",
                     "attribution": false,
                     "share-alike": false
                 },
-                "year": "2014",
-                "protocol": "ftp",
-                "compression": "zip",
+                "protocol": "ESRI",
                 "conform": {
-                    "file": "buildings/buildings.shp",
-                    "number": "number",
+                    "format": "geojson",
+                    "number": "NUMBER",
                     "street": [
-                        "name",
-                        "type"
+                        "DIR",
+                        "NAME",
+                        "TYPE"
                     ],
-                    "format": "shapefile-polygon",
-                    "postcode": "zipcode"
+                    "unit": "LOC_APT",
+                    "city": "POST",
+                    "postcode": "ZIPCODE"
                 }
             }
         ]


### PR DESCRIPTION
The addresses source's data URL, \`ftp://ftp.clarkecounty.gov/gis/buildings.zip\`, has been dead for some time — Clarke County's old FTP server no longer resolves the request and returns a 400 (confirmed via recent batch job logs, e.g. job 912362: \`openaddr.cache.DownloadError: 400 response from ftp://ftp.clarkecounty.gov/gis/buildings.zip\`).

## Search

Clarke County has moved its GIS hosting to ArcGIS Online, under the org \`clarkeva.maps.arcgis.com\` (owner account \`llemmon_clarkeva\`). That org hosts a live, actively maintained \`Addresses\` FeatureServer whose fields line up closely with the old, defunct shapefile's schema (\`NUMBER\`, \`NAME\`, \`TYPE\`, \`ZIPCODE\`), and whose \`SITE_NGUID\`/\`DISCRPAGID\` values reference \`clarkecounty.gov\` directly, confirming it's the authoritative county dataset:

- https://services7.arcgis.com/1uNEgmtBVWGKSY5Q/arcgis/rest/services/Addresses/FeatureServer/0

## Verification

- 7,529 total features, 7,357 (97.7%) tagged \`COUNTY = 'CLARKE'\`; the remainder is expected border noise from neighboring Jefferson County WV, Loudoun, Warren, and Frederick counties.
- Verified fields and sample records with \`esri-explore.py\`.
- \`DIR\` (not the always-blank \`ST_PREDIR\`) carries real predirectional values (N/S/E/W) for the street conform.
- \`POST\` carries the mailing city (Front Royal, Boyce, White Post, Paris) and is used for \`city\`.
- \`LOC_APT\` carries unit/suite designators.

## Changes

- Replaced the dead FTP shapefile source with the live ArcGIS FeatureServer.
- Updated \`protocol\` to \`ESRI\` and \`conform.format\` to \`geojson\` accordingly (this also incidentally fixes the same stale \`shapefile-polygon\` conform value already flagged and fixed elsewhere in the repo — since this file needed touching anyway, it's included here as \`geojson\`, which is required for ESRI sources).
- Added a \`website\` link to the hosted item page.