### PR TITLE
Fix broken Providence, RI parcel address source

### DIFF
--- a/sources/us/ri/providence.json
+++ b/sources/us/ri/providence.json
@@ -22,7 +22,7 @@
             {
                 "name": "city",
                 "conform": {
-                    "format": "shapefile-polygon",
+                    "format": "geojson",
                     "number": {
                         "function": "regexp",
                         "field": "property_a",
@@ -40,13 +40,17 @@
                     },
                     "postcode": "zip_postal"
                 },
-                "data": "https://data.providenceri.gov/api/geospatial/29is-vppi?method=export&format=Shapefile",
+                "data": "https://data.providenceri.gov/api/views/cfbm-tf7t/rows.geojson?accessType=DOWNLOAD",
                 "website": "https://data.providenceri.gov/Neighborhoods/Providence-Parcel-Boundaries-2015/29is-vppi",
                 "protocol": "http",
-                "compression": "zip",
+                "license": {
+                    "text": "Open Data Commons Public Domain Dedication and License (PDDL)",
+                    "attribution": false,
+                    "share-alike": false
+                },
                 "year": "2015",
                 "note": {
-                    "description": "Full parcel shapefile set (not points); address string is stored in the property_a attribute; current as of 2015",
+                    "description": "Full parcel set (not points); address string is stored in the property_a attribute; current as of 2015/2016. The old export endpoint (/api/geospatial/29is-vppi?method=export&format=Shapefile) started returning HTML/500 errors; this uses the underlying Socrata dataset (cfbm-tf7t, 'Parcels_2015', the same data backing the 29is-vppi map view) directly as GeoJSON, which has the same property_a/zip_postal fields.",
                     "unit regexp": "There is a 'Unit St' in Providence so the unit regexp has to include the house number non-capturing group",
                     "examples": [
                         "1 Di Mario St",


### PR DESCRIPTION
## What was broken

The addresses source for Providence, RI (`sources/us/ri/providence.json`) downloaded from `https://data.providenceri.gov/api/geospatial/29is-vppi?method=export&format=Shapefile`, a Socrata dataset-export endpoint. That endpoint now returns an HTTP 500 (previously HTML), so the batch pipeline fails with `zipfile.BadZipFile: File is not a zip file`.

## Investigation

- Confirmed via job log and a direct request that `/api/geospatial/29is-vppi?method=export&format=Shapefile` (and `format=GeoJSON`/`KML`) return either a 500 or an empty `FeatureCollection` stub — the export mechanism for this map view is broken.
- Found that the `29is-vppi` map view ("Providence Parcel Boundaries 2015") is a thin wrapper around the real underlying Socrata dataset `cfbm-tf7t` ("Parcels_2015"), which is still live and fully queryable.
- Verified `cfbm-tf7t` via `/resource/cfbm-tf7t.geojson`: 43,380 features, with the exact same `property_a` (address string) and `zip_postal` fields the existing conform already parses, including the same `Unit`/`Bldg`/`Apt` edge cases documented in the source's `note.examples`.
- Searched the Providence Socrata catalog (scoped to `data.providenceri.gov`) for a dedicated address-point layer or a newer parcel dataset. No address-point dataset exists; the "2017" parcel boundaries dataset is actually from 2018 and has a different, address-poorer schema (owner mailing address only, no parcel-level zip). Stuck with the same underlying 2015/2016 parcel data since it's still the best available and is unchanged aside from the access method.

## Fix

- `data`: switched to `https://data.providenceri.gov/api/views/cfbm-tf7t/rows.geojson?accessType=DOWNLOAD`, the canonical Socrata "download all rows as GeoJSON" endpoint (same pattern already used in `sources/us/tx/city_of_austin.json`), returning all 43,380 records in one request.
- `conform.format`: `shapefile-polygon` → `geojson` (no longer downloading a shapefile ZIP).
- Removed `compression: zip` (no longer applicable).
- Added a `license` block (Open Data Commons Public Domain Dedication and License, per the dataset's Socrata metadata) — the source previously had no license info.
- Left the `number`/`street`/`unit` regexes and documentation notes untouched since the `property_a` address-string format is unchanged.

Validated against `test/lib.js` — schema is valid.