### PR TITLE
Fix broken Davie County, NC address source

### DIFF
--- a/sources/us/nc/davie.json
+++ b/sources/us/nc/davie.json
@@ -15,8 +15,7 @@
             {
                 "name": "county",
                 "conform": {
-                    "format": "shapefile-polygon",
-                    "file": "address.shp",
+                    "format": "geojson",
                     "number": "HSNM",
                     "street": [
                         "PREDIR",
@@ -26,10 +25,9 @@
                     ],
                     "unit": "UNIT"
                 },
-                "data": "https://maps.co.davie.nc.us/DavieGISweb/gisdata/address.zip",
-                "protocol": "http",
-                "compression": "zip",
-                "website": "https://www.daviecountync.gov/index.aspx?NID=394"
+                "data": "https://gis.daviecountync.gov/server/rest/services/Addresses/FeatureServer/0",
+                "protocol": "ESRI",
+                "website": "https://gis.daviecountync.gov/daviegis/"
             }
         ]
     }


### PR DESCRIPTION
## Summary
- The old shapefile download at maps.co.davie.nc.us no longer resolves; replaced it with the county's ArcGIS FeatureServer endpoint (ESRI protocol, geojson format).
- Updated the website link to the current GIS portal.

## Test plan
- [x] `npm test` passes for the modified source
- [x] Verified the ESRI FeatureServer layer returns address features with the expected fields (HSNM, PREDIR, STREETNAME, STREETTYPE, UNIT)