### PR TITLE
Fix broken Edwards County, KS addresses source

### DIFF
--- a/sources/us/ks/edwards_county.json
+++ b/sources/us/ks/edwards_county.json
@@ -16,18 +16,21 @@
                 "name": "county",
                 "conform": {
                     "format": "geojson",
-                    "number": "structno",
-                    "street": [
-                        "predir",
-                        "streetname",
-                        "streettype",
-                        "sufdir"
+                    "number": [
+                        "HNO",
+                        "HNS"
                     ],
-                    "unit": "apartment",
-                    "city": "community",
-                    "postcode": "zipcode"
+                    "street": [
+                        "PRD",
+                        "RD",
+                        "STS"
+                    ],
+                    "unit": "UNIT",
+                    "city": "MUNI",
+                    "postcode": "ZIP"
                 },
-                "data": "https://72.205.198.131/ArcGIS/rest/services/Edwards/Edwards/MapServer/32",
+                "data": "https://services7.arcgis.com/QfD34vvHtHcH5kGh/arcgis/rest/services/EdwardsAddressPoints_240108/FeatureServer/3",
+                "website": "https://www.arcgis.com/home/item.html?id=6caf4906f73e4507997d38b046837af0",
                 "protocol": "ESRI"
             }
         ]


### PR DESCRIPTION
## What was broken

The source pointed at `https://72.205.198.131/ArcGIS/rest/services/Edwards/Edwards/MapServer/32`, a bare-IP host that is now dead — reverse DNS shows the IP has been reassigned to a residential Cox cable customer. This is the same shared-vendor dead-IP issue affecting a batch of other Kansas counties.

## What was searched

- Checked the ATCiMaps ArcGIS Online org (`services9.arcgis.com/zDY8zW24CdJKhVIw`) that resolved the identical issue for Barber County — no Edwards-named service exists there.
- Checked the Kansas statewide NG911 source (`sources/us/ks/statewide.json`, `AddressPoints_NG911_ALL_GCS`) to see if it already covers Edwards County per this repo's convention of leaving a county source broken when a statewide source covers it. Confirmed via attribute query (`COUNTY='EDWARDS COUNTY'` → 0 features) and a spatial query around Kinsley, KS (0 features) that it does **not** include Edwards County. So this fallback does not apply.
- Found Edwards County-specific NG911 address layers hosted on a different ArcGIS Online org (`services7.arcgis.com/QfD34vvHtHcH5kGh`). Verified jurisdiction match: `COUNTY<>'EDWARDS COUNTY'` returns 0 of ~2200+ records, distinct `MUNI` values (`KINSLEY`, `BELPRE`, `LEWIS`, `OFFERLE`, `UNINCORPORATED`) are all genuinely within Edwards County, and the service's bounding extent matches Edwards County's location.
- Two candidate layers existed on that org: `EDCO_Address_Points` (2221 records, last substantive update 2014) and `EdwardsAddressPoints_240108/FeatureServer/3` (2232 records, edits as recent as 2021, explicitly NENA 02-014 / Kansas NG9-1-1 compliant). Chose the actively-maintained one.

## Fix

Updated `data` to `https://services7.arcgis.com/QfD34vvHtHcH5kGh/arcgis/rest/services/EdwardsAddressPoints_240108/FeatureServer/3` and added a `website` link to the ArcGIS Online item. Updated `conform` field names to match the live service (`number: [HNO, HNS]`, `street: [PRD, RD, STS]`, `unit: UNIT`, `city: MUNI`, `postcode: ZIP`) — verified exact field names and non-empty values against live samples; `STP`, `POD`, and `POM` were confirmed always empty and omitted.

Validated against `test/lib.js` schema.