### PR TITLE
Fix broken Caribou County, ID address source

### DIFF
--- a/sources/us/id/caribou.json
+++ b/sources/us/id/caribou.json
@@ -14,10 +14,11 @@
         "addresses": [
             {
                 "name": "county",
-                "data": "https://opendata.arcgis.com/datasets/a8ad676c58274e3196c05b7b906efae6_0.zip",
-                "protocol": "http",
+                "data": "https://services1.arcgis.com/qnw9CxcuDG55fwTB/arcgis/rest/services/Election_Addresses/FeatureServer/0",
+                "website": "https://cariboucountymapgallery-caribougis.hub.arcgis.com",
+                "protocol": "ESRI",
                 "conform": {
-                    "format": "shapefile",
+                    "format": "geojson",
                     "number": "AN",
                     "street": [
                         "PreDir",
@@ -29,7 +30,8 @@
                         "SecUnit",
                         "SecRange"
                     ],
-                    "city": "CityCode"
+                    "city": "post_comm",
+                    "postcode": "post_code"
                 }
             }
         ]


### PR DESCRIPTION
The addresses source pointed at an ArcGIS Online opendata hosted-download shortcut (`https://opendata.arcgis.com/datasets/a8ad676c58274e3196c05b7b906efae6_0.zip`). The underlying AGOL item has been deleted (`https://www.arcgis.com/sharing/rest/content/items/a8ad676c58274e3196c05b7b906efae6?f=json` returns "Item does not exist or is inaccessible"), so every job for at least the last 17 runs has failed with a 400 response on download (most recently job 909700).

Found a working replacement on Caribou County's own ArcGIS Online org (admin_caribou, org id qnw9CxcuDG55fwTB): a live FeatureServer called "Election Addresses", described by the county as "Address Points in Caribou County. Most updated layer." It exposes 4,176 point address features with the exact same field schema as the original conform (AN, PreDir, Street, Suffix, SuffixDir, SecUnit, SecRange) — almost certainly the same underlying county address dataset, now only reachable via the live service rather than the dead opendata zip link.

Jurisdiction verified: grouping by city fields shows all records fall into Soda Springs, Grace, Bancroft, Wayan, and Freedom — all towns within Caribou County, ID — with matching ZIP codes (83276, 83241, 83217, 83120, 83285). No records from other counties.

Changes:
- Layer: addresses
- Source: https://services1.arcgis.com/qnw9CxcuDG55fwTB/arcgis/rest/services/Election_Addresses/FeatureServer/0
- Switched protocol from http/shapefile to ESRI/geojson
- Added website link to the county's public GIS map gallery
- Improved city/postcode mapping to use post_comm/post_code (real city names) instead of the coded CityCode field

Schema-validated against test/lib.js (VALID).