### PR TITLE
fix broken Harper County, KS addresses source

### DIFF
--- a/sources/us/ks/harper_county.json
+++ b/sources/us/ks/harper_county.json
@@ -16,17 +16,21 @@
                 "name": "county",
                 "conform": {
                     "format": "geojson",
-                    "number": "add_num",
+                    "number": "HNO",
                     "street": [
-                        "st_dir",
-                        "st_name",
-                        "st_type",
-                        "st_suf"
+                        "PRD",
+                        "RD",
+                        "STS",
+                        "POD"
                     ],
-                    "city": "city",
-                    "postcode": "zip"
+                    "unit": "UNIT",
+                    "city": "MUNI",
+                    "district": "COUNTY",
+                    "region": "STATE",
+                    "postcode": "ZIP"
                 },
-                "data": "https://72.205.198.131/ArcGIS/rest/services/Harper/Harper/MapServer/31",
+                "data": "https://services9.arcgis.com/yGerJCngvNpaN2km/arcgis/rest/services/KScoHP_NG911AddressPoints/FeatureServer/0",
+                "website": "https://experience.arcgis.com/experience/51bf748747d34b3dbc2dd1ced0d1aea9",
                 "protocol": "ESRI"
             }
         ]


### PR DESCRIPTION
The addresses source in sources/us/ks/harper_county.json pointed at a dead bare-IP host (https://72.205.198.131/ArcGIS/rest/services/Harper/Harper/MapServer/31), part of a shared GIS vendor outage affecting roughly a dozen Kansas counties.

## What was wrong
- The old data URL is a bare IP that has since been reassigned to a residential Cox cable customer (confirmed via reverse DNS); the vendor's old static IP is gone.

## What was checked before replacing
- Kansas's statewide NG911 address source (`sources/us/ks/statewide.json`) does not cover Harper County — its `COUNTY` field has no `HARPER` value at all (`COUNTY='HARPER'` returns 0 of ~1.04M features), so the "leave broken, statewide already covers it" fallback did not apply here.
- Searched ArcGIS Online and found `KScoHP_NG911AddressPoints` on the county's GIS vendor org (`services9.arcgis.com/yGerJCngvNpaN2km`, owner `lkmap`), which also hosts a public "Harper County Public Web Map" and "Harper County Community GIS Website" experience app confirming it's the county's actual GIS provider.
- Verified jurisdiction match: all 4,667 features have `COUNTY='HARPER COUNTY'` (0 features otherwise) — no cross-jurisdiction contamination.
- Verified sample records: correct NG911-standard schema (HNO, PRD, RD, STS, POD, UNIT, ZIP, MUNI) with real Harper County towns (Anthony, Attica, Bluff City, Freeport, Harper, Unincorporated).
- Confirmed `STP`/`POM` street-component fields are empty for this county and omitted them from `street`, consistent with sibling fixes for other counties on the same vendor pattern (e.g. Barber, Wabaunsee).

## Change
- `data`: now points to `https://services9.arcgis.com/yGerJCngvNpaN2km/arcgis/rest/services/KScoHP_NG911AddressPoints/FeatureServer/0`
- `website`: added link to the county's public GIS experience app
- `conform`: updated field names to match the new service (`HNO`, `PRD`/`RD`/`STS`/`POD`, `UNIT`, `MUNI`, `COUNTY`, `STATE`, `ZIP`)

Schema-validated with `test/lib.js` (VALID).